### PR TITLE
chore: engine Docker 컨테이너화 (#66)

### DIFF
--- a/docs/work/done/000066-engine-dockerize/00_issue.md
+++ b/docs/work/done/000066-engine-dockerize/00_issue.md
@@ -1,0 +1,44 @@
+# chore: engine Dockerize
+
+## 목적
+engine을 Docker 컨테이너로 빌드하고 EC2에서 실행 가능하게 한다.
+
+## 배경
+EC2 배포 시 의존성 충돌 없이 일관된 환경에서 엔진을 실행하기 위해 Dockerize가 필요하다.
+
+## 완료 기준
+- [x] `engine/Dockerfile` 작성 (python:3.12-slim 기반)
+- [x] `docker build` 로컬 빌드 성공
+- [x] `docker run` 으로 `GET /` 응답 확인 (`{"status":"ok"}`)
+- [x] `.dockerignore` 작성 (tests/, .venv/, __pycache__ 등 제외)
+
+## 구현 플랜
+1. `engine/Dockerfile` 작성
+   - python:3.12-slim 베이스
+   - pyproject.toml 기반 의존성 설치 (`pip install .`)
+   - `uvicorn app.main:app --host 0.0.0.0 --port 8000` 실행
+2. `engine/.dockerignore` 작성
+3. 로컬 빌드 및 실행 확인
+
+## 개발 체크리스트
+- [x] 해당 디렉토리 .ai.md 최신화
+
+---
+
+## 작업 내역
+
+### engine/Dockerfile
+`python:3.12-slim` 기반 Dockerfile 작성. 레이어 캐시 효율화를 위해 `pyproject.toml` 복사 후 `pip install`, 이후 앱 소스를 복사하는 순서로 구성. `PYTHONUNBUFFERED=1`로 로그 실시간 출력, `useradd -m appuser` + `USER appuser`로 non-root 실행.
+
+### engine/.dockerignore
+`.venv/`, `__pycache__/`, `tests/`, `.git/`, `docs/`, `.env` 등 런타임 불필요 파일 제외. `.env`는 API 키 보호를 위해 명시적으로 제외.
+
+### engine/README.md
+빌드·구동·환경변수 운영 가이드 문서 신규 작성. 로컬 개발, Docker 로컬 실행, EC2 자동 재시작(`--restart unless-stopped`) 방법 포함. GitHub Secrets 동기화(`gh secret set --env-file .env`) 및 CI/CD 주입 예시도 기재.
+
+### engine/.ai.md
+Docker 실행 섹션 추가 (포트 8000, non-root, 자동 재시작). 구조 트리에 `Dockerfile`, `.dockerignore`, `README.md` 항목 추가.
+
+### 기술적 결정
+- 이슈에서 `GET /health`를 완료 기준으로 명시했으나 실제 엔드포인트는 `GET /` (`app/main.py:36`). 계획 문서에 명시 후 `GET /`로 검증.
+- 환경변수는 이미지에 굽지 않고 런타임 주입 방식 채택 → ECR+GitHub Actions 연동 시에도 동일 방식 사용 가능.

--- a/docs/work/done/000066-engine-dockerize/01_plan.md
+++ b/docs/work/done/000066-engine-dockerize/01_plan.md
@@ -1,0 +1,187 @@
+# [#66] chore: engine Dockerize — 구현 계획
+
+> 작성: 2026-03-12 | 리뷰: Architect·Critic 완료
+
+---
+
+## 완료 기준
+
+- [ ] `engine/Dockerfile` 작성 (python:3.12-slim 기반, non-root user 포함)
+- [ ] `docker build` 로컬 빌드 성공
+- [ ] `docker run` 으로 `GET /` 응답 확인 (`{"status": "ok"}`)
+- [ ] `engine/.dockerignore` 작성 (tests/, .venv/, .env 등 제외)
+- [ ] `engine/README.md` 작성 (빌드·구동·환경변수 운영 가이드)
+- [ ] `engine/.ai.md` 최신화 (Docker 실행 정보 한 줄 추가)
+
+> ⚠️ 이슈 문서는 `GET /health`로 기재됐으나 실제 헬스 엔드포인트는 `GET /` (`engine/app/main.py:36`)
+
+---
+
+## 구현 계획
+
+### Step 1 — `engine/Dockerfile` 작성
+
+**목표**: 보안을 고려한 컨테이너 빌드 후 uvicorn으로 FastAPI 앱 실행
+
+```dockerfile
+FROM python:3.12-slim
+
+# 로그 버퍼링 비활성화 (stdout 실시간 출력)
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# 의존성만 먼저 복사 → 캐시 레이어 최적화
+# (코드만 변경 시 pip install 재실행 안 함)
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
+
+# 앱 소스 복사
+COPY app/ app/
+
+# 보안: non-root user 실행
+RUN useradd -m appuser
+USER appuser
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+**근거**:
+- `engine/pyproject.toml:3` — requires-python = ">=3.12", `python:3.12-slim` 충족
+- `engine/pyproject.toml:5-13` — `pip install .` 로 13개 의존성 설치
+- `engine/app/main.py:12` — 진입점 `app.main:app`
+- `engine/app/main.py:36` — 헬스 엔드포인트 `GET /`
+- COPY 순서: pyproject.toml → pip install → app/ (코드 변경 시 의존성 재설치 방지)
+- PYTHONUNBUFFERED: 로그가 uvicorn에서 즉시 stdout으로 출력됨
+- non-root user: 컨테이너 보안 모범 사례 (API 키 노출 위험 최소화)
+
+### Step 2 — `engine/.dockerignore` 작성
+
+빌드 컨텍스트에서 제외할 파일/디렉토리:
+
+```
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+tests/
+.git/
+.gitignore
+*.md
+docs/
+.env
+```
+
+**근거**:
+- `.env` 명시적 제외 — API 키 등 민감 정보가 이미지에 포함되지 않도록 (`engine/app/config.py:8`)
+- `tests/`, `.venv/`, `__pycache__` — 런타임 불필요
+- `*.md`, `docs/` — 문서 파일 제외로 이미지 크기 최소화
+
+### Step 3 — 로컬 빌드·실행 검증
+
+```bash
+# engine/ 디렉토리에서 실행
+cd engine
+
+# 빌드
+docker build -t mirai-engine .
+
+# 실행 (환경변수는 -e 플래그 또는 --env-file로 주입)
+docker run --rm -p 8000:8000 \
+  -e OPENROUTER_API_KEY=<key> \
+  mirai-engine
+
+# 헬스 확인
+curl http://localhost:8000/
+# 기대값: {"status":"ok"}
+```
+
+---
+
+## 환경변수 처리
+
+엔진은 `engine/app/config.py`에서 환경변수를 읽는다. Docker 실행 시 `-e` 플래그 또는 `--env-file` 옵션으로 주입한다. `.env` 파일은 이미지에 포함하지 않는다 (`.dockerignore`로 제외).
+
+---
+
+## 검증 방법
+
+| 항목 | 명령어 | 기대 결과 |
+|------|--------|-----------|
+| 빌드 성공 | `docker build -t mirai-engine .` | 오류 없이 완료 |
+| 컨테이너 기동 | `docker run --rm -p 8000:8000 -e OPENROUTER_API_KEY=<key> mirai-engine` | uvicorn 로그 출력 |
+| 헬스 응답 | `curl http://localhost:8000/` | `{"status":"ok"}` |
+
+---
+
+## 환경변수 운영 가이드
+
+### 로컬 개발
+```bash
+# engine/.env 파일로 관리 (git 미추적)
+docker run --rm -p 8000:8000 --env-file .env mirai-engine
+```
+
+### CI/CD 자동 배포 (GitHub Actions + ECR 연동 시)
+
+`.env` → GitHub Actions Secrets 동기화:
+```bash
+# 로컬에서 한 번만 실행 (변경 시마다 재실행)
+gh secret set --env-file engine/.env
+
+# 확인
+gh secret list
+```
+
+GitHub Actions에서 주입:
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy to EC2
+  env:
+    OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  run: |
+    ssh ec2-user@<ip> "docker run -d -p 8000:8000 \
+      -e OPENROUTER_API_KEY=$OPENROUTER_API_KEY \
+      <ecr-url>/mirai-engine:latest"
+```
+
+| 단계 | 방식 | 비고 |
+|------|------|------|
+| 로컬 개발 | `--env-file .env` | `.env`는 git 미추적 |
+| CI/CD 자동 배포 | GitHub Actions Secrets | `gh secret set --env-file` 로 동기화 |
+| AWS 인프라 확장 시 | SSM Parameter Store | ECS 전환 등 대규모 운영 시 |
+
+---
+
+### Step 4 — `engine/README.md` 작성
+
+사람이 읽는 운영 가이드. 다음 내용 포함:
+
+- **로컬 개발**: `pip install -e ".[dev]"` + uvicorn 직접 실행
+- **Docker 빌드**: `docker build -t mirai-engine .`
+- **Docker 구동**: `docker run -d --restart unless-stopped -p 8000:8000 --env-file .env mirai-engine`
+- **환경변수 목록**: `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`
+- **GitHub Secrets 동기화**: `gh secret set --env-file engine/.env`
+- **헬스 확인**: `curl http://localhost:8000/`
+
+### Step 5 — `engine/.ai.md` 최신화
+
+기존 `.ai.md`에 Docker 실행 정보 한 줄 추가:
+- 실행 방식: Docker 컨테이너, 포트 8000, 진입점 `app.main:app`
+
+---
+
+## 이번 이슈 범위 밖 (추후 고려)
+
+- Graceful shutdown (ALB draining 대응) — uvicorn `--timeout-keep-alive` 설정
+- 헬스 체크 강화 — API 키 유효성 확인 엔드포인트 (`GET /health`)
+- Docker 이미지 버전 고정 (`python:3.12.1-slim`)
+- ECR 리포지토리 생성 + GitHub Actions CI/CD 파이프라인
+
+---
+
+## 참고 파일
+
+- `engine/pyproject.toml` — 의존성 정의 (pip install . 기반)
+- `engine/app/main.py` — FastAPI 진입점, 헬스 엔드포인트 (line 36)
+- `engine/app/config.py` — 환경변수 설정 (OPENROUTER_API_KEY)

--- a/engine/.ai.md
+++ b/engine/.ai.md
@@ -4,6 +4,20 @@
 전원 공동 설계·기여하는 공통 기술 레이어. TDD 적용.
 서비스들이 공유하는 파서·LLM·프롬프트 인프라를 제공.
 
+## 실행
+
+Docker 컨테이너로 실행. 포트 8000, 진입점 `app.main:app`.
+
+```bash
+# 빌드
+docker build -t mirai-engine .
+
+# 구동 (자동 재시작)
+docker run -d --restart unless-stopped -p 8000:8000 --env-file .env mirai-engine
+```
+
+상세 운영 가이드 → `engine/README.md`
+
 ## 구조
 ```
 engine/
@@ -18,6 +32,9 @@ engine/
 ├── tests/            pytest 테스트
 │   └── fixtures/     테스트 데이터 (샘플 PDF, 예상 응답 JSON)
 ├── docs/             엔진 설계 문서
+├── Dockerfile        컨테이너 빌드 (python:3.12-slim, non-root)
+├── .dockerignore     빌드 컨텍스트 제외 목록
+├── README.md         빌드·구동·환경변수 운영 가이드
 └── pyproject.toml    Python 프로젝트 설정
 ```
 

--- a/engine/.dockerignore
+++ b/engine/.dockerignore
@@ -1,0 +1,10 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+tests/
+.git/
+.gitignore
+*.md
+docs/
+.env

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+# 로그 버퍼링 비활성화 (stdout 실시간 출력)
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# 의존성만 먼저 복사 → 캐시 레이어 최적화
+# (코드만 변경 시 pip install 재실행 안 함)
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
+
+# 앱 소스 복사
+COPY app/ app/
+
+# 보안: non-root user 실행
+RUN useradd -m appuser
+USER appuser
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,111 @@
+# MirAI Engine
+
+FastAPI 기반 AI 엔진. PDF 파싱, LLM 호출, 면접 질문 생성을 담당한다.
+
+---
+
+## 환경변수
+
+| 변수 | 설명 | 필수 |
+|------|------|------|
+| `OPENROUTER_API_KEY` | OpenRouter API 키 | ✅ |
+| `OPENROUTER_MODEL` | 사용할 모델 ID (기본값: `google/gemini-2.5-flash`) | — |
+
+`engine/.env` 파일을 만들어 로컬에서 관리한다 (git 미추적):
+```
+OPENROUTER_API_KEY=sk-...
+OPENROUTER_MODEL=google/gemini-2.5-flash
+```
+
+---
+
+## 로컬 개발
+
+### Python 직접 실행
+
+```bash
+cd engine
+pip install -e ".[dev]"
+uvicorn app.main:app --reload --port 8000
+```
+
+### 테스트
+
+```bash
+cd engine
+pytest
+```
+
+---
+
+## Docker
+
+### 빌드
+
+```bash
+cd engine
+docker build -t mirai-engine .
+```
+
+### 구동 (로컬)
+
+```bash
+docker run --rm -p 8000:8000 --env-file .env mirai-engine
+```
+
+### 구동 (EC2 — 자동 재시작 포함)
+
+```bash
+docker run -d --restart unless-stopped \
+  -p 8000:8000 \
+  --env-file /home/ec2-user/mirai-engine.env \
+  mirai-engine
+```
+
+### 헬스 확인
+
+```bash
+curl http://localhost:8000/
+# {"status":"ok"}
+```
+
+---
+
+## 환경변수 운영
+
+### CI/CD (GitHub Actions) 연동
+
+로컬 `.env`를 GitHub Secrets에 동기화:
+
+```bash
+# engine/ 루트에서 실행 (변경 시마다 재실행)
+gh secret set --env-file .env
+
+# 확인
+gh secret list
+```
+
+GitHub Actions에서 주입 예시:
+```yaml
+- name: Deploy
+  env:
+    OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  run: |
+    docker run -d --restart unless-stopped -p 8000:8000 \
+      -e OPENROUTER_API_KEY=$OPENROUTER_API_KEY \
+      mirai-engine
+```
+
+---
+
+## API 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| `GET` | `/` | 헬스 체크 |
+| `POST` | `/api/resume/questions` | PDF → 면접 질문 생성 |
+| `POST` | `/api/interview/start` | 면접 세션 시작 |
+| `POST` | `/api/interview/answer` | 답변 처리 → 다음 질문 |
+| `POST` | `/api/interview/followup` | 심화 질문 생성 |
+
+상세 계약은 `engine/.ai.md` 참고.


### PR DESCRIPTION
## 이슈 배경

EC2 배포 시 의존성 충돌 없이 일관된 환경에서 엔진을 실행하기 위해 Docker 컨테이너화가 필요했다. `python:3.12-slim` 기반 Dockerfile을 작성하고 로컬 빌드 및 실행을 검증했다.

## 완료 기준 (AC)

- [x] `engine/Dockerfile` 작성 (python:3.12-slim 기반)
- [x] `docker build` 로컬 빌드 성공
- [x] `docker run` 으로 `GET /` 응답 확인 (`{"status":"ok"}`)
- [x] `.dockerignore` 작성 (tests/, .venv/, __pycache__ 등 제외)

## 작업 내역

### engine/Dockerfile
`python:3.12-slim` 기반 Dockerfile 작성. 레이어 캐시 효율화를 위해 `pyproject.toml` 복사 후 `pip install`, 이후 앱 소스를 복사하는 순서로 구성. `PYTHONUNBUFFERED=1`로 로그 실시간 출력, `useradd -m appuser` + `USER appuser`로 non-root 실행.

### engine/.dockerignore
`.venv/`, `__pycache__/`, `tests/`, `.git/`, `docs/`, `.env` 등 런타임 불필요 파일 제외. `.env`는 API 키 보호를 위해 명시적으로 제외.

### engine/README.md
빌드·구동·환경변수 운영 가이드 문서 신규 작성. 로컬 개발, Docker 로컬 실행, EC2 자동 재시작(`--restart unless-stopped`) 방법 포함. GitHub Secrets 동기화(`gh secret set --env-file .env`) 및 CI/CD 주입 예시도 기재.

### engine/.ai.md
Docker 실행 섹션 추가 (포트 8000, non-root, 자동 재시작). 구조 트리에 `Dockerfile`, `.dockerignore`, `README.md` 항목 추가.

### 기술적 결정
- 이슈에서 `GET /health`를 완료 기준으로 명시했으나 실제 엔드포인트는 `GET /` (`app/main.py:36`). 계획 문서에 명시 후 `GET /`로 검증.
- 환경변수는 이미지에 굽지 않고 런타임 주입 방식 채택 → ECR+GitHub Actions 연동 시에도 동일 방식 사용 가능.

Closes #66