### PR TITLE
fix: 대시보드 헤더 '새 면접 시작'·로그아웃 버튼 겹침 수정 (#172)

### DIFF
--- a/docs/work/done/000172-dashboard-header-overlap/00_issue.md
+++ b/docs/work/done/000172-dashboard-header-overlap/00_issue.md
@@ -1,0 +1,34 @@
+# [seung] 대시보드 헤더 '새 면접 시작' 버튼과 로그아웃 버튼 겹침 수정
+
+## 사용자 관점 목표
+대시보드에서 '새 면접 시작' 버튼과 로그아웃 버튼이 겹치지 않아야 한다.
+
+## 배경
+- `layout.tsx`: 로그아웃 버튼이 `fixed top-3 right-4 z-50`으로 화면 우상단에 고정됨
+- `dashboard/page.tsx`: 헤더가 `justify-between`으로 '새 면접 시작' 버튼을 오른쪽 끝에 배치함
+- 두 버튼이 같은 위치(우상단)에 겹쳐 표시됨
+
+## 완료 기준
+- [x] 대시보드 헤더에서 '새 면접 시작' 버튼과 로그아웃 버튼이 겹치지 않음
+- [x] 로그아웃 버튼이 항상 클릭 가능한 상태로 노출됨
+
+## 구현 힌트
+`dashboard/page.tsx` 헤더에 오른쪽 패딩 추가:
+```diff
+- <header className="border-b border-gray-200 bg-white px-6 py-4 flex items-center justify-between">
++ <header className="border-b border-gray-200 bg-white pl-6 pr-28 py-4 flex items-center justify-between">
+```
+
+
+---
+
+## 작업 내역
+
+### 2026-03-20 — 헤더 우측 패딩 조정으로 버튼 겹침 해소
+
+**변경 파일:**
+- `services/seung/src/app/dashboard/page.tsx` — 헤더 `px-6` → `pl-6 pr-28`
+  - `layout.tsx`의 로그아웃 버튼이 `fixed top-3 right-4`(≈76px)를 차지하므로, 헤더 우측 패딩을 `pr-28`(112px)으로 확장해 겹침 방지
+  - `layout.tsx`는 수정 불필요 — 로그아웃 버튼 위치는 그대로 유지
+- `services/seung/src/app/dashboard/.ai.md` — 헤더 패딩 관련 내용 추가
+

--- a/docs/work/done/000172-dashboard-header-overlap/01_plan.md
+++ b/docs/work/done/000172-dashboard-header-overlap/01_plan.md
@@ -1,0 +1,46 @@
+# [#172] [seung] 대시보드 헤더 '새 면접 시작' 버튼과 로그아웃 버튼 겹침 수정 — 구현 계획
+
+> 작성: 2026-03-20
+
+---
+
+## 완료 기준
+
+- [x] 대시보드 헤더에서 '새 면접 시작' 버튼과 로그아웃 버튼이 겹치지 않음
+- [x] 로그아웃 버튼이 항상 클릭 가능한 상태로 노출됨
+
+---
+
+## 구현 계획
+
+### 원인 분석
+
+| 파일 | 위치 | 현재 동작 |
+|------|------|-----------|
+| `services/seung/src/app/layout.tsx:45` | `fixed top-3 right-4 z-50` | 로그아웃 버튼이 화면 우상단에 고정됨 |
+| `services/seung/src/app/dashboard/page.tsx:126` | `px-6 py-4 ... justify-between` | '새 면접 시작' 버튼이 헤더 우측 끝에 배치됨 |
+
+두 버튼이 같은 위치(우상단)에 겹쳐 표시되어 로그아웃 버튼이 가려짐.
+
+### 수정 방법
+
+**Step 1 — `dashboard/page.tsx` 헤더 우측 패딩 추가** (1줄 수정)
+
+```diff
+- <header className="border-b border-gray-200 bg-white px-6 py-4 flex items-center justify-between">
++ <header className="border-b border-gray-200 bg-white pl-6 pr-28 py-4 flex items-center justify-between">
+```
+
+`px-6`(좌우 동일 패딩) → `pl-6 pr-28`(우측 패딩을 7rem으로 확장)
+
+로그아웃 버튼의 폭(~60px) + `right-4`(16px) = 약 76px이므로 `pr-28`(112px)이면 충분히 겹치지 않음.
+
+### 변경 파일
+
+- `services/seung/src/app/dashboard/page.tsx` — 헤더 className 1줄 수정
+
+### 주의사항
+
+- `layout.tsx`는 수정 불필요 (로그아웃 버튼 위치는 그대로 유지)
+- 모바일 화면에서도 `pr-28`이 충분한지 확인 (로그아웃 버튼 텍스트 길이 고정이므로 OK)
+- 다른 페이지(`/resume`, `/login` 등)는 헤더 구조가 다르므로 영향 없음

--- a/services/seung/src/app/dashboard/.ai.md
+++ b/services/seung/src/app/dashboard/.ai.md
@@ -21,7 +21,7 @@ dashboard/
 - `GET /api/dashboard` 호출 → `DashboardResumeItem[]` 수신
 - 자소서별 카드 렌더링: PDF 파일명, 업로드 날짜, 면접 세션 수, 리포트 링크, 서류 진단 링크
 - 빈 상태(empty state): 자소서 없을 때 "새 면접 시작" CTA
-- 헤더 "새 면접 시작" 버튼 → `/resume` (새 업로드)
+- 헤더 "새 면접 시작" 버튼 → `/resume` (새 업로드) — 로그아웃 버튼과 겹침 방지를 위해 헤더 우측 패딩 `pr-28` 적용 (#172)
 - 카드 "이 자소서로 다시 면접하기" 버튼 → `/resume?resumeId={id}` (업로드 스킵, 바로 모드 선택)
 - 카드 "삭제" 버튼 → `DELETE /api/resume/[id]` → Report + Session + Resume cascade 삭제
 

--- a/services/seung/src/app/dashboard/page.tsx
+++ b/services/seung/src/app/dashboard/page.tsx
@@ -123,7 +123,7 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="border-b border-gray-200 bg-white px-6 py-4 flex items-center justify-between">
+      <header className="border-b border-gray-200 bg-white pl-6 pr-28 py-4 flex items-center justify-between">
         <h1 className="text-lg font-bold text-gray-900">MirAI — 내 면접 기록</h1>
         <button
           onClick={handleStart}


### PR DESCRIPTION
## 이슈 배경

`layout.tsx`의 로그아웃 버튼이 `fixed top-3 right-4 z-50`으로 우상단에 고정되어 있고, `dashboard/page.tsx` 헤더가 `justify-between`으로 '새 면접 시작' 버튼을 우측 끝에 배치해 두 버튼이 겹쳐 표시되는 문제가 있었습니다. 로그아웃 버튼이 가려져 클릭이 불가능한 상태였습니다.

## 완료 기준 (AC)

- [x] 대시보드 헤더에서 '새 면접 시작' 버튼과 로그아웃 버튼이 겹치지 않음
- [x] 로그아웃 버튼이 항상 클릭 가능한 상태로 노출됨

## 작업 내역

- `services/seung/src/app/dashboard/page.tsx` — 헤더 `px-6` → `pl-6 pr-28`
  - 로그아웃 버튼이 `fixed top-3 right-4`(≈76px)를 차지하므로, 헤더 우측 패딩을 `pr-28`(112px)으로 확장해 겹침 방지
  - `layout.tsx`는 수정 불필요 — 로그아웃 버튼 위치는 그대로 유지
- `services/seung/src/app/dashboard/.ai.md` — 헤더 패딩 관련 내용 추가

Closes #172