### PR TITLE
feat: seung 역량 평가 리포트 구현 (Report 모델·API·페이지·테스트) (#81)

### DIFF
--- a/docs/work/done/000081-services-seung-phase/00_issue.md
+++ b/docs/work/done/000081-services-seung-phase/00_issue.md
@@ -1,0 +1,86 @@
+# feat: services/seung Phase 2 — 역량 평가 리포트 구현
+
+## 사용자 관점 목표
+seung 서비스에서 패널 면접 완료 후 8축 역량 평가 리포트를 확인할 수 있다. 각 축별 점수·피드백과 총점을 리포트 페이지에서 조회한다.
+
+## 배경
+engine 기능 07(`POST /api/report/generate`)이 완료됐으며, seung Next.js 서비스가 이를 연동한다. Phase 1(패널 면접 + 꼬리질문)은 완료 상태. 엔진은 완전 stateless — `history`와 `resumeText`는 seung이 Supabase에서 관리하고 엔진 호출 시 풀 컨텍스트를 전달한다.
+
+**필드명 주의:** 엔진이 반환하는 `axisFeedbacks: AxisFeedback[8]`을 기준으로 저장·반환. `dev_spec.md` 기능07 응답 예시의 `actionItems`는 명명 불일치 — 엔진 계약 우선.
+
+**레이더 차트는 이번 범위 외.** 기본 UI(숫자+프로그레스 바)로 구현 후 별도 이슈 고도화.
+
+**엔진 수정 금지** — 엔진 API 규격(`engine/.ai.md`)에 맞게 서비스 파트만 개발한다.
+
+## 사전 검토 필수
+- `engine/.ai.md` — `/api/report/generate` 계약 (`axisFeedbacks` 필드, 내부 LLM timeout 60s)
+- `docs/specs/mirai/dev_spec.md` — 기능 07 명세
+- `docs/specs/mirai/ux_flow.md` — 기능 07 화면 구성
+
+## 완료 기준
+- [x] `lib/types.ts`에 `AxisScores`, `AxisFeedback`, `ReportResponse` 타입 추가
+- [x] `Report` Prisma 모델 추가 (`id`, `sessionId` FK → InterviewSession, `totalScore Int`, `scores Json`, `summary String`, `axisFeedbacks Json`, `createdAt DateTime @default(now())`) + `prisma migrate dev` + Supabase RLS SQL 마이그레이션
+- [x] `POST /api/report/generate` 라우트: `sessionComplete === false` → 400 / 동일 sessionId Report 기존재 시 기존 `reportId` 반환 / 엔진 호출 (`AbortSignal.timeout(90_000)`, `maxDuration = 100`) / 엔진 422(InsufficientAnswersError) → 서비스 422 반환 / Report 저장 → `reportId` 반환
+- [x] `GET /api/report?reportId=xxx` 라우트: DB 조회 후 반환, 없으면 404
+- [x] `InterviewChat` 컴포넌트: `onReport?: () => void` prop 추가, 면접 완료 블록에 "리포트 생성하기"(로딩 스피너) + "다시 시작" 버튼 병렬 표시
+- [x] `/interview` 페이지: `isGeneratingReport` 상태 + `handleReport` 핸들러 — 로딩 중 버튼 비활성화, 완료 시 `/report?reportId=xxx` 이동, 에러 시 인라인 메시지 표시
+- [x] `/report` 페이지: Suspense 래퍼(`useSearchParams`), `reportId` 없거나 404 시 `/resume` redirect, 총점·8축 점수(숫자+프로그레스 바)·종합 요약·축별 피드백 카드·"홈으로" 버튼 표시
+- [x] Vitest 단위 테스트 (mockPrisma에 `report.findFirst`, `report.create` 포함)
+- [x] Playwright E2E (`test.setTimeout(120_000)` 이상, 면접 완료 → 리포트 생성 → 리포트 페이지 전 과정)
+- [x] `services/seung/.ai.md` 최신화
+
+## 구현 플랜
+1. **타입 정의** — `lib/types.ts`에 `AxisScores`, `AxisFeedback`, `ReportResponse` 추가
+2. **Prisma 스키마** — `Report` 모델 추가, `prisma migrate dev`, Supabase RLS SQL 적용
+3. **API 라우트 TDD**:
+   - `POST /api/report/generate` — `select { resumeId, history, sessionComplete }`로 세션 조회 → 완료 검증 → 중복 체크(findFirst) → DB history에서 `questionType` 제거 후 엔진 호출(90s timeout, maxDuration=100) → Report 저장
+   - `GET /api/report` — reportId DB 조회 후 반환
+4. **컴포넌트 수정** — `InterviewChat.tsx`: `onReport` prop 추가, 완료 블록 버튼 2개
+5. **페이지 수정** — `interview/page.tsx`: `isGeneratingReport` 상태 + `handleReport` 핸들러
+6. **리포트 페이지** — `app/report/page.tsx` (Suspense 래퍼) + `ReportCard` 컴포넌트 (점수 바·피드백·growthCurve null 플레이스홀더·홈으로 버튼)
+7. **Playwright E2E** — 면접 완료 → 리포트 생성 → 리포트 페이지 확인 (test.setTimeout ≥ 120_000)
+
+## 개발 체크리스트
+- [ ] 테스트 코드 포함 (Vitest unit + Playwright e2e)
+- [ ] 해당 디렉토리 `.ai.md` 최신화
+- [ ] 불변식 위반 없음 (LLM 직접 호출 금지 — 엔진 경유만)
+- [ ] `SUPABASE_SERVICE_ROLE_KEY` 서버 전용 (`NEXT_PUBLIC_` 금지)
+
+---
+
+## 작업 내역
+
+### 2026-03-16 — Phase 2 구현 완료
+
+**구현 내역:**
+- `src/lib/types.ts` — `AxisScores`, `AxisFeedback`, `ReportResponse`, `StoredHistoryEntry` 타입 추가
+- `src/app/api/interview/answer/route.ts` — 로컬 `StoredHistoryEntry` 타입 제거 → `lib/types.ts` import 교체
+- `prisma/schema.prisma` — `Report` 모델 추가, `InterviewSession.report?` 역관계 추가
+- `prisma migrate dev --name add-report` 실행 완료 (migration: `20260316033520_add_report`)
+- Supabase RLS SQL 적용 완료 (`ALTER TABLE "Report" ENABLE ROW LEVEL SECURITY` + policy)
+- `src/app/api/report/generate/route.ts` — POST 라우트 신규 (maxDuration=100, 90s timeout, P2002 fallback)
+- `src/app/api/report/route.ts` — GET 라우트 신규
+- `src/components/InterviewChat.tsx` — `onReport`, `isGeneratingReport` prop 추가, animate-spin 스피너
+- `src/app/interview/page.tsx` — `handleReport`, `isGeneratingReport`, `reportError` 추가
+- `src/app/report/page.tsx` — 신규 (Suspense, 총점/8축/피드백/growthCurve 플레이스홀더/홈으로)
+- `tests/api/report-generate.test.ts` — 9개 케이스 신규
+- `tests/api/report-get.test.ts` — 3개 케이스 신규
+- `tests/components/InterviewChat.test.tsx` — 2개 케이스 추가
+- `tests/e2e/report-flow.spec.ts` — 2개 E2E 케이스 신규 (test.setTimeout 120_000)
+- `services/seung/.ai.md` 최신화
+
+**테스트 결과:** Vitest 56/56 통과
+
+### 2026-03-17
+
+**현황**: 9/9 완료
+
+**완료된 항목**:
+- 실제 엔진 연동 E2E 검증 (`real-report-flow.spec.ts` 신규 추가, 1/1 통과, 소요 1.4분)
+- `tests/e2e/real-report-flow.spec.ts` — 자소서 업로드 → 패널 면접 → 리포트 생성 전체 플로우 실제 환경 검증
+- Playwright 비디오 녹화 확인 (`test-results/real-report-flow-*/video.webm`)
+
+**미완료 항목**: 없음
+
+**변경 파일**: 1개 (`tests/e2e/real-report-flow.spec.ts` 신규)
+

--- a/docs/work/done/000081-services-seung-phase/01_plan.md
+++ b/docs/work/done/000081-services-seung-phase/01_plan.md
@@ -1,0 +1,519 @@
+# [#81] feat: services/seung Phase 2 — 역량 평가 리포트 구현 — 구현 계획
+
+> 작성: 2026-03-16
+
+---
+
+## 완료 기준
+
+- [x] `lib/types.ts`에 `AxisScores`, `AxisFeedback`, `ReportResponse` 타입 추가
+- [x] `Report` Prisma 모델 추가 (`id`, `sessionId` FK → InterviewSession, `totalScore Int`, `scores Json`, `summary String`, `axisFeedbacks Json`, `createdAt DateTime @default(now())`) + `prisma migrate dev` + Supabase RLS SQL 마이그레이션
+- [x] `POST /api/report/generate` 라우트: `sessionComplete === false` → 400 / 동일 sessionId Report 기존재 시 기존 `reportId` 반환 / 엔진 호출 (`AbortSignal.timeout(90_000)`, `maxDuration = 100`) / 엔진 422(InsufficientAnswersError) → 서비스 422 반환 / Report 저장 → `reportId` 반환
+- [x] `GET /api/report?reportId=xxx` 라우트: DB 조회 후 반환, 없으면 404
+- [x] `InterviewChat` 컴포넌트: `onReport?: () => void` prop 추가, 면접 완료 블록에 "리포트 생성하기"(로딩 스피너) + "다시 시작" 버튼 병렬 표시
+- [x] `/interview` 페이지: `isGeneratingReport` 상태 + `handleReport` 핸들러 — 로딩 중 버튼 비활성화, 완료 시 `/report?reportId=xxx` 이동, 에러 시 인라인 메시지 표시
+- [x] `/report` 페이지: Suspense 래퍼(`useSearchParams`), `reportId` 없거나 404 시 `/resume` redirect, 총점·8축 점수(숫자+프로그레스 바)·종합 요약·축별 피드백 카드·"홈으로" 버튼 표시
+- [x] Vitest 단위 테스트 (mockPrisma에 `report.findFirst`, `report.create` 포함)
+- [x] Playwright E2E (`test.setTimeout(120_000)` 이상, 면접 완료 → 리포트 생성 → 리포트 페이지 전 과정)
+- [x] `services/seung/.ai.md` 최신화
+
+---
+
+## 구현 계획
+
+### 핵심 설계 원칙
+
+- 엔진 계약 우선 — `axisFeedbacks` 필드명 사용 (`dev_spec.md`의 `actionItems` 무시)
+- LLM 직접 호출 금지 — 반드시 엔진 경유 (아키텍처 불변식)
+- 멱등성 보장 — 동일 `sessionId` 재호출 시 기존 `reportId` 반환
+
+### 핵심 고민 포인트
+
+**1. timeout 설정**
+엔진 내부 LLM timeout이 60s이므로, 서비스 fetch timeout을 **90s**로 설정해야 합니다.
+Vercel function도 기본 10s가 상한이므로 `maxDuration = 100`을 명시했습니다.
+
+**2. 중복 리포트 방지 (멱등성)**
+사용자가 버튼을 여러 번 클릭하거나 네트워크 재시도가 발생할 경우, 리포트가 중복 생성되면 안 됩니다.
+두 가지 레이어로 처리했습니다:
+- 엔진 호출 전 `report.findFirst`로 기존 리포트 확인 → 있으면 바로 반환
+- `sessionId @unique` 제약으로 DB 레벨 방어 → 동시 요청 시 P2002를 catch해서 기존 ID 반환
+
+**3. 리포트 생성 방식 — 동기 vs 비동기**
+비동기 큐/폴링(POST → pending → GET polling)이 race condition을 완전히 해결하지만, Redis/BullMQ 인프라가 필요해 현재 범위를 초과합니다.
+동기 90s fetch로도 엔진 응답(12~18s)을 충분히 수용할 수 있어 동기 방식을 선택했습니다.
+→ Phase 3에서 `Report.status` 필드 추가 및 비동기 패턴 전환 검토 예정
+
+**4. DB 쿼리 방식**
+세션 조회 시 `resume`를 `include`해서 1회 쿼리로 `resumeText`까지 획득합니다.
+기존 `answer/route.ts`처럼 resume를 별도 쿼리하면 round-trip이 늘어납니다.
+
+---
+
+### 구현 단계
+
+#### Step 1: `src/lib/types.ts` 타입 추가
+
+```typescript
+// 엔진 계약 타입
+export type AxisScores = {
+  communication: number
+  problemSolving: number
+  logicalThinking: number
+  jobExpertise: number
+  cultureFit: number
+  leadership: number
+  creativity: number
+  sincerity: number
+}
+
+export type AxisFeedback = {
+  axis: string
+  axisLabel: string
+  score: number
+  type: 'strength' | 'improvement'
+  feedback: string
+}
+
+export type EngineReportResponse = {
+  scores: AxisScores
+  totalScore: number
+  summary: string
+  axisFeedbacks: AxisFeedback[]
+  growthCurve: null
+}
+
+// 서비스 응답 타입
+export type ReportData = {
+  id: string
+  sessionId: string
+  totalScore: number
+  scores: AxisScores
+  summary: string
+  axisFeedbacks: AxisFeedback[]
+  createdAt: string
+}
+
+// StoredHistoryEntry — interview/answer/route.ts에서 추출 (중복 제거)
+export type StoredHistoryEntry = HistoryItem & { questionType?: string }
+```
+
+> **주의**: `StoredHistoryEntry` 추출 후 `src/app/api/interview/answer/route.ts:68`의 로컬 타입 정의를 import로 교체
+
+---
+
+#### Step 2: Prisma 스키마 (`prisma/schema.prisma`)
+
+```prisma
+model Report {
+  id            String           @id @default(cuid())
+  sessionId     String           @unique
+  session       InterviewSession @relation(fields: [sessionId], references: [id])
+  totalScore    Int
+  scores        Json
+  summary       String
+  axisFeedbacks Json
+  createdAt     DateTime         @default(now())
+}
+```
+
+`InterviewSession` 모델에 역관계 추가:
+```prisma
+report Report?
+```
+
+마이그레이션:
+```bash
+cd services/seung && npx prisma migrate dev --name add-report
+```
+
+Supabase RLS SQL (마이그레이션 후 별도 실행):
+```sql
+ALTER TABLE "Report" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "service_role_full" ON "Report" FOR ALL USING (true);
+```
+
+---
+
+#### Step 3: `src/app/api/report/generate/route.ts` (신규)
+
+```typescript
+export const maxDuration = 100  // Vercel function timeout
+const ENGINE_FETCH_TIMEOUT_MS = 90_000
+
+export async function POST(request: NextRequest) {
+  // 1. body 파싱: { sessionId }
+  // 2. sessionId 없으면 400
+
+  // 3. ENGINE_BASE_URL 없으면 500
+  const engineUrl = process.env.ENGINE_BASE_URL
+  if (!engineUrl) return NextResponse.json({ error: '서버 설정 오류입니다.' }, { status: 500 })
+
+  // 4. session + resume include 1회 쿼리
+  //    prisma.interviewSession.findUnique({
+  //      where: { id: sessionId },
+  //      include: { resume: { select: { resumeText: true } } }
+  //    }) → 없으면 404
+
+  // 5. sessionComplete === false → 400 "면접이 아직 완료되지 않았습니다."
+
+  // 6. 중복 체크: prisma.report.findFirst({ where: { sessionId } })
+  //    → 있으면 200 + { reportId: existing.id }
+
+  // 7. history에서 questionType 제거 (StoredHistoryEntry 타입)
+  //    (session.history as StoredHistoryEntry[]).map(({ questionType: _qt, ...rest }) => rest)
+
+  // 8. 엔진 호출
+  //    fetch(`${engineUrl}/api/report/generate`, {
+  //      method: 'POST',
+  //      body: JSON.stringify({ resumeText, history }),
+  //      signal: AbortSignal.timeout(ENGINE_FETCH_TIMEOUT_MS)
+  //    })
+
+  // 9. 엔진 422 → 서비스 422 "답변이 부족합니다. 더 많은 질문에 답변해 주세요."
+  // 10. 엔진 500 / fetch 에러 → 서비스 500 "서버 오류가 발생했습니다."
+
+  // 11. Math.round(engineData.totalScore)로 Int 보장
+
+  // 12. Report 저장 (P2002 race condition 처리)
+  //    try {
+  //      const report = await prisma.report.create({
+  //        data: { sessionId, totalScore, scores, summary, axisFeedbacks }
+  //      })
+  //      return NextResponse.json({ reportId: report.id }, { status: 201 })
+  //    } catch (err) {
+  //      if (err.code === 'P2002') {
+  //        const existing = await prisma.report.findUnique({ where: { sessionId } })
+  //        return NextResponse.json({ reportId: existing!.id }, { status: 200 })
+  //      }
+  //      return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  //    }
+}
+```
+
+---
+
+#### Step 4: `src/app/api/report/route.ts` (신규)
+
+```typescript
+export async function GET(request: NextRequest) {
+  const reportId = request.nextUrl.searchParams.get('reportId')
+  // reportId 없으면 400
+
+  // prisma.report.findUnique({ where: { id: reportId } })
+  // 없으면 404
+
+  // scores, axisFeedbacks: Json → AxisScores, AxisFeedback[] 캐스팅 후 반환
+  // return NextResponse.json(report as ReportData, { status: 200 })
+}
+```
+
+---
+
+#### Step 5: `src/components/InterviewChat.tsx` 수정
+
+Props 타입에 추가:
+```typescript
+type Props = {
+  messages: Message[]
+  sessionComplete: boolean
+  onRestart?: () => void
+  onReport?: () => void           // 신규
+  isGeneratingReport?: boolean    // 신규
+}
+```
+
+`sessionComplete` 블록 수정 — 버튼 2개 병렬 표시:
+```tsx
+{sessionComplete && (
+  <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+    <p className="mb-6 text-lg font-semibold text-gray-900">면접이 완료되었습니다.</p>
+    <div className="flex justify-center gap-3">
+      {onReport && (
+        <button
+          onClick={onReport}
+          disabled={isGeneratingReport}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+        >
+          {isGeneratingReport ? '리포트 생성 중...' : '리포트 생성하기'}
+        </button>
+      )}
+      {onRestart && (
+        <button
+          onClick={onRestart}
+          disabled={isGeneratingReport}
+          className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
+        >
+          다시 시작
+        </button>
+      )}
+    </div>
+  </div>
+)}
+```
+
+---
+
+#### Step 6: `src/app/interview/page.tsx` 수정
+
+`InterviewContent` 함수에 추가:
+```typescript
+const [isGeneratingReport, setIsGeneratingReport] = useState(false)
+const [reportError, setReportError] = useState<string | null>(null)
+
+const handleReport = async () => {
+  if (!sessionId) return
+  setIsGeneratingReport(true)
+  setReportError(null)
+  try {
+    const res = await fetch('/api/report/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setReportError(data?.error ?? '리포트 생성에 실패했습니다. 다시 시도해 주세요.')
+      return
+    }
+    router.push(`/report?reportId=${data.reportId}`)
+  } catch {
+    setReportError('네트워크 오류가 발생했습니다. 다시 시도해 주세요.')
+  } finally {
+    setIsGeneratingReport(false)
+  }
+}
+```
+
+`InterviewChat` 컴포넌트 호출 시 prop 추가:
+```tsx
+<InterviewChat
+  messages={messages}
+  sessionComplete={sessionComplete}
+  onRestart={handleRestart}
+  onReport={handleReport}
+  isGeneratingReport={isGeneratingReport}
+/>
+```
+
+`reportError` 인라인 표시 (submitError 아래):
+```tsx
+{reportError && (
+  <p role="alert" className="text-sm text-red-600 text-center px-4">
+    {reportError}
+  </p>
+)}
+```
+
+---
+
+#### Step 7: `/report` 페이지 (`src/app/report/page.tsx`, 신규)
+
+```tsx
+'use client'
+import { Suspense } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import type { ReportData, AxisFeedback } from '@/lib/types'
+
+// Suspense 래퍼 (interview/page.tsx 동일 패턴)
+export default function ReportPage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center"><p className="text-gray-500">리포트를 불러오는 중...</p></div>}>
+      <ReportContent />
+    </Suspense>
+  )
+}
+
+function ReportContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const reportId = searchParams.get('reportId')
+  const [report, setReport] = useState<ReportData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!reportId) { router.replace('/resume'); return }
+    fetch(`/api/report?reportId=${reportId}`)
+      .then(r => { if (!r.ok) { router.replace('/resume'); return null } return r.json() })
+      .then(data => { if (data) setReport(data) })
+      .catch(() => router.replace('/resume'))
+      .finally(() => setLoading(false))
+  }, [reportId, router])
+
+  if (loading) return <LoadingScreen />
+
+  // UI 구성:
+  // - 총점: 큰 숫자 표시
+  // - 8축 점수: 각 축별 axisLabel + 숫자 + progress bar (score/100 * 100%)
+  //   type='strength' → 파란색, 'improvement' → 주황색
+  // - 종합 요약: report.summary
+  // - 축별 피드백 카드: axisFeedbacks 순회
+  // - "홈으로" 버튼 → router.push('/resume')
+}
+```
+
+---
+
+#### Step 8: Vitest 단위 테스트
+
+**`tests/api/report-generate.test.ts`** (신규, 9개):
+
+```typescript
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    interviewSession: { findUnique: vi.fn() },
+    report: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }))
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+```
+
+테스트 케이스:
+1. 성공: sessionComplete=true → 엔진 호출 → report.create → `{ reportId }` 반환 (201)
+2. sessionId 누락 → 400
+3. ENGINE_BASE_URL 없음 → 500
+4. 세션 없음 → 404
+5. sessionComplete=false → 400
+6. 기존 Report 있음 → findFirst hit → 기존 reportId 반환 (200), 엔진 미호출 확인
+7. 엔진 422 → 서비스 422
+8. 엔진 500 → 서비스 500
+9. report.create P2002 에러 → findUnique fallback → 기존 reportId 반환 (200)
+
+**`tests/api/report-get.test.ts`** (신규, 3개):
+1. reportId 있음 → 200 + ReportData
+2. reportId 없음 → 400
+3. 리포트 없음 → 404
+
+**`tests/components/InterviewChat.test.tsx`** 업데이트:
+- `onReport` prop 전달 시 "리포트 생성하기" 버튼 표시 테스트
+- `isGeneratingReport=true` 시 버튼 disabled 테스트
+
+---
+
+#### Step 9: Playwright E2E (`tests/e2e/report-flow.spec.ts`, 신규)
+
+```typescript
+import { test, expect } from '@playwright/test'
+
+const MOCK_SESSION_COMPLETE = {
+  currentQuestion: '', currentPersona: 'hr', currentPersonaLabel: 'HR 면접관',
+  currentQuestionType: 'main', history: [], sessionComplete: true,
+}
+const MOCK_REPORT_GENERATE = { reportId: 'report-123' }
+const MOCK_REPORT_DATA = {
+  id: 'report-123', sessionId: 'session-456', totalScore: 75,
+  scores: { communication: 80, problemSolving: 70, logicalThinking: 82,
+            jobExpertise: 78, cultureFit: 88, leadership: 75, creativity: 60, sincerity: 55 },
+  summary: '논리적 사고와 조직 적합성이 강점입니다.',
+  axisFeedbacks: [
+    { axis: 'communication', axisLabel: '의사소통', score: 80, type: 'strength', feedback: '명확하고 구체적인 답변' }
+    // ... 7개 더
+  ],
+  createdAt: '2026-03-16T00:00:00.000Z',
+}
+
+test.describe('리포트 플로우', () => {
+  test.setTimeout(120_000)
+
+  test('면접 완료 → 리포트 생성하기 → 리포트 페이지 표시', async ({ page }) => {
+    await page.route('**/api/interview/session*', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_SESSION_COMPLETE) })
+    )
+    await page.route('**/api/report/generate', route =>
+      route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(MOCK_REPORT_GENERATE) })
+    )
+    await page.route('**/api/report*', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_REPORT_DATA) })
+    )
+
+    await page.goto('/interview?sessionId=session-456')
+    await expect(page.getByText('면접이 완료되었습니다.')).toBeVisible()
+    await expect(page.getByRole('button', { name: '리포트 생성하기' })).toBeVisible()
+
+    await page.getByRole('button', { name: '리포트 생성하기' }).click()
+    await expect(page).toHaveURL(/\/report\?reportId=report-123/)
+    await expect(page.getByText('75')).toBeVisible()  // 총점
+    await expect(page.getByText('논리적 사고와 조직 적합성이 강점입니다.')).toBeVisible()
+  })
+
+  test('reportId 없이 /report 접근 시 /resume 리다이렉트', async ({ page }) => {
+    await page.goto('/report')
+    await expect(page).toHaveURL(/\/resume/)
+  })
+})
+```
+
+---
+
+#### Step 10: `services/seung/.ai.md` 최신화
+
+업데이트 항목:
+- 구조 트리에 추가:
+  - `src/app/report/page.tsx`
+  - `src/app/api/report/generate/route.ts`
+  - `src/app/api/report/route.ts`
+  - `tests/api/report-generate.test.ts`
+  - `tests/api/report-get.test.ts`
+  - `tests/e2e/report-flow.spec.ts`
+- Prisma 스키마에 `Report` 모델 반영
+- 진행 상태: `- [x] Phase 2: 역량 평가 리포트` 체크 처리
+- Phase 2+ TODO에서 역량 평가 항목 제거
+
+---
+
+### 구현 순서 (의존성 기반)
+
+| # | 작업 | 파일 | 의존성 |
+|---|------|------|--------|
+| 1 | 타입 추가 + StoredHistoryEntry 추출 | `src/lib/types.ts`, `answer/route.ts` | - |
+| 2 | Prisma 스키마 + migrate | `prisma/schema.prisma` | Step 1 |
+| 3 | Vitest 테스트 작성 (Red) | `tests/api/report-*.test.ts` | Step 1, 2 |
+| 4 | POST /api/report/generate 구현 (Green) | `src/app/api/report/generate/route.ts` | Step 3 |
+| 5 | GET /api/report 구현 (Green) | `src/app/api/report/route.ts` | Step 3 |
+| 6 | InterviewChat.tsx 수정 | `src/components/InterviewChat.tsx` | Step 1 |
+| 7 | interview/page.tsx 수정 | `src/app/interview/page.tsx` | Step 4, 6 |
+| 8 | /report 페이지 구현 | `src/app/report/page.tsx` | Step 5 |
+| 9 | InterviewChat.test.tsx 업데이트 | `tests/components/InterviewChat.test.tsx` | Step 6 |
+| 10 | Playwright E2E 작성 | `tests/e2e/report-flow.spec.ts` | Step 4, 5, 7, 8 |
+| 11 | .ai.md 최신화 | `services/seung/.ai.md` | 전체 |
+
+---
+
+### 리스크 및 완화
+
+| 리스크 | 완화 방법 |
+|--------|----------|
+| P2002 동시 요청 | `report.create` try/catch P2002 → `findUnique` fallback으로 기존 reportId 반환 |
+| LLM 응답 지연 (최대 60s) | `maxDuration=100`, `AbortSignal.timeout(90_000)` |
+| `totalScore` float 반환 | `Math.round(engineData.totalScore)` 후 DB 저장 |
+| `useSearchParams` SSR 오류 | `Suspense` 래퍼 필수 |
+| Supabase RLS 미적용 | `prisma migrate` 후 별도 SQL 실행 필수 |
+| `scores`/`axisFeedbacks` Json 타입 손실 | GET 라우트에서 타입 캐스팅 (`as AxisScores`, `as AxisFeedback[]`) |
+
+---
+
+### 검증 단계
+
+1. `cd services/seung && npx vitest run` → 단위 테스트 전체 통과
+2. `npx playwright test tests/e2e/report-flow.spec.ts` → E2E 2개 통과
+3. `npx prisma migrate status` → `add-report` 마이그레이션 적용 확인
+4. `services/seung/.ai.md` 구조·진행 상태 업데이트 확인
+
+---
+
+### Changelog (적용된 Architect/Critic 개선)
+
+- P2002 race condition 처리 추가 (Architect [Critical])
+- `StoredHistoryEntry` 타입 `lib/types.ts`로 추출 (Architect [Medium])
+- `Math.round(totalScore)` guard 추가 (Architect [Medium])
+- `ENGINE_BASE_URL` 없음 테스트 케이스 추가 (Architect [Low])
+- P2002 concurrent create 테스트 케이스 추가 (Architect [Low])
+- `InterviewChat.test.tsx` 업데이트 명시 (Critic 노트)
+- `sessionComplete=false` 에러 메시지 명시: "면접이 아직 완료되지 않았습니다." (Critic 노트)

--- a/docs/work/done/000081-services-seung-phase/02_test.md
+++ b/docs/work/done/000081-services-seung-phase/02_test.md
@@ -1,0 +1,142 @@
+# [#81] feat: services/seung Phase 2 — 역량 평가 리포트 구현 — 테스트 결과
+
+> 작성: 2026-03-16
+
+---
+
+## 최종 테스트 결과
+
+### Vitest 단위 테스트
+
+```
+Test Files  8 passed (8)
+Tests       56 passed (56)
+Duration    3.48s
+```
+
+**파일별 결과:**
+
+| 파일 | 테스트 수 | 결과 |
+|------|-----------|------|
+| `tests/api/report-generate.test.ts` | 9 | ✅ 전체 통과 |
+| `tests/api/report-get.test.ts` | 3 | ✅ 전체 통과 |
+| `tests/api/interview-answer.test.ts` | 10 | ✅ 전체 통과 |
+| `tests/api/interview-start.test.ts` | 5 | ✅ 전체 통과 |
+| `tests/api/questions.test.ts` | 9 | ✅ 전체 통과 |
+| `tests/components/InterviewChat.test.tsx` | 7 | ✅ 전체 통과 |
+| `tests/components/QuestionList.test.tsx` | 5 | ✅ 전체 통과 |
+| `tests/components/UploadForm.test.tsx` | 7 | ✅ 전체 통과 |
+
+---
+
+### 신규 테스트 케이스 상세
+
+#### `tests/api/report-generate.test.ts` (9개)
+
+| # | 케이스 | 상태 |
+|---|--------|------|
+| 1 | 성공: sessionComplete=true → 엔진 호출 → report.create → `{ reportId }` (201) | ✅ |
+| 2 | sessionId 누락 → 400 | ✅ |
+| 3 | ENGINE_BASE_URL 없음 → 500 | ✅ |
+| 4 | 세션 없음 → 404 | ✅ |
+| 5 | sessionComplete=false → 400 "면접이 아직 완료되지 않았습니다." | ✅ |
+| 6 | 기존 Report 있음 → findFirst hit → 기존 reportId (200), 엔진 미호출 | ✅ |
+| 7 | 엔진 422 → 서비스 422 "답변이 부족합니다." | ✅ |
+| 8 | 엔진 500 → 서비스 500 | ✅ |
+| 9 | report.create P2002 → findUnique fallback → 기존 reportId (200) | ✅ |
+
+#### `tests/api/report-get.test.ts` (3개)
+
+| # | 케이스 | 상태 |
+|---|--------|------|
+| 1 | reportId 있음 → 200 + ReportResponse | ✅ |
+| 2 | reportId 없음 → 400 | ✅ |
+| 3 | 리포트 없음 → 404 | ✅ |
+
+#### `tests/components/InterviewChat.test.tsx` (2개 추가)
+
+| # | 케이스 | 상태 |
+|---|--------|------|
+| 6 | onReport prop 전달 시 "리포트 생성하기" 버튼 표시 | ✅ |
+| 7 | isGeneratingReport=true 시 버튼 disabled + "리포트 생성 중..." 텍스트 | ✅ |
+
+---
+
+### Playwright E2E
+
+> `tests/e2e/report-flow.spec.ts` (test.setTimeout 120_000)
+
+| # | 케이스 | 비고 |
+|---|--------|------|
+| 1 | 면접 완료 → "리포트 생성하기" 클릭 → `/report?reportId=xxx` → 총점 표시 | API 모킹 |
+| 2 | `/report` (reportId 없음) → `/resume` redirect | API 모킹 |
+
+> E2E는 API 모킹 기반. 실제 엔진 연동 E2E는 아래 참조.
+
+---
+
+### 실제 엔진 연동 E2E (2026-03-17)
+
+> `tests/e2e/real-report-flow.spec.ts` (test.setTimeout 600_000)
+
+| # | 케이스 | 비고 | 결과 |
+|---|--------|------|------|
+| 1 | 자소서 업로드 → 패널 면접 → 리포트 생성 전체 플로우 | 실제 엔진 + Supabase | ✅ 1.4분 소요 |
+
+**사용 fixture**: `engine/tests/fixtures/input/sample_resume.pdf`
+
+**검증 항목**:
+- PDF 업로드 → 질문 생성 (LLM 호출)
+- 면접 시작 → 다수 답변 제출 → 면접 완료
+- "리포트 생성하기" 클릭 → 엔진 LLM 호출 → `/report?reportId=xxx` 이동
+- 총점·역량 축별 점수·종합 요약·축별 피드백·홈으로 버튼 표시 확인
+
+**비디오 녹화**: `test-results/real-report-flow-*/video.webm`
+
+---
+
+### DB 마이그레이션
+
+| 항목 | 결과 |
+|------|------|
+| `prisma migrate dev --name add-report` | ✅ 완료 (`20260316033520_add_report`) |
+| Supabase RLS `ALTER TABLE "Report" ENABLE ROW LEVEL SECURITY` | ✅ 완료 |
+| Supabase RLS `CREATE POLICY "service_role_full"` | ✅ 완료 |
+
+---
+
+---
+
+### 코드 리뷰 후 수정 사항 (2026-03-17)
+
+| 심각도 | 파일 | 내용 | 조치 |
+|--------|------|------|------|
+| MEDIUM | `report/page.tsx` | `report.axisFeedbacks`가 null/undefined일 때 `.find()` / `.map()` 호출 시 런타임 에러 가능 | `(report.axisFeedbacks ?? []).find(...)` / `.map(...)` 으로 null 가드 추가 |
+
+---
+
+### 코드 리뷰 후 수정 사항 (2026-03-16)
+
+| 심각도 | 파일 | 내용 | 조치 |
+|--------|------|------|------|
+| CRITICAL | `report/generate/route.ts` | P2002 fallback `findUnique`가 try/catch 없이 호출 → 예외 시 unhandled crash | fallback 내부 try/catch 추가 |
+| HIGH | `report/generate/route.ts` | `session.history`가 null/non-array 시 `.map()` TypeError | `Array.isArray()` 가드 추가, 비정상 시 500 반환 |
+| HIGH | `report/page.tsx` | `report.scores`가 null 시 `Object.entries()` TypeError → 화이트스크린 | `report.scores ?? {}` null 가드 추가 |
+| MEDIUM | `report/page.tsx` | `setLoading(false)` `.then()`과 `.finally()` 중복 호출 | `.then()`에서 제거, `.finally()`만 유지 |
+| MEDIUM | `report/page.tsx` | `axisFeedbacks`가 비어있을 때 feedback 없는 축이 강제로 주황색 표시 | feedback 미존재 시 중립 회색으로 처리 |
+
+---
+
+### 트러블슈팅 기록
+
+#### `vi.clearAllMocks()` vs `vi.resetAllMocks()` 이슈
+
+- **현상**: `report-generate.test.ts`에서 테스트 5~9번이 한 칸씩 밀려서 실패
+- **원인**: `vi.clearAllMocks()`는 호출 기록만 지우고, `mockResolvedValueOnce` 큐는 유지됨. TEST 3 (ENGINE_BASE_URL 없음)에서 route가 early return하여 소비되지 않은 mock이 이후 테스트로 누출
+- **해결**: `beforeEach`를 `vi.resetAllMocks()`로 교체 + TEST 3의 불필요한 mock 제거
+
+#### `.env` vs `.env.local` Prisma 인식 문제
+
+- **현상**: `prisma migrate dev` 실행 시 `DIRECT_URL` not found 에러
+- **원인**: Prisma는 `.env`만 읽고 `.env.local`은 Next.js 전용
+- **해결**: `.env.local` 내용을 `.env`로 복사 (`.gitignore`에 `.env*` 패턴 적용 확인)

--- a/services/seung/.ai.md
+++ b/services/seung/.ai.md
@@ -8,19 +8,25 @@ DDD (Domain-Driven Design) + TDD 적용.
 ```
 seung/
 ├── prisma/
-│   └── schema.prisma                          ← DB 스키마 (Resume, InterviewSession)
+│   └── schema.prisma                          ← DB 스키마 (Resume, InterviewSession, Report)
 ├── src/
 │   ├── app/
 │   │   ├── page.tsx                           ← 루트: /resume 로 리다이렉트
 │   │   ├── resume/
 │   │   │   └── page.tsx                       ← 자소서·질문 플로우 + 면접 시작 버튼
 │   │   ├── interview/
-│   │   │   └── page.tsx                       ← 패널 면접 채팅 UI (세션 기반)
+│   │   │   └── page.tsx                       ← 패널 면접 채팅 UI (세션 기반) + 리포트 생성 버튼
+│   │   ├── report/
+│   │   │   └── page.tsx                       ← 역량 평가 리포트 (총점/8축/피드백)
 │   │   ├── layout.tsx
 │   │   └── api/
 │   │       ├── resume/
 │   │       │   └── questions/
 │   │       │       └── route.ts               ← 엔진 포워딩 + PDF 텍스트 추출 + DB 저장
+│   │       ├── report/
+│   │       │   ├── route.ts                   ← GET /api/report?reportId=xxx → ReportResponse
+│   │       │   └── generate/
+│   │       │       └── route.ts               ← POST /api/report/generate → 엔진 호출 + DB 저장
 │   │       └── interview/
 │   │           ├── start/
 │   │           │   └── route.ts               ← 면접 세션 생성 (엔진 호출 → DB 저장)
@@ -41,17 +47,20 @@ seung/
 │   ├── e2e/
 │   │   ├── upload-flow.spec.ts                ← Playwright E2E 테스트 (4개, API 모킹)
 │   │   ├── interview-flow.spec.ts             ← Playwright E2E 테스트 (5개, 면접 플로우)
+│   │   ├── report-flow.spec.ts                ← Playwright E2E 테스트 (2개, 리포트 플로우)
 │   │   ├── real-flow.spec.ts                  ← Playwright E2E 테스트 (1개, 실제 엔진 연동)
 │   │   ├── real-interview-flow.spec.ts        ← Playwright E2E 테스트 (1개, 이슈 #57 전체 플로우, 영상 녹화)
 │   │   └── fixtures/                          ← 테스트용 PDF (gitignore)
 │   ├── api/
 │   │   ├── questions.test.ts                  ← API 라우트 단위 테스트 (9개)
 │   │   ├── interview-start.test.ts            ← 면접 시작 API 테스트 (5개)
-│   │   └── interview-answer.test.ts           ← 답변 처리 API 테스트 (6개)
+│   │   ├── interview-answer.test.ts           ← 답변 처리 API 테스트 (10개)
+│   │   ├── report-generate.test.ts            ← 리포트 생성 API 테스트 (9개)
+│   │   └── report-get.test.ts                 ← 리포트 조회 API 테스트 (3개)
 │   ├── components/
 │   │   ├── UploadForm.test.tsx                ← UploadForm 컴포넌트 테스트 (7개)
 │   │   ├── QuestionList.test.tsx              ← QuestionList 컴포넌트 테스트 (5개)
-│   │   └── InterviewChat.test.tsx             ← InterviewChat 컴포넌트 테스트 (5개)
+│   │   └── InterviewChat.test.tsx             ← InterviewChat 컴포넌트 테스트 (7개)
 │   └── setup.ts
 ├── playwright.config.ts
 ├── vitest.config.ts
@@ -90,7 +99,16 @@ seung/
 - [x] Phase 1: 전체 테스트 53개 통과 (단위 42 + E2E 모킹 9 + E2E 실제 연동 2)
 - [x] Phase 1: E2E 테스트 9개 추가 (면접 플로우 5 + 업로드 플로우 4)
 - [x] Phase 1: real-interview-flow.spec.ts — 실제 엔진 + Supabase 연동 E2E (영상 녹화)
-- [ ] Phase 2: 역량 평가
+- [x] Phase 2: 역량 평가 리포트
+  - [x] Prisma Report 모델 + migrate + RLS
+  - [x] POST /api/report/generate (완료검증/중복방지/엔진호출/P2002 fallback)
+  - [x] GET /api/report?reportId=xxx
+  - [x] InterviewChat: onReport + isGeneratingReport + animate-spin 스피너
+  - [x] /interview: handleReport + reportError
+  - [x] /report: 총점/8축/요약/피드백/growthCurve 플레이스홀더/홈으로
+  - [x] Vitest 12개 (report-generate 9, report-get 3)
+  - [x] InterviewChat 테스트 2개 추가
+  - [x] Playwright E2E 2개 (report-flow.spec.ts)
 - [ ] Phase 3: practice 모드
 
 ## 인증·DB·스토리지
@@ -131,7 +149,6 @@ seung/
 |------|------|
 | 세션 소유권 검증 | `InterviewSession`에 `userId` 컬럼 추가 후, `/api/interview/session`, `/api/interview/answer`에서 "현재 사용자 ↔ 세션 소유자" 일치 검사 도입 (인증 붙을 때 함께) |
 | 연습 모드 | `interviewMode: "practice"` (Phase 3 예정) |
-| 역량 평가 리포트 | Phase 2 예정 |
 
 ## 규칙 변경 시 컨펌 필요
 이 파일에 기재된 규칙과 충돌하는 변경을 하려는 경우, 작업을 진행하기 전에 반드시 사람(팀원)에게 먼저 확인을 받아야 한다.

--- a/services/seung/prisma/migrations/20260316033520_add_report/migration.sql
+++ b/services/seung/prisma/migrations/20260316033520_add_report/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Report" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "totalScore" INTEGER NOT NULL,
+    "scores" JSONB NOT NULL,
+    "summary" TEXT NOT NULL,
+    "axisFeedbacks" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Report_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Report_sessionId_key" ON "Report"("sessionId");
+
+-- AddForeignKey
+ALTER TABLE "Report" ADD CONSTRAINT "Report_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "InterviewSession"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/services/seung/prisma/schema.prisma
+++ b/services/seung/prisma/schema.prisma
@@ -29,4 +29,16 @@ model InterviewSession {
   currentQuestionType String   @default("main")
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
+  report              Report?
+}
+
+model Report {
+  id            String           @id @default(cuid())
+  sessionId     String           @unique
+  session       InterviewSession @relation(fields: [sessionId], references: [id])
+  totalScore    Int
+  scores        Json
+  summary       String
+  axisFeedbacks Json
+  createdAt     DateTime         @default(now())
 }

--- a/services/seung/src/app/api/interview/answer/route.ts
+++ b/services/seung/src/app/api/interview/answer/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import type { HistoryItem, QueueItem, PersonaType, QuestionType } from '@/lib/types'
+import type { HistoryItem, QueueItem, PersonaType, QuestionType, StoredHistoryEntry } from '@/lib/types'
 
 export const maxDuration = 35
 
@@ -65,7 +65,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '자소서를 찾을 수 없습니다.' }, { status: 404 })
   }
 
-  type StoredHistoryEntry = HistoryItem & { questionType?: string }
   const history = session.history as unknown as StoredHistoryEntry[]
   const questionsQueue = session.questionsQueue as unknown as QueueItem[]
 

--- a/services/seung/src/app/api/report/generate/route.ts
+++ b/services/seung/src/app/api/report/generate/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import type { StoredHistoryEntry, AxisScores, AxisFeedback } from '@/lib/types'
+
+export const maxDuration = 100
+
+const ENGINE_FETCH_TIMEOUT_MS = 90_000
+
+export async function POST(request: NextRequest) {
+  let body: { sessionId?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: '요청을 읽을 수 없습니다.' }, { status: 400 })
+  }
+
+  const { sessionId } = body
+
+  if (!sessionId) {
+    return NextResponse.json({ error: 'sessionId가 필요합니다.' }, { status: 400 })
+  }
+
+  const engineUrl = process.env.ENGINE_BASE_URL
+  if (!engineUrl) {
+    return NextResponse.json({ error: '서버 설정 오류입니다.' }, { status: 500 })
+  }
+
+  let session: {
+    id: string
+    sessionComplete: boolean
+    history: unknown
+    resume: { resumeText: string }
+  } | null
+  try {
+    session = await prisma.interviewSession.findUnique({
+      where: { id: sessionId },
+      include: { resume: { select: { resumeText: true } } },
+    })
+  } catch (err) {
+    console.error('[report/generate] session lookup failed', { sessionId, err })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+
+  if (!session) {
+    return NextResponse.json({ error: '세션을 찾을 수 없습니다.' }, { status: 404 })
+  }
+
+  if (!session.sessionComplete) {
+    return NextResponse.json({ error: '면접이 아직 완료되지 않았습니다.' }, { status: 400 })
+  }
+
+  // 이미 생성된 리포트가 있으면 재사용
+  let existingReport: { id: string } | null
+  try {
+    existingReport = await prisma.report.findFirst({ where: { sessionId } })
+  } catch (err) {
+    console.error('[report/generate] report findFirst failed', { sessionId, err })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+
+  if (existingReport) {
+    return NextResponse.json({ reportId: existingReport.id }, { status: 200 })
+  }
+
+  // history에서 questionType 제거 후 엔진 전달
+  const rawHistory = session.history
+  if (!Array.isArray(rawHistory)) {
+    console.error('[report/generate] session.history is not an array', { sessionId })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+  const history = (rawHistory as StoredHistoryEntry[]).map(
+    ({ questionType: _qt, ...rest }) => rest
+  )
+
+  let engineResponse: Response
+  try {
+    engineResponse = await fetch(`${engineUrl}/api/report/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        resumeText: session.resume.resumeText,
+        history,
+      }),
+      signal: AbortSignal.timeout(ENGINE_FETCH_TIMEOUT_MS),
+    })
+  } catch (err) {
+    console.error('[report/generate] engine fetch failed', { sessionId, err })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+
+  if (!engineResponse.ok) {
+    if (engineResponse.status === 422) {
+      return NextResponse.json(
+        { error: '답변이 부족합니다. 더 많은 질문에 답변해 주세요.' },
+        { status: 422 }
+      )
+    }
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+
+  let engineData: {
+    totalScore: number
+    scores: AxisScores
+    summary: string
+    axisFeedbacks: AxisFeedback[]
+  }
+  try {
+    engineData = await engineResponse.json()
+  } catch (err) {
+    console.error('[report/generate] engine response parse failed', { sessionId, err })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+
+  const totalScore = Math.round(engineData.totalScore)
+
+  try {
+    const report = await prisma.report.create({
+      data: {
+        sessionId,
+        totalScore,
+        scores: engineData.scores as object,
+        summary: engineData.summary,
+        axisFeedbacks: engineData.axisFeedbacks as object[],
+      },
+    })
+    return NextResponse.json({ reportId: report.id }, { status: 201 })
+  } catch (err) {
+    // P2002: sessionId unique constraint — 동시 요청으로 이미 생성됨
+    if ((err as { code?: string }).code === 'P2002') {
+      try {
+        const fallback = await prisma.report.findUnique({ where: { sessionId } })
+        if (fallback) {
+          return NextResponse.json({ reportId: fallback.id }, { status: 200 })
+        }
+      } catch (fallbackErr) {
+        console.error('[report/generate] P2002 fallback findUnique failed', { sessionId, fallbackErr })
+      }
+    }
+    console.error('[report/generate] report create failed', { sessionId, err })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/services/seung/src/app/api/report/route.ts
+++ b/services/seung/src/app/api/report/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import type { AxisScores, AxisFeedback } from '@/lib/types'
+
+export async function GET(request: NextRequest) {
+  const reportId = request.nextUrl.searchParams.get('reportId')
+
+  if (!reportId) {
+    return NextResponse.json({ error: 'reportId가 필요합니다.' }, { status: 400 })
+  }
+
+  let report: {
+    id: string
+    sessionId: string
+    totalScore: number
+    scores: unknown
+    summary: string
+    axisFeedbacks: unknown
+    createdAt: Date
+  } | null
+  try {
+    report = await prisma.report.findUnique({ where: { id: reportId } })
+  } catch (err) {
+    console.error('[report] findUnique failed', { reportId, err })
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+
+  if (!report) {
+    return NextResponse.json({ error: '리포트를 찾을 수 없습니다.' }, { status: 404 })
+  }
+
+  return NextResponse.json(
+    {
+      id: report.id,
+      sessionId: report.sessionId,
+      totalScore: report.totalScore,
+      scores: report.scores as AxisScores,
+      summary: report.summary,
+      axisFeedbacks: report.axisFeedbacks as AxisFeedback[],
+      createdAt: report.createdAt.toISOString(),
+    },
+    { status: 200 }
+  )
+}

--- a/services/seung/src/app/interview/page.tsx
+++ b/services/seung/src/app/interview/page.tsx
@@ -20,6 +20,8 @@ function InterviewContent() {
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isGeneratingReport, setIsGeneratingReport] = useState(false)
+  const [reportError, setReportError] = useState<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const submittingRef = useRef(false)
   const msgIdRef = useRef(0)
@@ -116,6 +118,29 @@ function InterviewContent() {
     }
   }
 
+  const handleReport = async () => {
+    if (!sessionId) return
+    setIsGeneratingReport(true)
+    setReportError(null)
+    try {
+      const res = await fetch('/api/report/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setReportError(data?.error ?? '리포트 생성에 실패했습니다. 다시 시도해 주세요.')
+        return
+      }
+      router.push(`/report?reportId=${data.reportId}`)
+    } catch {
+      setReportError('네트워크 오류가 발생했습니다. 다시 시도해 주세요.')
+    } finally {
+      setIsGeneratingReport(false)
+    }
+  }
+
   const handleRestart = () => {
     router.push('/resume')
   }
@@ -138,10 +163,17 @@ function InterviewContent() {
           messages={messages}
           sessionComplete={sessionComplete}
           onRestart={handleRestart}
+          onReport={handleReport}
+          isGeneratingReport={isGeneratingReport}
         />
         {submitError && (
           <p role="alert" className="text-sm text-red-600 text-center px-4">
             {submitError}
+          </p>
+        )}
+        {reportError && (
+          <p role="alert" className="text-sm text-red-600 text-center px-4">
+            {reportError}
           </p>
         )}
         <AnswerInput

--- a/services/seung/src/app/report/page.tsx
+++ b/services/seung/src/app/report/page.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useEffect, useState, Suspense } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { ReportResponse } from '@/lib/types'
+
+function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-gray-500">리포트를 불러오는 중...</p>
+    </div>
+  )
+}
+
+const AXIS_LABEL_MAP: Record<string, string> = {
+  communication: '의사소통',
+  problemSolving: '문제해결',
+  logicalThinking: '논리적 사고',
+  jobExpertise: '직무 전문성',
+  cultureFit: '조직 적합성',
+  leadership: '리더십',
+  creativity: '창의성',
+  sincerity: '성실성',
+}
+
+function ReportContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const reportId = searchParams.get('reportId')
+
+  const [report, setReport] = useState<ReportResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!reportId) {
+      router.replace('/resume')
+      return
+    }
+
+    fetch(`/api/report?reportId=${reportId}`)
+      .then((r) => {
+        if (!r.ok) {
+          router.replace('/resume')
+          return null
+        }
+        return r.json()
+      })
+      .then((data) => {
+        if (!data) return
+        setReport(data)
+      })
+      .catch(() => {
+        router.replace('/resume')
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [reportId, router])
+
+  if (loading) {
+    return <LoadingScreen />
+  }
+
+  if (!report) return null
+
+  const scoreEntries = Object.entries(report.scores ?? {}) as [string, number][]
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="border-b border-gray-200 bg-white px-6 py-4">
+        <h1 className="text-lg font-bold text-gray-900">MirAI — 역량 평가 리포트</h1>
+      </header>
+
+      <main className="mx-auto max-w-2xl px-6 py-8 space-y-8">
+        {/* 총점 */}
+        <section className="rounded-xl border border-gray-200 bg-white p-6 text-center shadow-sm">
+          <p className="text-sm text-gray-500 mb-1">종합 점수</p>
+          <p className="text-6xl font-bold text-gray-900">{report.totalScore}</p>
+          <p className="text-sm text-gray-400 mt-1">/ 100</p>
+        </section>
+
+        {/* 8축 점수 */}
+        <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-gray-900 mb-4">역량 축별 점수</h2>
+          <div className="space-y-3">
+            {scoreEntries.map(([axis, score]) => {
+              const feedback = (report.axisFeedbacks ?? []).find((f) => f.axis === axis)
+              const colorClass =
+                feedback?.type === 'strength'
+                  ? { text: 'text-blue-600', bar: 'bg-blue-500' }
+                  : feedback?.type === 'improvement'
+                    ? { text: 'text-orange-500', bar: 'bg-orange-400' }
+                    : { text: 'text-gray-600', bar: 'bg-gray-400' }
+              return (
+                <div key={axis}>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="text-gray-700 font-medium">
+                      {AXIS_LABEL_MAP[axis] ?? axis}
+                    </span>
+                    <span className={`font-semibold ${colorClass.text}`}>
+                      {score}
+                    </span>
+                  </div>
+                  <div className="w-full bg-gray-100 rounded-full h-2">
+                    <div
+                      className={`h-2 rounded-full ${colorClass.bar}`}
+                      style={{ width: `${score}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* 종합 요약 */}
+        <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-gray-900 mb-2">종합 요약</h2>
+          <p className="text-gray-700 leading-relaxed">{report.summary}</p>
+        </section>
+
+        {/* 축별 피드백 카드 */}
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-gray-900">축별 피드백</h2>
+          {(report.axisFeedbacks ?? []).map((fb) => (
+            <div
+              key={fb.axis}
+              className={`rounded-xl border p-4 ${
+                fb.type === 'strength'
+                  ? 'bg-blue-50 border-blue-200'
+                  : 'bg-orange-50 border-orange-200'
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <span className="font-semibold text-gray-900 text-sm">{fb.axisLabel}</span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    fb.type === 'strength'
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'bg-orange-100 text-orange-700'
+                  }`}
+                >
+                  {fb.type === 'strength' ? '강점' : '개선'}
+                </span>
+                <span className="ml-auto text-sm font-semibold text-gray-600">{fb.score}점</span>
+              </div>
+              <p className="text-sm text-gray-700">{fb.feedback}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* growthCurve 플레이스홀더 */}
+        <section className="rounded-xl border border-dashed border-gray-300 bg-white p-6 text-center shadow-sm">
+          <p className="text-sm text-gray-400">성장 곡선은 추후 업데이트 예정입니다.</p>
+        </section>
+
+        {/* 홈으로 */}
+        <div className="flex justify-center pb-8">
+          <button
+            onClick={() => router.push('/resume')}
+            className="rounded-lg bg-gray-900 px-6 py-2 text-sm font-medium text-white hover:bg-gray-700"
+          >
+            홈으로
+          </button>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default function ReportPage() {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <ReportContent />
+    </Suspense>
+  )
+}

--- a/services/seung/src/components/InterviewChat.tsx
+++ b/services/seung/src/components/InterviewChat.tsx
@@ -28,9 +28,17 @@ type Props = {
   messages: Message[]
   sessionComplete: boolean
   onRestart?: () => void
+  onReport?: () => void
+  isGeneratingReport?: boolean
 }
 
-export default function InterviewChat({ messages, sessionComplete, onRestart }: Props) {
+export default function InterviewChat({
+  messages,
+  sessionComplete,
+  onRestart,
+  onReport,
+  isGeneratingReport,
+}: Props) {
   return (
     <div className="space-y-4">
       {messages.map((msg) => {
@@ -63,14 +71,52 @@ export default function InterviewChat({ messages, sessionComplete, onRestart }: 
       {sessionComplete && (
         <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
           <p className="mb-4 text-lg font-semibold text-gray-900">면접이 완료되었습니다.</p>
-          {onRestart && (
-            <button
-              onClick={onRestart}
-              className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700"
-            >
-              다시 시작
-            </button>
-          )}
+          <div className="flex justify-center gap-3">
+            {onReport && (
+              <button
+                onClick={onReport}
+                disabled={isGeneratingReport}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+              >
+                {isGeneratingReport ? (
+                  <>
+                    <svg
+                      className="animate-spin h-4 w-4 mr-2 inline"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                      />
+                    </svg>
+                    리포트 생성 중...
+                  </>
+                ) : (
+                  '리포트 생성하기'
+                )}
+              </button>
+            )}
+            {onRestart && (
+              <button
+                onClick={onRestart}
+                disabled={isGeneratingReport}
+                className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
+              >
+                다시 시작
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/services/seung/src/lib/types.ts
+++ b/services/seung/src/lib/types.ts
@@ -49,6 +49,37 @@ export type InterviewSessionState = {
   sessionComplete: boolean
 }
 
+export type AxisScores = {
+  communication: number
+  problemSolving: number
+  logicalThinking: number
+  jobExpertise: number
+  cultureFit: number
+  leadership: number
+  creativity: number
+  sincerity: number
+}
+
+export type AxisFeedback = {
+  axis: string
+  axisLabel: string
+  score: number
+  type: 'strength' | 'improvement'
+  feedback: string
+}
+
+export type ReportResponse = {
+  id: string
+  sessionId: string
+  totalScore: number
+  scores: AxisScores
+  summary: string
+  axisFeedbacks: AxisFeedback[]
+  createdAt: string
+}
+
+export type StoredHistoryEntry = HistoryItem & { questionType?: string }
+
 export type UploadState = 'idle' | 'uploading' | 'processing' | 'done' | 'error'
 
 export const ERROR_MESSAGES: Record<number, string> = {

--- a/services/seung/tests/api/report-generate.test.ts
+++ b/services/seung/tests/api/report-generate.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    interviewSession: { findUnique: vi.fn() },
+    report: { findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }))
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+import { POST } from '@/app/api/report/generate/route'
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as NextRequest
+}
+
+const mockSession = {
+  id: 'session-1',
+  sessionComplete: true,
+  history: [
+    {
+      persona: 'hr',
+      personaLabel: 'HR 면접관',
+      question: '자기소개를 해주세요.',
+      answer: '저는 개발자입니다.',
+      questionType: 'main',
+    },
+  ],
+  resume: { resumeText: '자소서 내용입니다.' },
+}
+
+const mockEngineResponse = {
+  totalScore: 78.5,
+  scores: {
+    communication: 80,
+    problemSolving: 75,
+    logicalThinking: 82,
+    jobExpertise: 70,
+    cultureFit: 85,
+    leadership: 72,
+    creativity: 78,
+    sincerity: 88,
+  },
+  summary: '전반적으로 우수한 역량을 보여주었습니다.',
+  axisFeedbacks: [
+    {
+      axis: 'communication',
+      axisLabel: '의사소통',
+      score: 80,
+      type: 'strength',
+      feedback: '명확한 의사소통 능력을 보여주었습니다.',
+    },
+  ],
+}
+
+describe('POST /api/report/generate', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.ENGINE_BASE_URL = 'http://localhost:8000'
+  })
+
+  afterEach(() => {
+    process.env.ENGINE_BASE_URL = 'http://localhost:8000'
+  })
+
+  it('성공: sessionComplete=true → 엔진 호출 → report.create → { reportId } (201)', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce(mockSession)
+    mockPrisma.report.findFirst.mockResolvedValueOnce(null)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockEngineResponse,
+    })
+    mockPrisma.report.create.mockResolvedValueOnce({ id: 'report-1' })
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(201)
+
+    const body = await response.json()
+    expect(body.reportId).toBe('report-1')
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(mockPrisma.report.create).toHaveBeenCalledOnce()
+  })
+
+  it('sessionId 누락 → 400', async () => {
+    const response = await POST(makeRequest({}))
+    expect(response.status).toBe(400)
+    expect(mockPrisma.interviewSession.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('ENGINE_BASE_URL 없음 → 500', async () => {
+    delete process.env.ENGINE_BASE_URL
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(500)
+  })
+
+  it('세션 없음 → 404', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce(null)
+
+    const response = await POST(makeRequest({ sessionId: 'nonexistent' }))
+    expect(response.status).toBe(404)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('sessionComplete=false → 400 "면접이 아직 완료되지 않았습니다."', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce({
+      ...mockSession,
+      sessionComplete: false,
+    })
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toBe('면접이 아직 완료되지 않았습니다.')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('기존 Report 있음 → findFirst hit → 기존 reportId (200), mockFetch 미호출', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce(mockSession)
+    mockPrisma.report.findFirst.mockResolvedValueOnce({ id: 'existing-report-1' })
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.reportId).toBe('existing-report-1')
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mockPrisma.report.create).not.toHaveBeenCalled()
+  })
+
+  it('엔진 422 → 서비스 422', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce(mockSession)
+    mockPrisma.report.findFirst.mockResolvedValueOnce(null)
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({ detail: '답변 부족' }),
+    })
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.error).toBe('답변이 부족합니다. 더 많은 질문에 답변해 주세요.')
+  })
+
+  it('엔진 500 → 서비스 500', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce(mockSession)
+    mockPrisma.report.findFirst.mockResolvedValueOnce(null)
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: '엔진 오류' }),
+    })
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toBe('서버 오류가 발생했습니다.')
+  })
+
+  it('report.create P2002 → findUnique fallback → 기존 reportId (200)', async () => {
+    mockPrisma.interviewSession.findUnique.mockResolvedValueOnce(mockSession)
+    mockPrisma.report.findFirst.mockResolvedValueOnce(null)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockEngineResponse,
+    })
+    const p2002Error = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
+    mockPrisma.report.create.mockRejectedValueOnce(p2002Error)
+    mockPrisma.report.findUnique.mockResolvedValueOnce({ id: 'race-report-1' })
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.reportId).toBe('race-report-1')
+  })
+})

--- a/services/seung/tests/api/report-get.test.ts
+++ b/services/seung/tests/api/report-get.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    report: { findUnique: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }))
+
+import { GET } from '@/app/api/report/route'
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/report')
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v)
+  }
+  return { nextUrl: url } as unknown as NextRequest
+}
+
+const mockReport = {
+  id: 'report-1',
+  sessionId: 'session-1',
+  totalScore: 79,
+  scores: {
+    communication: 80,
+    problemSolving: 75,
+    logicalThinking: 82,
+    jobExpertise: 70,
+    cultureFit: 85,
+    leadership: 72,
+    creativity: 78,
+    sincerity: 88,
+  },
+  summary: '전반적으로 우수한 역량을 보여주었습니다.',
+  axisFeedbacks: [
+    {
+      axis: 'communication',
+      axisLabel: '의사소통',
+      score: 80,
+      type: 'strength',
+      feedback: '명확한 의사소통 능력을 보여주었습니다.',
+    },
+  ],
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+describe('GET /api/report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reportId 있음 → 200 + ReportResponse', async () => {
+    mockPrisma.report.findUnique.mockResolvedValueOnce(mockReport)
+
+    const response = await GET(makeRequest({ reportId: 'report-1' }))
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.id).toBe('report-1')
+    expect(body.sessionId).toBe('session-1')
+    expect(body.totalScore).toBe(79)
+    expect(body.summary).toBe('전반적으로 우수한 역량을 보여주었습니다.')
+    expect(body.axisFeedbacks).toHaveLength(1)
+    expect(body.createdAt).toBeDefined()
+  })
+
+  it('reportId 없음 → 400', async () => {
+    const response = await GET(makeRequest({}))
+    expect(response.status).toBe(400)
+    expect(mockPrisma.report.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('리포트 없음 → 404', async () => {
+    mockPrisma.report.findUnique.mockResolvedValueOnce(null)
+
+    const response = await GET(makeRequest({ reportId: 'nonexistent' }))
+    expect(response.status).toBe(404)
+  })
+})

--- a/services/seung/tests/components/InterviewChat.test.tsx
+++ b/services/seung/tests/components/InterviewChat.test.tsx
@@ -72,6 +72,33 @@ describe('InterviewChat', () => {
     expect(screen.getByText('저는 개발자입니다.')).toBeInTheDocument()
   })
 
+  it('onReport prop 전달 시 "리포트 생성하기" 버튼이 표시된다', () => {
+    render(
+      <InterviewChat
+        messages={[]}
+        sessionComplete={true}
+        onReport={vi.fn()}
+        isGeneratingReport={false}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '리포트 생성하기' })).toBeInTheDocument()
+  })
+
+  it('isGeneratingReport=true 시 버튼이 disabled되고 "리포트 생성 중..." 텍스트가 표시된다', () => {
+    render(
+      <InterviewChat
+        messages={[]}
+        sessionComplete={true}
+        onReport={vi.fn()}
+        isGeneratingReport={true}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: /리포트 생성 중/ })
+    expect(button).toBeDisabled()
+  })
+
   it('main 타입 질문에는 꼬리질문 배지가 없다', () => {
     const messages: Message[] = [
       {

--- a/services/seung/tests/e2e/real-report-flow.spec.ts
+++ b/services/seung/tests/e2e/real-report-flow.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test'
+import path from 'path'
+
+/**
+ * 실제 엔진 + 실제 Supabase를 사용하는 리포트 전체 플로우 E2E 테스트.
+ * 실행 전 필수:
+ *   - 엔진 서버: http://localhost:8000 실행 중
+ *   - services/seung: .env.local에 DATABASE_URL, SUPABASE_SERVICE_ROLE_KEY 설정
+ *   - PDF fixture: engine/tests/fixtures/input/sample_resume.pdf
+ */
+
+const PDF_PATH = path.join(
+  __dirname,
+  '../../../../engine/tests/fixtures/input/sample_resume.pdf'
+)
+
+const LLM_TIMEOUT = 90_000
+
+const SAMPLE_ANSWERS = [
+  '저는 팀 협업을 중시하며, 백엔드 API 설계를 주도하여 팀 생산성을 30% 향상시켰습니다. 구체적으로 REST API 표준을 수립하고 Swagger 문서화를 통해 프론트엔드팀과의 소통 비용을 줄였습니다.',
+  'Redis 캐싱 도입과 N+1 쿼리 해결을 통해 API 응답 시간을 200ms에서 80ms로 줄였습니다. 데이터 기반으로 병목 지점을 파악하고 단계적으로 개선했습니다.',
+  '문제가 발생하면 먼저 로그와 지표를 통해 근본 원인을 파악합니다. 이후 가설을 세우고 작은 단위로 검증하며 해결책을 적용합니다.',
+  '새로운 기술을 습득할 때는 공식 문서와 사이드 프로젝트를 병행합니다. 최근에는 Next.js App Router와 Prisma를 직접 적용해보며 학습했습니다.',
+  '팀원과의 명확한 커뮤니케이션을 위해 작업 진행 상황을 주기적으로 공유하고, 이슈가 생기면 빠르게 알립니다.',
+  '리더십은 강요가 아니라 팀원의 강점을 파악하고 적재적소에 역할을 분배하는 것이라고 생각합니다. 이전 프로젝트에서 팀장을 맡아 이런 방식으로 운영했습니다.',
+  '창의적인 아이디어를 제안할 때는 실현 가능성과 비용을 함께 제시합니다. 아이디어만 제안하는 것이 아니라 실행 계획까지 준비합니다.',
+  '성실함이 저의 가장 큰 강점입니다. 마감 기한을 반드시 지키며, 어려운 상황에서도 최선을 다해 완수하는 것을 원칙으로 합니다.',
+  '앞으로 풀스택 엔지니어로 성장하여 제품 전반을 이해하고 더 넓은 관점으로 기여하고 싶습니다.',
+  '이 회사에서 다양한 도메인의 문제를 경험하고, 기술적으로도 인격적으로도 성장하고 싶습니다.',
+  '저는 코드 품질을 중요시하여 코드 리뷰에 적극적으로 참여하고, 테스트 코드 작성을 습관화하고 있습니다.',
+  '협업 도구 활용에 익숙하며, Jira와 Notion을 통해 팀 전체가 동일한 목표를 바라볼 수 있도록 문서화합니다.',
+]
+
+test('전체 플로우: 자소서 업로드 → 패널 면접 → 리포트 생성', async ({ page }) => {
+  test.setTimeout(600_000) // 실제 LLM 호출 다수 포함 — 최대 10분
+
+  // 1. /resume 접속 + PDF 업로드
+  await page.goto('/')
+  await expect(page.getByText('자소서 분석')).toBeVisible()
+
+  await page.getByLabel('PDF 파일').setInputFiles(PDF_PATH)
+  await page.getByRole('button', { name: '질문 생성' }).click()
+
+  // 2. 질문 생성 완료 대기 (LLM 호출)
+  await expect(page.getByText('예상 면접 질문')).toBeVisible({ timeout: LLM_TIMEOUT })
+
+  // 3. 면접 시작
+  const startBtn = page.getByRole('button', { name: /면접 시작/ })
+  await expect(startBtn).toBeVisible({ timeout: LLM_TIMEOUT })
+  await startBtn.click()
+
+  // 4. /interview 페이지 이동 대기
+  await expect(page).toHaveURL(/\/interview\?sessionId=/, { timeout: LLM_TIMEOUT })
+  await expect(page.getByText('MirAI — 패널 면접')).toBeVisible()
+
+  // 5. 면접 완료될 때까지 답변 반복 제출
+  const textarea = page.getByPlaceholder('답변을 입력하세요...')
+  const submitBtn = page.getByRole('button', { name: '답변 제출' })
+
+  for (const answer of SAMPLE_ANSWERS) {
+    // textarea가 숨겨지면(sessionComplete) 루프 종료
+    const isHidden = !(await textarea.isVisible())
+    if (isHidden) break
+
+    await expect(textarea).toBeEnabled({ timeout: LLM_TIMEOUT })
+    await textarea.fill(answer)
+    await submitBtn.click()
+
+    // 다음 질문 수신(textarea 재활성화) 또는 면접 완료 대기
+    await page.waitForFunction(
+      () => {
+        const ta = document.querySelector('textarea[placeholder="답변을 입력하세요..."]')
+        const complete = document.body.textContent?.includes('면접이 완료되었습니다.')
+        return complete || (ta !== null && !(ta as HTMLTextAreaElement).disabled)
+      },
+      { timeout: LLM_TIMEOUT }
+    )
+  }
+
+  // 6. 면접 완료 메시지 확인
+  await expect(page.locator('text=면접이 완료되었습니다.')).toBeVisible({ timeout: LLM_TIMEOUT })
+
+  // 7. 리포트 생성하기 클릭
+  await page.getByRole('button', { name: '리포트 생성하기' }).click()
+  await expect(page.getByRole('button', { name: /리포트 생성 중/ })).toBeVisible()
+
+  // 8. /report 페이지 이동 대기 (엔진 LLM 호출 — 최대 120초)
+  await expect(page).toHaveURL(/\/report\?reportId=/, { timeout: 120_000 })
+
+  // 9. 리포트 내용 확인
+  await expect(page.locator('text=종합 점수')).toBeVisible()
+  await expect(page.locator('text=역량 축별 점수')).toBeVisible()
+  await expect(page.locator('text=종합 요약')).toBeVisible()
+  await expect(page.locator('text=축별 피드백')).toBeVisible()
+  await expect(page.locator('p.text-6xl')).toBeVisible() // 총점 숫자
+
+  // 10. 홈으로 버튼 확인
+  await expect(page.getByRole('button', { name: '홈으로' })).toBeVisible()
+})

--- a/services/seung/tests/e2e/report-flow.spec.ts
+++ b/services/seung/tests/e2e/report-flow.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test'
+
+test.setTimeout(120_000)
+
+test('면접 완료 후 "리포트 생성하기" 클릭 → /report?reportId=xxx → 총점 표시', async ({ page }) => {
+  // 면접 세션 상태 API 모킹 (세션 완료 상태)
+  await page.route('/api/interview/session*', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        currentQuestion: '자기소개를 해주세요.',
+        currentPersona: 'hr',
+        currentPersonaLabel: 'HR 면접관',
+        currentQuestionType: 'main',
+        history: [
+          {
+            persona: 'hr',
+            personaLabel: 'HR 면접관',
+            question: '자기소개를 해주세요.',
+            answer: '저는 개발자입니다.',
+            questionType: 'main',
+          },
+        ],
+        sessionComplete: true,
+      }),
+    })
+  })
+
+  // 리포트 생성 API 모킹
+  await page.route('/api/report/generate', (route) => {
+    route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ reportId: 'test-report-123' }),
+    })
+  })
+
+  // 리포트 조회 API 모킹
+  await page.route('/api/report*', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'test-report-123',
+        sessionId: 'test-session-1',
+        totalScore: 82,
+        scores: {
+          communication: 85,
+          problemSolving: 80,
+          logicalThinking: 82,
+          jobExpertise: 78,
+          cultureFit: 88,
+          leadership: 75,
+          creativity: 83,
+          sincerity: 90,
+        },
+        summary: '전반적으로 우수한 역량을 보여주었습니다.',
+        axisFeedbacks: [
+          {
+            axis: 'communication',
+            axisLabel: '의사소통',
+            score: 85,
+            type: 'strength',
+            feedback: '명확한 의사소통 능력을 보여주었습니다.',
+          },
+          {
+            axis: 'problemSolving',
+            axisLabel: '문제해결',
+            score: 80,
+            type: 'strength',
+            feedback: '체계적인 문제해결 접근법을 보여주었습니다.',
+          },
+          {
+            axis: 'logicalThinking',
+            axisLabel: '논리적 사고',
+            score: 82,
+            type: 'strength',
+            feedback: '논리적인 사고 능력이 뛰어납니다.',
+          },
+          {
+            axis: 'jobExpertise',
+            axisLabel: '직무 전문성',
+            score: 78,
+            type: 'improvement',
+            feedback: '직무 관련 심화 학습이 필요합니다.',
+          },
+          {
+            axis: 'cultureFit',
+            axisLabel: '조직 적합성',
+            score: 88,
+            type: 'strength',
+            feedback: '조직 문화에 잘 어울릴 것으로 보입니다.',
+          },
+          {
+            axis: 'leadership',
+            axisLabel: '리더십',
+            score: 75,
+            type: 'improvement',
+            feedback: '리더십 경험을 더 쌓아보세요.',
+          },
+          {
+            axis: 'creativity',
+            axisLabel: '창의성',
+            score: 83,
+            type: 'strength',
+            feedback: '창의적인 아이디어 제시가 인상적입니다.',
+          },
+          {
+            axis: 'sincerity',
+            axisLabel: '성실성',
+            score: 90,
+            type: 'strength',
+            feedback: '성실하고 책임감 있는 태도가 돋보입니다.',
+          },
+        ],
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }),
+    })
+  })
+
+  await page.goto('/interview?sessionId=test-session-1')
+  await page.waitForSelector('text=면접이 완료되었습니다.')
+
+  await page.click('button:has-text("리포트 생성하기")')
+
+  await page.waitForURL(/\/report\?reportId=test-report-123/)
+
+  await expect(page.locator('p.text-6xl')).toContainText('82')
+  await expect(page.locator('text=종합 점수')).toBeVisible()
+  await expect(page.locator('text=전반적으로 우수한 역량을 보여주었습니다.')).toBeVisible()
+})
+
+test('/report (reportId 없음) → /resume redirect', async ({ page }) => {
+  await page.goto('/report')
+  await page.waitForURL(/\/resume/)
+  expect(page.url()).toContain('/resume')
+})


### PR DESCRIPTION
## 이슈 배경

패널 면접 완료 후 사용자가 8축 역량 평가 리포트를 확인할 수 있도록 합니다. 엔진의 `/api/report/generate`가 이미 구현된 상태이며, seung Next.js 서비스에서 이를 연동하는 Phase 2 작업입니다.

## 완료 기준 (AC)

- [x] `lib/types.ts`에 `AxisScores`, `AxisFeedback`, `ReportResponse` 타입 추가
- [x] `Report` Prisma 모델 추가 + `prisma migrate dev` + Supabase RLS 마이그레이션
- [x] `POST /api/report/generate` 라우트 (완료 검증 / 중복 방지 / 엔진 호출 90s / P2002 fallback)
- [x] `GET /api/report?reportId=xxx` 라우트
- [x] `InterviewChat` 컴포넌트: `onReport` prop + 로딩 스피너 + "다시 시작" 버튼 병렬 표시
- [x] `/interview` 페이지: `handleReport` + `isGeneratingReport` + `reportError`
- [x] `/report` 페이지: Suspense 래퍼, 총점·8축 점수·요약·피드백 카드·홈으로 버튼
- [x] Vitest 단위 테스트 56/56 통과 (report-generate 9개, report-get 3개, InterviewChat 2개 추가)
- [x] Playwright E2E (모킹 2개 + 실제 엔진 연동 1개, test.setTimeout 120_000 이상)
- [x] `services/seung/.ai.md` 최신화

## 작업 내역

- `src/lib/types.ts` — `AxisScores`, `AxisFeedback`, `ReportResponse`, `StoredHistoryEntry` 타입 추가. 기존 `answer/route.ts` 내부 로컬 타입 중복 제거
- `prisma/schema.prisma` — `Report` 모델 추가 (`sessionId @unique`), `InterviewSession` 역관계 추가
- `prisma/migrations/20260316033520_add_report/` — 마이그레이션 파일, Supabase RLS 적용 완료
- `src/app/api/report/generate/route.ts` — POST 라우트. maxDuration=100, AbortSignal.timeout(90s), 멱등성(findFirst + P2002 fallback), history에서 questionType 제거 후 엔진 전달
- `src/app/api/report/route.ts` — GET 라우트. reportId 조회 후 반환, 없으면 404
- `src/components/InterviewChat.tsx` — `onReport`, `isGeneratingReport` prop 추가. 로딩 스피너·버튼 비활성화 처리
- `src/app/interview/page.tsx` — `handleReport` 핸들러, `reportError` 인라인 표시, 완료 시 `/report?reportId=xxx` 이동
- `src/app/report/page.tsx` — 신규. Suspense 래퍼, 총점/8축 점수(프로그레스 바)/종합 요약/축별 피드백 카드/growthCurve 플레이스홀더
- `tests/api/report-generate.test.ts` — 9개 케이스 (성공, 누락, 미완료, 중복, 엔진오류, P2002)
- `tests/api/report-get.test.ts` — 3개 케이스
- `tests/e2e/report-flow.spec.ts` — 2개 E2E (API 모킹)
- `tests/e2e/real-report-flow.spec.ts` — 실제 엔진·DB 전체 플로우 E2E (sample_resume.pdf, 1/1 통과, 약 1.4분 소요)

Closes #81