### PR TITLE
chore: broadpull-main 커맨드 추가 (#101)

### DIFF
--- a/.claude/commands/.ai.md
+++ b/.claude/commands/.ai.md
@@ -6,8 +6,9 @@ Claude Code 슬래시 커맨드 파일 모음. 이슈 워크플로우 자동화 
 ## 파일 목록
 
 ### 워크플로우 커맨드
-- `backlog-issue.md`  — 새 이슈를 Backlog에 생성 (feat/chore 템플릿에 구현 플랜 섹션 포함)
-- `start-issue.md`   — 이슈 작업 시작 (워크트리/브랜치/work 폴더 생성, 이슈 assign, Ready 상태 검증, gitignore 대상 심볼릭 링크 자동 연결)
+- `backlog-issue.md`   — 새 이슈를 Backlog에 생성 (feat/chore 템플릿에 구현 플랜 섹션 포함)
+- `broadpull-main.md` — 모든 활성 워크트리에 origin/main을 rebase pull (충돌 시 건너뛰고 결과 집계)
+- `start-issue.md`    — 이슈 작업 시작 (워크트리/브랜치/work 폴더 생성, 이슈 assign, Ready 상태 검증, gitignore 대상 심볼릭 링크 자동 연결)
 - `plan.md`          — 현재 이슈의 구현 계획 작성 (OMC 있으면 ralplan 호출, 없으면 Claude 직접 작성 → 01_plan.md 저장)
 - `finish-issue.md`  — 구현 완료 후 커밋 및 PR 생성 (코드 간소화→리뷰→AC 체크→커밋 순서, docs/work 완료문서 PR 반영, active→done 이동)
 - `drop-issue.md`    — 이슈 중도 포기 (사유 입력, CWD 가드, 미커밋 확인, 이슈 닫기, DROPPED- 접두사로 done 이동, 워크트리/브랜치 정리)

--- a/.claude/commands/broadpull-main.md
+++ b/.claude/commands/broadpull-main.md
@@ -1,0 +1,86 @@
+---
+description: 모든 활성 워크트리에 origin/main을 rebase 방식으로 pull한다. 충돌 시 해당 워크트리를 건너뛰고 결과를 집계한다. 사용법: /broadpull-main
+---
+
+## 개요
+
+인수 없음. 실행 시 모든 활성 워크트리에 `git pull --rebase origin main`을 순차 실행하고 결과를 집계한다.
+
+---
+
+## 실행 순서
+
+### 1. 워크트리 목록 수집
+
+```bash
+git worktree list --porcelain
+```
+
+`--porcelain` 출력을 블록 단위(빈 줄 구분)로 파싱한다.
+
+각 블록에서 추출:
+- `worktree {경로}` → 워크트리 경로
+- `branch refs/heads/{브랜치명}` → 브랜치명
+- `detached` 또는 `bare` 키워드 → 해당 워크트리는 처리 대상 제외
+
+메인 워크트리(첫 번째 블록)를 목록 맨 앞에 두고 순차 처리한다.
+
+---
+
+### 2. 각 워크트리 순차 처리
+
+워크트리마다 다음 순서로 실행한다:
+
+#### 2-1. Detached HEAD / bare 건너뜀
+
+블록에 `detached` 또는 `bare` 키워드가 있으면:
+- 결과 목록에 "⏭️ 해당없음 (detached/bare)" 기록 후 다음으로
+
+#### 2-2. 미커밋 변경사항 확인
+
+```bash
+git -C {경로} status --porcelain
+```
+
+출력이 비어있지 않으면 (스테이징·언스테이징·미추적 파일 포함):
+- 결과 목록에 "⏭️ 미커밋 변경사항 — 건너뜀" 기록 후 다음으로
+
+#### 2-3. Rebase pull 실행
+
+```bash
+git -C {경로} pull --rebase origin main
+```
+
+종료 코드 확인:
+- **exit 0** → 결과 목록에 "✓ 성공" 기록
+- **exit != 0** → 아래 처리 후 결과 목록에 "⚠️ 충돌 — rebase 중단됨" 기록:
+  ```bash
+  git -C {경로} rebase --abort
+  ```
+
+---
+
+### 3. 결과 집계 및 출력
+
+모든 워크트리 처리 완료 후 다음 형식으로 출력:
+
+```
+## broadpull-main 결과
+
+| 워크트리 경로 | 브랜치 | 결과 |
+|---------------|--------|------|
+| (메인) | main | ✓ 성공 |
+| .worktree/000015-pdf-upload | feat/000015-pdf-upload | ✓ 성공 |
+| .worktree/000023-parser-fix | fix/000023-parser-fix | ⚠️ 충돌 — rebase 중단됨 |
+| .worktree/000030-auth-flow  | feat/000030-auth-flow | ⏭️ 미커밋 변경사항 — 건너뜀 |
+
+---
+성공: 2 / 충돌: 1 / 건너뜀: 1 / 총: 4
+```
+
+충돌이 1건 이상이면 테이블 아래에 추가 출력:
+
+```
+⚠️  충돌이 발생한 워크트리는 수동으로 rebase를 진행하세요:
+  cd {충돌워크트리경로} && git pull --rebase origin main
+```

--- a/docs/work/done/000101-broadpull-main/00_issue.md
+++ b/docs/work/done/000101-broadpull-main/00_issue.md
@@ -1,0 +1,46 @@
+# chore: broadpull-main 커맨드 추가
+
+## 목적
+main 워크트리와 모든 활성 워크트리에서 origin/main을 한 번에 pull하는 커맨드를 추가한다.
+
+## 배경
+워크트리가 여러 개일 때 각각 이동해서 pull하는 번거로움을 없애기 위함.
+
+## 완료 기준
+- [x] `.claude/commands/broadpull-main.md` 작성 (main + 전체 워크트리 순차 pull)
+- [x] pull 방식은 **rebase 기반** (`git pull --rebase origin main`)
+- [x] 충돌 발생 시 자동 처리 금지 — 해당 워크트리 건너뛰고 충돌 경고 출력
+- [x] 각 워크트리 pull 성공/실패/충돌 결과 집계 후 출력
+- [x] `.claude/commands/.ai.md` 커맨드 목록 반영
+
+## 구현 플랜
+1. `git worktree list`로 전체 워크트리 경로 수집
+2. 각 경로에서 `git -C {path} pull --rebase origin main` 실행
+3. 충돌 발생 시 `git -C {path} rebase --abort` 후 경고 출력, 다음 워크트리로 진행
+4. 성공/실패/충돌 여부 집계 후 최종 출력
+
+## 개발 체크리스트
+- [ ] 해당 디렉토리 .ai.md 최신화
+
+---
+
+## 작업 내역
+
+### 2026-03-15
+
+**현황**: 5/5 완료
+
+**완료된 항목**:
+- `.claude/commands/broadpull-main.md` 작성 (rebase pull, 충돌 건너뜀, 결과 집계)
+- pull 방식 rebase 기반 구현 (`git pull --rebase origin main`)
+- 충돌 시 exit code 감지 후 `rebase --abort` 실행, "⚠️ 충돌" 경고 기록
+- 성공/충돌/건너뜀 결과 집계 테이블 + 수량 요약 출력
+- `.claude/commands/.ai.md` 커맨드 목록에 broadpull-main 반영
+
+**미완료 항목**: 없음
+
+**변경 파일**: 3개
+
+**구현 상세**:
+- `broadpull-main.md`: `git worktree list --porcelain` 파싱으로 워크트리 수집. detached/bare 필터링. dirty 워크트리(`status --porcelain` 비어있지 않음) 건너뜀. exit code 기반 충돌 감지(grep 미사용). 충돌 시 `rebase --abort` 자동 실행. 결과 마크다운 테이블 집계.
+- `.claude/commands/.ai.md`: broadpull-main.md 항목 추가 (워크플로우 커맨드 섹션 알파벳순 삽입)

--- a/docs/work/done/000101-broadpull-main/01_plan.md
+++ b/docs/work/done/000101-broadpull-main/01_plan.md
@@ -1,0 +1,142 @@
+# [#101] chore: broadpull-main 커맨드 추가 — 구현 계획
+
+> 작성: 2026-03-15
+
+---
+
+## 완료 기준
+
+- [ ] `.claude/commands/broadpull-main.md` 작성 (main + 전체 워크트리 순차 pull)
+- [ ] pull 방식은 **rebase 기반** (`git pull --rebase origin main`)
+- [ ] 충돌 발생 시 자동 처리 금지 — 해당 워크트리 건너뛰고 충돌 경고 출력
+- [ ] 각 워크트리 pull 성공/실패/충돌 결과 집계 후 출력
+- [ ] `.claude/commands/.ai.md` 커맨드 목록 반영
+
+---
+
+## 구현 계획
+
+### 개요
+
+2개 파일을 변경한다:
+
+| 파일 | 동작 |
+|------|------|
+| `.claude/commands/broadpull-main.md` | 신규 생성 |
+| `.claude/commands/.ai.md` | 수정 (항목 추가) |
+
+---
+
+### Step 1: `broadpull-main.md` 커맨드 파일 작성
+
+**파일**: `.claude/commands/broadpull-main.md`
+
+커맨드 파일은 YAML frontmatter + 실행 순서 마크다운으로 구성한다.
+
+#### YAML frontmatter
+
+```
+---
+description: 모든 활성 워크트리에 origin/main을 rebase 방식으로 pull한다. 충돌 시 해당 워크트리를 건너뛰고 결과를 집계한다. 사용법: /broadpull-main
+---
+```
+
+인수(`$ARGUMENTS`)는 없다. 이 커맨드는 인수 없이 실행된다.
+
+#### 실행 순서 — 본문에 기술할 내용
+
+**1. 워크트리 목록 수집**
+
+```bash
+git worktree list --porcelain
+```
+
+`--porcelain` 출력을 블록 단위로 파싱한다. 각 블록의 형식:
+```
+worktree {경로}
+HEAD {커밋해시}
+branch refs/heads/{브랜치명}    ← 정상 브랜치
+# 또는
+detached                        ← detached HEAD
+# 또는
+bare                            ← bare 레포
+```
+
+파싱 규칙:
+- `worktree` 라인 → 경로 추출
+- `branch refs/heads/` 라인 → 브랜치명 추출
+- `detached` 또는 `bare` 라인 → 해당 워크트리는 **건너뜀** (결과에 "해당없음"으로 기록)
+
+수집 후 **메인 워크트리(첫 번째 블록)를 목록 맨 앞**에 두고 순차 처리한다.
+
+**2. 각 워크트리 순차 처리**
+
+워크트리마다 다음 순서:
+
+2-1. Detached HEAD / bare 여부 확인 → 해당하면 건너뜀
+
+2-2. 미커밋 변경사항 확인:
+```bash
+git -C {경로} status --porcelain
+```
+출력이 비어있지 않으면 → **건너뜀**, 결과에 "⏭️ 미커밋 변경사항" 기록
+
+2-3. rebase pull 실행:
+```bash
+git -C {경로} pull --rebase origin main
+```
+
+2-4. 종료 코드 확인:
+- `exit 0` → 결과에 "✓ 성공" 기록
+- `exit != 0` → 진행 중인 rebase 중단 후 결과에 "⚠️ 충돌" 기록:
+  ```bash
+  git -C {경로} rebase --abort
+  ```
+
+**3. 결과 집계 및 출력**
+
+모든 워크트리 처리 완료 후 요약 테이블 출력:
+
+```
+## broadpull-main 결과
+
+| 워크트리 경로 | 브랜치 | 결과 |
+|---------------|--------|------|
+| (메인) | main | ✓ 성공 |
+| .worktree/000015-pdf-upload | feat/000015-pdf-upload | ✓ 성공 |
+| .worktree/000023-parser-fix | fix/000023-parser-fix | ⚠️ 충돌 — rebase 중단됨 |
+| .worktree/000030-auth-flow  | feat/000030-auth-flow | ⏭️ 미커밋 변경사항 — 건너뜀 |
+
+---
+성공: 2 / 충돌: 1 / 건너뜀: 1 / 총: 4
+```
+
+충돌이 1건 이상이면 하단에 수동 해결 안내 출력:
+```
+⚠️  충돌이 발생한 워크트리는 수동으로 rebase를 진행하세요:
+  cd {워크트리경로} && git pull --rebase origin main
+```
+
+---
+
+### Step 2: `.ai.md` 커맨드 목록 반영
+
+**파일**: `.claude/commands/.ai.md`
+
+`### 워크플로우 커맨드` 섹션 — `backlog-issue.md` 다음에 삽입:
+
+```markdown
+- `broadpull-main.md` — 모든 활성 워크트리에 origin/main을 rebase pull (충돌 시 건너뛰고 결과 집계)
+```
+
+---
+
+## 설계 결정 사항
+
+| 결정 | 이유 |
+|------|------|
+| 모든 워크트리에 `origin/main` rebase | 이슈 명시 목적: 기능 브랜치도 최신 main 위에 유지 |
+| `git status --porcelain` 사용 | `--short`는 로케일 영향 가능, porcelain은 기계 안정적 |
+| exit code로 충돌 감지 | `grep "rebase in progress"` 방식은 로케일·버전 의존적 |
+| detached HEAD / bare 건너뜀 | pull 대상 브랜치 없음, 안전 우선 |
+| 미커밋 변경사항 있으면 건너뜀 | rebase 충돌 위험 방지, 사용자 코드 보호 |


### PR DESCRIPTION
## 이슈 배경

워크트리가 여러 개일 때 각각 이동해서 `git pull`하는 번거로움을 없애기 위해, 모든 활성 워크트리에 `origin/main`을 한 번에 rebase pull하는 `/broadpull-main` 커맨드를 추가한다.

## 완료 기준 (AC)

- [x] `.claude/commands/broadpull-main.md` 작성 (main + 전체 워크트리 순차 pull)
- [x] pull 방식은 rebase 기반 (`git pull --rebase origin main`)
- [x] 충돌 발생 시 자동 처리 금지 — 해당 워크트리 건너뛰고 충돌 경고 출력
- [x] 각 워크트리 pull 성공/실패/충돌 결과 집계 후 출력
- [x] `.claude/commands/.ai.md` 커맨드 목록 반영

## 작업 내역

- `broadpull-main.md`: `git worktree list --porcelain` 파싱으로 워크트리 수집. detached/bare 필터링. dirty 워크트리(`status --porcelain` 비어있지 않음) 건너뜀. exit code 기반 충돌 감지(grep 미사용). 충돌 시 `rebase --abort` 자동 실행. 결과 마크다운 테이블 집계.
- `.claude/commands/.ai.md`: broadpull-main.md 항목 추가 (워크플로우 커맨드 섹션 알파벳순 삽입)

Closes #101