### PR TITLE
feat: [seung] UX 흐름 개선 — 리다이렉트·진행률·이어하기·이탈경고·복수리포트 (#171)

### DIFF
--- a/docs/work/done/000171-ux-flow-fix/00_issue.md
+++ b/docs/work/done/000171-ux-flow-fix/00_issue.md
@@ -1,0 +1,75 @@
+# feat: [seung] UX 흐름 개선 — 면접 진행성·리다이렉트·접근성 수정
+
+## 사용자 관점 목표
+면접 진행 상황을 파악할 수 있고, 오류 상황에서 올바른 페이지로 안내받으며,
+원하는 시점에 리포트를 생성하고 이전 기록에 자유롭게 접근할 수 있다.
+
+## 배경
+작업 범위: services/seung (Next.js)
+
+핵심 기능 구현 후 실사용 시 발견된 UX 흐름 문제 8가지:
+- 면접 중 이탈 수단 없음 (헤더 나가기 버튼 부재)
+- 10개 답변 완료(sessionComplete) 전 리포트 생성 불가 — 엔진은 5개 이상이면 허용
+- 면접 진행률 미표시 (몇 번째 질문인지 알 수 없음)
+- 오류·파라미터 누락 시 /resume 리다이렉트 — interview·report·diagnosis 3개 파일
+- report 페이지 growthCurve 플레이스홀더 노출
+- 대시보드에서 진행 중 세션 복귀 불가 ("이어하기" 없음)
+- 답변 입력 중 이탈 경고 없음 (beforeunload 미등록)
+- 대시보드에서 리포트 1개만 접근 가능 (세션별 리포트 목록 미노출)
+
+## 완료 기준
+- [x] 면접 헤더에 "나가기" 버튼 추가 → /dashboard 이동
+- [x] 리포트 생성 조건 완화: report/generate/route.ts sessionComplete 게이트 제거, InterviewChat 리포트 버튼을 답변 5개 이상 시 노출 (엔진이 history < 5 시 422)
+- [x] 면접 진행률 표시 — 답변 완료 수 / 총 질문 수 (세션 API 응답에 totalQuestions 추가)
+- [x] 에러·파라미터 누락 리다이렉트 수정: interview/page.tsx · report/page.tsx · diagnosis/page.tsx /resume → /dashboard
+- [x] report 페이지 growthCurve 플레이스홀더 숨김
+- [x] 대시보드 진행 중 세션 "이어하기": /api/dashboard에서 sessionComplete=false 세션 포함, ResumeCard에 이어하기 버튼 추가
+- [x] AnswerInput beforeunload 이탈 경고 (textarea 내용 있을 때만)
+- [x] 대시보드 리포트 복수 접근: /api/dashboard 응답에 reports 배열 추가, ResumeCard에 세션별 리포트 링크 목록 표시
+
+## 구현 플랜
+1. 단순 수정 — interview·report·diagnosis 리다이렉트, growthCurve 숨김, 헤더 나가기 버튼
+2. 리포트 조건 완화 — report/generate/route.ts sessionComplete 제거 + InterviewChat 버튼 노출 조건 변경 + report-generate.test.ts 업데이트
+3. 진행률 표시 — /api/interview/session 응답에 totalQuestions 추가 + interview/page.tsx에서 추적 + InterviewChat props 확장
+4. beforeunload — AnswerInput useEffect로 window 이벤트 등록
+5. 이어하기 + 복수 리포트 — /api/dashboard 스키마 확장 + DashboardResumeItem 타입 변경 + ResumeCard UI
+
+## 개발 체크리스트
+- [x] 테스트 코드 포함
+- [x] 해당 디렉토리 .ai.md 최신화
+- [x] 불변식 위반 없음
+
+
+---
+
+## 작업 내역
+
+### 변경 파일 요약
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/app/interview/page.tsx` | 리다이렉트 3곳 `/resume`→`/dashboard`, 헤더 나가기 버튼 추가, `totalQuestions` state 추가 및 InterviewChat prop 전달 |
+| `src/app/report/page.tsx` | 리다이렉트 3곳 수정, growthCurve 플레이스홀더 섹션 삭제 |
+| `src/app/diagnosis/page.tsx` | 리다이렉트 3곳 수정 |
+| `src/app/api/report/generate/route.ts` | `sessionComplete` 게이트 블록 제거 |
+| `src/app/api/interview/session/route.ts` | `questionsQueue` select 추가, `totalQuestions` 계산·반환 |
+| `src/app/api/dashboard/route.ts` | 타입 가드 filter, `reports[]` 반환, `inProgressSessionId` 반환 (`s.report === null` 조건 제거 — 코드리뷰 반영) |
+| `src/components/InterviewChat.tsx` | `totalQuestions` prop, 진행률 표시, `answerCount >= 5` 리포트 버튼 |
+| `src/components/AnswerInput.tsx` | controlled textarea 전환, `beforeunload` useEffect 등록 |
+| `src/lib/types.ts` | `DashboardResumeItem`에 `inProgressSessionId`, `reports[]` 추가 |
+| `src/app/dashboard/page.tsx` | 이어하기 버튼, `reports.map()` 기반 리포트 목록 |
+
+### 핵심 결정 사항
+
+1. **`answerCount` props 제거** — 초안에서는 API 응답에 `answerCount`를 포함하려 했으나, `InterviewChat`이 이미 `messages` 배열을 갖고 있으므로 내부에서 `messages.filter(m => m.type === 'answer').length`로 계산. 외부에서 받을 필요 없음.
+
+2. **Prisma 타입 가드** — `filter((s) => s.report !== null)` 후에도 TypeScript가 `s.report`를 nullable로 추론하는 문제를 `(s): s is typeof s & { report: NonNullable<typeof s.report> }` 타입 가드로 해결. `!` non-null assertion 미사용.
+
+3. **`inProgressSessionId` 조건 수정 (코드리뷰 반영)** — 초안의 `!s.sessionComplete && s.report === null`에서 `s.report === null`을 제거. 조기 리포트 생성이 가능해진 이번 이슈에서, 리포트가 있지만 `sessionComplete=false`인 세션도 이어하기 대상이어야 함.
+
+### 테스트
+
+- Vitest 138개 전체 통과 (15파일)
+- 신규: `tests/components/AnswerInput.test.tsx` (8개)
+- 추가: `tests/api/dashboard.test.ts` — `sessionComplete=false` + 리포트 있는 케이스 (코드리뷰 반영)
+

--- a/docs/work/done/000171-ux-flow-fix/01_plan.md
+++ b/docs/work/done/000171-ux-flow-fix/01_plan.md
@@ -1,0 +1,354 @@
+# [#171] feat: [seung] UX 흐름 개선 — 면접 진행성·리다이렉트·접근성 수정 — 구현 계획
+
+> 작성: 2026-03-20
+
+---
+
+## 완료 기준
+
+- [x] 면접 헤더에 "나가기" 버튼 추가 → /dashboard 이동
+- [x] 리포트 생성 조건 완화: report/generate/route.ts sessionComplete 게이트 제거, InterviewChat 리포트 버튼을 답변 5개 이상 시 노출 (엔진이 history < 5 시 422)
+- [x] 면접 진행률 표시 — 답변 완료 수 / 총 질문 수 (세션 API 응답에 totalQuestions 추가)
+- [x] 에러·파라미터 누락 리다이렉트 수정: interview/page.tsx · report/page.tsx · diagnosis/page.tsx /resume → /dashboard
+- [x] report 페이지 growthCurve 플레이스홀더 숨김
+- [x] 대시보드 진행 중 세션 "이어하기": /api/dashboard에서 sessionComplete=false 세션 포함, ResumeCard에 이어하기 버튼 추가
+- [x] AnswerInput beforeunload 이탈 경고 (textarea 내용 있을 때만)
+- [x] 대시보드 리포트 복수 접근: /api/dashboard 응답에 reports 배열 추가, ResumeCard에 세션별 리포트 링크 목록 표시
+- [x] 테스트 코드 포함
+- [x] 해당 디렉토리 .ai.md 최신화
+- [x] 불변식 위반 없음
+
+---
+
+## 구현 계획
+
+### 전체 Step 요약
+
+| Step | 내용 | 변경 파일 |
+|------|------|-----------|
+| 1 | 단순 수정 — 리다이렉트·growthCurve·헤더 나가기 버튼 | `interview/page.tsx`, `report/page.tsx`, `diagnosis/page.tsx` |
+| 2 | 리포트 조건 완화 — sessionComplete 게이트 제거, 5개 이상 버튼 노출 | `api/report/generate/route.ts`, `InterviewChat.tsx`, `report-generate.test.ts`, `InterviewChat.test.tsx` |
+| 3 | 면접 진행률 표시 — totalQuestions (answerCount는 InterviewChat 내부 계산) | `api/interview/session/route.ts`, `interview/page.tsx`, `InterviewChat.tsx`, `interview-session.test.ts` |
+| 4 | beforeunload 이탈 경고 | `AnswerInput.tsx`, `AnswerInput.test.tsx` (신규) |
+| 5 | 대시보드 이어하기 + 복수 리포트 | `types.ts`, `api/dashboard/route.ts`, `dashboard/page.tsx`, `dashboard.test.ts` |
+
+---
+
+### Step 1 — 단순 수정 (리다이렉트 · growthCurve · 헤더 나가기)
+
+변경 파일이 서로 독립적이어서 한꺼번에 처리한다.
+
+#### 1-1. 리다이렉트 `/resume` → `/dashboard` 수정
+
+| 파일 | 위치 | 변경 내용 |
+|------|------|-----------|
+| `services/seung/src/app/interview/page.tsx` | L37, L49, L89 | `'/resume'` → `'/dashboard'` |
+| `services/seung/src/app/report/page.tsx` | L36, L43, L53 | `'/resume'` → `'/dashboard'` |
+| `services/seung/src/app/diagnosis/page.tsx` | L33, L40, L50 | `'/resume'` → `'/dashboard'` |
+
+#### 1-2. report 페이지 growthCurve 플레이스홀더 숨김
+
+- `services/seung/src/app/report/page.tsx` L152-155 — 해당 `<section>` 블록 삭제
+
+#### 1-3. 면접 헤더 "나가기" 버튼 추가
+
+- `services/seung/src/app/interview/page.tsx` — `<header>` 태그 내부에 나가기 버튼 추가
+  ```tsx
+  // 변경 전
+  <header className="...">
+    <h1 ...>MirAI — 패널 면접</h1>
+  </header>
+
+  // 변경 후
+  <header className="... flex items-center justify-between">
+    <h1 ...>MirAI — 패널 면접</h1>
+    <button onClick={() => router.push('/dashboard')} className="...">
+      나가기
+    </button>
+  </header>
+  ```
+
+---
+
+### Step 2 — 리포트 생성 조건 완화
+
+#### 2-1. `api/report/generate/route.ts` — sessionComplete 게이트 제거
+
+- L60-63의 `if (!session.sessionComplete)` 블록 삭제
+- 엔진이 history < 5이면 422를 반환하므로 서비스 측 게이트 불필요
+
+#### 2-2. `InterviewChat.tsx` — 리포트 버튼 노출 조건 변경
+
+현재: `sessionComplete` 블록 안에서만 리포트 버튼 표시
+변경: `messages`에서 answer 개수를 내부 계산 → **answerCount >= 5이면 항상 리포트 버튼 표시**
+
+```tsx
+// InterviewChat 내부 계산 (props 추가 불필요)
+const answerCount = messages.filter((m) => m.type === 'answer').length
+
+// sessionComplete 블록과 별도로, 진행 중에도 버튼 노출
+{!sessionComplete && answerCount >= 5 && onReport && (
+  <div className="flex justify-end">
+    <button onClick={onReport} disabled={isGeneratingReport} className="...">
+      {isGeneratingReport ? '리포트 생성 중...' : '리포트 생성하기'}
+    </button>
+  </div>
+)}
+```
+
+#### 2-3. `tests/api/report-generate.test.ts` 업데이트
+
+- `sessionComplete=false → 400` 케이스 → 삭제 (게이트 제거됨)
+- sessionComplete=false 세션에서도 엔진 호출이 일어나는 성공 케이스 추가
+
+#### 2-4. `tests/components/InterviewChat.test.tsx` 업데이트
+
+- answerCount >= 5 + !sessionComplete 조건에서 리포트 버튼 노출 케이스 추가
+- answerCount < 5일 때 버튼 미노출 케이스 추가
+
+---
+
+### Step 3 — 면접 진행률 표시
+
+#### 3-1. `api/interview/session/route.ts` — totalQuestions 추가
+
+`questionsQueue`를 select에 추가하고 totalQuestions를 계산:
+
+```ts
+// session 타입에 questionsQueue 추가
+let session: {
+  ...,
+  questionsQueue: unknown,  // 추가
+} | null
+
+// select 추가
+select: {
+  ...,
+  questionsQueue: true,
+}
+
+// 응답 계산 (answerCount는 API 응답에 포함하지 않음 — InterviewChat이 messages에서 계산)
+const queue = Array.isArray(session.questionsQueue) ? session.questionsQueue : []
+const historyLen = Array.isArray(session.history) ? (session.history as unknown[]).length : 0
+const totalQuestions = historyLen + queue.length + (session.sessionComplete ? 0 : 1)
+
+return NextResponse.json({
+  ...,
+  totalQuestions,
+})
+```
+
+#### 3-2. `interview/page.tsx` — totalQuestions state만 관리
+
+```tsx
+const [totalQuestions, setTotalQuestions] = useState(0)
+
+// session fetch then 콜백에서
+setTotalQuestions(data.totalQuestions ?? 0)
+
+// answerCount state는 추가하지 않음 — InterviewChat이 messages에서 직접 계산
+```
+
+#### 3-3. `InterviewChat.tsx` — totalQuestions prop 추가, answerCount 내부 계산
+
+```tsx
+type Props = {
+  ...,
+  totalQuestions?: number   // API에서 받은 총 질문 수
+  // answerCount는 props 아님 — messages에서 내부 계산
+}
+
+// 컴포넌트 내부
+const answerCount = messages.filter((m) => m.type === 'answer').length
+
+// 메시지 목록 상단에 진행률 표시
+{(totalQuestions ?? 0) > 0 && (
+  <p className="text-sm text-gray-400 text-right">
+    {answerCount} / {totalQuestions} 답변 완료
+  </p>
+)}
+```
+
+#### 3-4. `tests/api/interview-session.test.ts` 업데이트
+
+- mock 세션 데이터에 `questionsQueue: []` 추가 (select에 포함되므로 필수)
+- 성공 케이스에 `totalQuestions` 응답 포함 검증 추가 (`answerCount`는 검증 불필요)
+
+---
+
+### Step 4 — AnswerInput beforeunload 이탈 경고
+
+`services/seung/src/components/AnswerInput.tsx` 수정:
+
+- textarea를 **controlled input**으로 전환 (value state 추가)
+- `useEffect`로 `window.beforeunload` 이벤트 등록 — value가 비어있지 않을 때만 경고
+- 기존 uncontrolled 방식의 `e.currentTarget.reset()` 및 DOM 기반 char-counter 제거 → `value.length`로 통합
+
+```tsx
+import { useState, useEffect } from 'react'
+
+export default function AnswerInput({ onSubmit, disabled = false, hidden = false }: Props) {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (value.trim()) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [value])
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const answer = value.trim()
+    if (!answer) return
+    onSubmit(answer)
+    setValue('')  // reset 대신 state 초기화
+  }
+
+  if (hidden) return null
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        name="answer"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        maxLength={MAX_LENGTH}
+        disabled={disabled}
+        placeholder="답변을 입력하세요..."
+        className="..."
+        rows={4}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-400">
+          {value.length} / {MAX_LENGTH}  {/* DOM 조작 제거, value.length로 대체 */}
+        </span>
+        <button type="submit" disabled={disabled} className="...">
+          {disabled ? '처리 중...' : '답변 제출'}
+        </button>
+      </div>
+    </form>
+  )
+}
+```
+
+#### 4-1. `tests/components/AnswerInput.test.tsx` 신규 추가
+
+현재 테스트 파일 없음 → 신규 생성:
+- textarea에 내용 있을 때 `beforeunload` 이벤트 핸들러 등록 확인
+- textarea가 비어있을 때 `beforeunload` 경고 미발생 확인
+- 제출 후 value가 빈 문자열로 초기화되는지 확인
+- `hidden=true`일 때 컴포넌트가 렌더링되지 않는지 확인
+
+---
+
+### Step 5 — 대시보드 이어하기 + 복수 리포트
+
+#### 5-1. `types.ts` — DashboardResumeItem 확장
+
+```ts
+export type DashboardResumeItem = {
+  id: string
+  createdAt: string
+  fileName: string
+  sessionCount: number
+  hasReport: boolean           // 하위 호환 유지
+  reportId: string | null      // 하위 호환 유지 (가장 오래된 리포트 id)
+  hasDiagnosis: boolean
+  inProgressSessionId: string | null   // NEW: 진행 중 세션 id
+  reports: { id: string; sessionId: string; createdAt: string }[]  // NEW: 전체 리포트 목록
+}
+```
+
+#### 5-2. `api/dashboard/route.ts` — 스키마 확장
+
+```ts
+// sessions include는 기존 유지 (include: { report: true } — 전체 필드 포함되므로 updatedAt 사용 가능)
+
+// result.map 수정
+// TypeScript: filter 후에도 s.report가 null로 추론되는 문제 → 타입 가드로 해결
+const sessionsWithReport = resume.sessions.filter(
+  (s): s is typeof s & { report: NonNullable<typeof s.report> } => s.report !== null
+)
+const allReports = sessionsWithReport.map((s) => ({
+  id: s.report.id,
+  sessionId: s.id,
+  createdAt: s.report.createdAt.toISOString(),
+}))
+
+const inProgressSession = resume.sessions
+  .filter((s) => !s.sessionComplete)
+  .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]
+
+return {
+  ...,
+  inProgressSessionId: inProgressSession?.id ?? null,
+  reports: allReports,
+}
+```
+
+> **주의**: `s.report!` non-null assertion 대신 타입 가드 filter를 사용해 TypeScript 안전성 확보.
+> `updatedAt` 정렬을 위해 sessions include에 `select` 없이 전체 필드를 include (schema.prisma에 `updatedAt` 확인 완료).
+
+#### 5-3. `dashboard/page.tsx` (ResumeCard) — UI 업데이트
+
+```tsx
+// 이어하기 버튼
+{item.inProgressSessionId && (
+  <button
+    onClick={() => router.push(`/interview?sessionId=${item.inProgressSessionId}`)}
+    className="rounded-md bg-green-50 px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100"
+  >
+    이어하기
+  </button>
+)}
+
+// 리포트 목록 (reports 배열 사용, 기존 단일 reportId 대체)
+{item.reports.map((r, i) => (
+  <button
+    key={r.id}
+    onClick={() => router.push(`/report?reportId=${r.id}`)}
+    className="rounded-md bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
+  >
+    역량 리포트 {item.reports.length > 1 ? `#${i + 1}` : ''}
+  </button>
+))}
+```
+
+기존 `{item.hasReport && item.reportId && ...}` 블록은 제거 (reports 배열로 대체).
+
+#### 5-4. `tests/api/dashboard.test.ts` 업데이트
+
+- 기존 mock에 `sessionComplete`, `updatedAt` 추가
+- `inProgressSessionId`, `reports` 필드 검증 케이스 추가
+- 진행 중 세션이 있는 resume 케이스 추가
+
+---
+
+### 작업 순서 요약
+
+| 순서 | 대상 | 의존성 |
+|------|------|--------|
+| 1 | Step 1 (리다이렉트·growthCurve·헤더) | 없음 |
+| 2 | Step 2 (리포트 조건 완화) | 없음 |
+| 3 | Step 3 (진행률) | 없음 (Step 2와 병렬 가능) |
+| 4 | Step 4 (beforeunload) | 없음 |
+| 5 | Step 5 (이어하기·복수 리포트) | 없음 |
+| 6 | 테스트 전체 실행 확인 | 1~5 완료 후 |
+| 7 | .ai.md 최신화 | 6 완료 후 |
+
+---
+
+### 주의사항
+
+- `InterviewSession.questionsQueue` (Json)은 배열 타입임을 가정 — `Array.isArray` 방어 처리 필수
+- `interview-session.test.ts` mock에 `questionsQueue: []` 추가 필요 — select에 포함되므로 없으면 undefined 오류
+- `dashboard/route.ts`에서 `s.report!` non-null assertion 금지 — 타입 가드 filter로 대체
+- `dashboard.test.ts` mock 데이터에 `sessionComplete`, `updatedAt`, `report.createdAt` 필드 추가 필요
+- `AnswerInput` controlled 전환 시 기존 `e.currentTarget.reset()` 및 DOM 기반 char-counter 완전 제거 — value state로 통합
+- `answerCount`는 API 응답 및 props에 포함하지 않음 — `InterviewChat` 내부에서 messages 기반으로 계산
+- 기존 `hasReport`, `reportId` 필드는 types.ts에 유지하되, ResumeCard UI는 `reports` 배열로 대체

--- a/docs/work/done/000171-ux-flow-fix/02_test.md
+++ b/docs/work/done/000171-ux-flow-fix/02_test.md
@@ -1,0 +1,84 @@
+# [#171] feat: [seung] UX 흐름 개선 — 테스트 결과
+
+> 작성: 2026-03-20
+
+---
+
+## 최종 테스트 결과
+
+### Vitest 단위 테스트
+
+```
+Test Files  15 passed (15)
+Tests       138 passed (138)
+Duration    4.57s
+```
+
+**파일별 결과:**
+
+| 파일 | 테스트 수 | 결과 | 비고 |
+|------|-----------|------|------|
+| `tests/api/report-generate.test.ts` | 11 | ✅ 전체 통과 | `sessionComplete=false → 400` 삭제, `sessionComplete=false` 성공 케이스 추가 |
+| `tests/api/interview-session.test.ts` | 6 | ✅ 전체 통과 | mock에 `questionsQueue` 추가, `totalQuestions` 응답 검증 추가 |
+| `tests/api/dashboard.test.ts` | 5 | ✅ 전체 통과 | mock에 `sessionComplete`·`updatedAt`·`report.createdAt` 추가, `inProgressSessionId`·`reports` 검증, `sessionComplete=false`+리포트 있는 케이스 추가 |
+| `tests/components/InterviewChat.test.tsx` | 15 | ✅ 전체 통과 | +4 신규 (진행률 표시, answerCount >= 5 리포트 버튼) |
+| `tests/components/AnswerInput.test.tsx` | 8 | ✅ 전체 통과 | 신규 파일 — beforeunload, controlled, 제출 후 초기화 |
+| `tests/api/questions.test.ts` | 19 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/interview-start.test.ts` | 8 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/interview-answer.test.ts` | 12 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/report-get.test.ts` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/practice-feedback.test.ts` | 12 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/resume-feedback.test.ts` | 13 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/resume-diagnosis.test.ts` | 7 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/resume-delete.test.ts` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/components/QuestionList.test.tsx` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/components/UploadForm.test.tsx` | 7 | ✅ 전체 통과 | 변경 없음 |
+
+---
+
+## 상태 범례
+
+| 아이콘 | 의미 |
+|--------|------|
+| ⬜ | 미구현 |
+| 🔴 | RED — 테스트 작성 완료, 실패 확인 |
+| 🟢 | GREEN — 구현 완료, 테스트 통과 |
+| ✅ | DONE — 리팩토링 완료 |
+| ❌ | FAIL — 테스트 실패 (수정 필요) |
+
+---
+
+## 변경 파일 및 수정 내용
+
+### 수정 파일
+
+| 파일 | 변경 | 결과 |
+|------|------|------|
+| `src/app/interview/page.tsx` | `/resume` → `/dashboard` 리다이렉트 3곳 수정, 헤더 "나가기" 버튼 추가, `totalQuestions` state 추가 및 InterviewChat에 prop 전달 | ✅ |
+| `src/app/report/page.tsx` | `/resume` → `/dashboard` 리다이렉트 3곳 수정, growthCurve 플레이스홀더 섹션 삭제 | ✅ |
+| `src/app/diagnosis/page.tsx` | `/resume` → `/dashboard` 리다이렉트 3곳 수정 | ✅ |
+| `src/app/api/report/generate/route.ts` | `sessionComplete` 게이트 블록 제거 (엔진이 history < 5 시 422 반환) | ✅ |
+| `src/app/api/interview/session/route.ts` | `questionsQueue` select 추가, `totalQuestions` 계산·응답 추가 | ✅ |
+| `src/app/api/dashboard/route.ts` | `sessionsWithReport` 타입 가드 filter, `reports` 배열 반환, `inProgressSessionId` 반환 (`s.report === null` 조건 제거 — 조기 리포트 생성 세션도 이어하기 표시) | ✅ |
+| `src/components/InterviewChat.tsx` | `totalQuestions` prop 추가, 진행률 표시, `answerCount >= 5` 시 리포트 버튼 노출 | ✅ |
+| `src/components/AnswerInput.tsx` | controlled textarea 전환, `beforeunload` useEffect 등록, char-counter DOM 조작 제거 | ✅ |
+| `src/lib/types.ts` | `DashboardResumeItem`에 `inProgressSessionId`, `reports[]` 필드 추가 | ✅ |
+| `src/app/dashboard/page.tsx` | ResumeCard에 "이어하기" 버튼 추가, 리포트 목록 UI를 `reports` 배열 기반으로 교체 | ✅ |
+
+### 신규 파일
+
+| 파일 | 내용 |
+|------|------|
+| `tests/components/AnswerInput.test.tsx` | AnswerInput 단위 테스트 (8개) — beforeunload, controlled, 제출·초기화 |
+
+---
+
+## TDD 사이클
+
+### RED → GREEN
+
+모든 변경사항을 구현 후 테스트를 일괄 실행:
+
+- 전체 테스트 → **138/138 통과**, 15 파일 전부 이상 없음
+- 회귀 없음 (기존 125개 모두 통과, 신규 13개 추가)
+- 코드 리뷰 피드백 반영: `inProgressSessionId` 조건에서 `s.report === null` 제거, 커버리지 케이스 1개 추가

--- a/services/seung/.ai.md
+++ b/services/seung/.ai.md
@@ -24,19 +24,19 @@ seung/
 │   │   │   └── callback/
 │   │   │       └── route.ts                   ← OAuth 콜백 (exchangeCodeForSession)
 │   │   ├── dashboard/
-│   │   │   └── page.tsx                       ← 내 면접 기록 대시보드 (자소서 카드, 삭제, 재사용)
+│   │   │   └── page.tsx                       ← 내 면접 기록 대시보드 (자소서 카드, 삭제, 재사용, 이어하기 버튼, 복수 리포트 목록)
 │   │   ├── resume/
 │   │   │   └── page.tsx                       ← 자소서 업로드 + 면접 시작 버튼 + 서류 진단 섹션 (?resumeId= 재사용 플로우 지원)
 │   │   ├── diagnosis/
 │   │   │   └── page.tsx                       ← 서류 강점·약점 진단 결과 (5개 항목 점수·강점·약점·개선 방향)
 │   │   ├── interview/
-│   │   │   └── page.tsx                       ← 패널 면접 채팅 UI (세션 기반) + 리포트 생성 버튼 + 다시하기(/dashboard)
+│   │   │   └── page.tsx                       ← 패널 면접 채팅 UI (세션 기반) + 나가기 버튼(/dashboard) + 진행률 표시 + 리포트 생성 버튼 + 다시하기(/dashboard)
 │   │   ├── report/
 │   │   │   └── page.tsx                       ← 역량 평가 리포트 (총점/8축/피드백)
 │   │   ├── layout.tsx                         ← async Server Component — getUser() + 로그아웃 Server Action
 │   │   └── api/
 │   │       ├── dashboard/
-│   │       │   └── route.ts                   ← GET /api/dashboard — userId 기준 Resume 목록 + 통계
+│   │       │   └── route.ts                   ← GET /api/dashboard — userId 기준 Resume 목록 + 통계 + inProgressSessionId + reports[]
 │   │       ├── resume/
 │   │       │   ├── questions/
 │   │       │   │   └── route.ts               ← engine /parse → Promise.all([DB 저장, engine /questions]) + resumeId 반환
@@ -59,12 +59,12 @@ seung/
 │   │           ├── answer/
 │   │           │   └── route.ts               ← 답변 처리 + 꼬리질문/다음 질문 (엔진 호출 → DB 업데이트)
 │   │           └── session/
-│   │               └── route.ts               ← 세션 상태 조회 (GET)
+│   │               └── route.ts               ← 세션 상태 조회 (GET) + totalQuestions 반환
 │   ├── components/
 │   │   ├── UploadForm.tsx                     ← PDF 업로드 폼 (5가지 상태 UI)
 │   │   ├── QuestionList.tsx                   ← 카테고리별 질문 리스트 + 다시하기
-│   │   ├── InterviewChat.tsx                  ← 면접 채팅 UI (페르소나별 색상, 꼬리질문 배지)
-│   │   └── AnswerInput.tsx                    ← 답변 입력 폼 (5000자 제한)
+│   │   ├── InterviewChat.tsx                  ← 면접 채팅 UI (페르소나별 색상, 꼬리질문 배지, 진행률 표시, answerCount>=5 리포트 버튼)
+│   │   └── AnswerInput.tsx                    ← 답변 입력 폼 (5000자 제한, controlled, beforeunload 이탈 경고)
 │   └── lib/
 │       ├── types.ts                           ← 공유 타입 (Question, PersonaType, HistoryItem 등)
 │       ├── prisma.ts                          ← Prisma 클라이언트 싱글턴
@@ -85,7 +85,7 @@ seung/
 │   │   ├── real-diagnosis-flow.spec.ts        ← Playwright E2E 테스트 (1개, 이슈 #127 전체 플로우, 영상 녹화)
 │   │   └── fixtures/                          ← 테스트용 PDF (gitignore)
 │   ├── api/
-│   │   ├── dashboard.test.ts                  ← GET /api/dashboard 테스트 (4개)
+│   │   ├── dashboard.test.ts                  ← GET /api/dashboard 테스트 (5개)
 │   │   ├── resume-delete.test.ts              ← DELETE /api/resume/[id] 테스트 (5개)
 │   │   ├── questions.test.ts                  ← API 라우트 단위 테스트 (19개)
 │   │   ├── interview-start.test.ts            ← 면접 시작 API 테스트 (8개)
@@ -99,7 +99,8 @@ seung/
 │   ├── components/
 │   │   ├── UploadForm.test.tsx                ← UploadForm 컴포넌트 테스트 (7개)
 │   │   ├── QuestionList.test.tsx              ← QuestionList 컴포넌트 테스트 (5개)
-│   │   └── InterviewChat.test.tsx             ← InterviewChat 컴포넌트 테스트 (11개)
+│   │   ├── InterviewChat.test.tsx             ← InterviewChat 컴포넌트 테스트 (15개)
+│   │   └── AnswerInput.test.tsx               ← AnswerInput 컴포넌트 테스트 (8개) — beforeunload, controlled, 제출·초기화
 │   └── setup.ts
 ├── Dockerfile                                 ← node:20-alpine, multi-stage build (deps/builder/runner)
 ├── entrypoint.sh                              ← Prisma migrate deploy + node server.js
@@ -183,6 +184,21 @@ seung/
   - [x] `src/app/api/resume/questions/route.ts`: callEngineAnalyze 호출로 교체, targetRole 추출·전달 ("미지정"/누락 시 생략), maxDuration 70 → 80
   - [x] `tests/api/questions.test.ts`: mockCallEngineAnalyze 전환, targetRole 케이스 3개 추가 (정상/미지정/누락)
   - [x] Vitest 125개 전체 통과 (14 파일)
+- [x] Phase 6: UX 흐름 개선 (#171)
+  - [x] `/resume` → `/dashboard` 리다이렉트 수정 (interview·report·diagnosis 3개 파일 9곳)
+  - [x] 면접 헤더 "나가기" 버튼 추가 (`/dashboard` 이동)
+  - [x] `report/page.tsx` growthCurve 플레이스홀더 섹션 삭제
+  - [x] `api/report/generate/route.ts`: sessionComplete 게이트 제거 (엔진이 history < 5 시 422)
+  - [x] `InterviewChat.tsx`: answerCount >= 5이면 리포트 버튼 노출 (sessionComplete 무관), totalQuestions 진행률 표시
+  - [x] `api/interview/session/route.ts`: questionsQueue select 추가, totalQuestions 계산·반환
+  - [x] `AnswerInput.tsx`: controlled textarea 전환, beforeunload 이탈 경고 (내용 있을 때만)
+  - [x] `api/dashboard/route.ts`: inProgressSessionId, reports[] 반환
+  - [x] `dashboard/page.tsx` ResumeCard: 이어하기 버튼, 복수 리포트 목록 UI
+  - [x] `src/lib/types.ts`: DashboardResumeItem에 inProgressSessionId, reports[] 추가
+  - [x] `tests/components/AnswerInput.test.tsx` 신규 (8개)
+  - [x] `api/dashboard/route.ts`: inProgressSessionId 조건에서 `s.report === null` 제거 (조기 리포트 생성 세션도 이어하기 표시)
+  - [x] `tests/api/dashboard.test.ts`: sessionComplete=false + 리포트 있는 케이스 추가 (5개)
+  - [x] Vitest 138개 전체 통과 (15 파일)
 - [x] 빌드 타입 오류 수정 (#147)
   - [x] `resume/feedback/route.ts`: `Prisma.JsonObject` → `Prisma.InputJsonValue` (@prisma/client v6 호환)
   - [x] `resume/questions/route.ts`: `catch((err: unknown)` — 암시적 any 제거

--- a/services/seung/src/app/api/dashboard/route.ts
+++ b/services/seung/src/app/api/dashboard/route.ts
@@ -29,6 +29,20 @@ export async function GET() {
 
   const result = resumes.map((resume) => {
     const reportSession = resume.sessions.find((s) => s.report !== null)
+
+    const sessionsWithReport = resume.sessions.filter(
+      (s): s is typeof s & { report: NonNullable<typeof s.report> } => s.report !== null
+    )
+    const reports = sessionsWithReport.map((s) => ({
+      id: s.report.id,
+      sessionId: s.id,
+      createdAt: s.report.createdAt.toISOString(),
+    }))
+
+    const inProgressSession = resume.sessions
+      .filter((s) => !s.sessionComplete)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]
+
     return {
       id: resume.id,
       createdAt: resume.createdAt.toISOString(),
@@ -37,6 +51,8 @@ export async function GET() {
       hasReport: reportSession !== undefined,
       reportId: reportSession?.report?.id ?? null,
       hasDiagnosis: resume.diagnosisResult !== null,
+      inProgressSessionId: inProgressSession?.id ?? null,
+      reports,
     }
   })
 

--- a/services/seung/src/app/api/interview/session/route.ts
+++ b/services/seung/src/app/api/interview/session/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: NextRequest) {
     currentPersonaLabel: string
     currentQuestionType: string
     history: unknown
+    questionsQueue: unknown
     sessionComplete: boolean
     interviewMode: string
   } | null
@@ -36,6 +37,7 @@ export async function GET(request: NextRequest) {
         currentPersonaLabel: true,
         currentQuestionType: true,
         history: true,
+        questionsQueue: true,
         sessionComplete: true,
         interviewMode: true,
       },
@@ -53,6 +55,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: '접근 권한이 없습니다.' }, { status: 403 })
   }
 
+  const queue = Array.isArray(session.questionsQueue) ? session.questionsQueue : []
+  const historyLen = Array.isArray(session.history) ? (session.history as unknown[]).length : 0
+  const totalQuestions = historyLen + queue.length + (session.sessionComplete ? 0 : 1)
+
   return NextResponse.json({
     currentQuestion: session.currentQuestion,
     currentPersona: session.currentPersona,
@@ -61,5 +67,6 @@ export async function GET(request: NextRequest) {
     history: session.history as HistoryItem[],
     sessionComplete: session.sessionComplete,
     interviewMode: session.interviewMode,
+    totalQuestions,
   })
 }

--- a/services/seung/src/app/api/report/generate/route.ts
+++ b/services/seung/src/app/api/report/generate/route.ts
@@ -57,10 +57,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '접근 권한이 없습니다.' }, { status: 403 })
   }
 
-  if (!session.sessionComplete) {
-    return NextResponse.json({ error: '면접이 아직 완료되지 않았습니다.' }, { status: 400 })
-  }
-
   // 이미 생성된 리포트가 있으면 재사용
   let existingReport: { id: string } | null
   try {

--- a/services/seung/src/app/dashboard/page.tsx
+++ b/services/seung/src/app/dashboard/page.tsx
@@ -70,14 +70,23 @@ function ResumeCard({ item, onDelete }: { item: DashboardResumeItem; onDelete: (
         <span className="text-xs text-gray-400">면접 {item.sessionCount}회</span>
       </div>
       <div className="flex flex-wrap gap-2">
-        {item.hasReport && item.reportId && (
+        {item.inProgressSessionId && (
           <button
-            onClick={() => router.push(`/report?reportId=${item.reportId}`)}
-            className="rounded-md bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
+            onClick={() => router.push(`/interview?sessionId=${item.inProgressSessionId}`)}
+            className="rounded-md bg-green-50 px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100"
           >
-            역량 리포트 보기
+            이어하기
           </button>
         )}
+        {item.reports.map((r, i) => (
+          <button
+            key={r.id}
+            onClick={() => router.push(`/report?reportId=${r.id}`)}
+            className="rounded-md bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
+          >
+            역량 리포트{item.reports.length > 1 ? ` #${i + 1}` : ''}
+          </button>
+        ))}
         {item.hasDiagnosis && (
           <button
             onClick={() => router.push(`/diagnosis?resumeId=${item.id}`)}

--- a/services/seung/src/app/diagnosis/page.tsx
+++ b/services/seung/src/app/diagnosis/page.tsx
@@ -30,14 +30,14 @@ function DiagnosisContent() {
 
   useEffect(() => {
     if (!resumeId) {
-      router.replace('/resume')
+      router.replace('/dashboard')
       return
     }
 
     fetch(`/api/resume/diagnosis?resumeId=${encodeURIComponent(resumeId)}`)
       .then((r) => {
         if (!r.ok) {
-          router.replace('/resume')
+          router.replace('/dashboard')
           return null
         }
         return r.json()
@@ -47,7 +47,7 @@ function DiagnosisContent() {
         setDiagnosis(data)
       })
       .catch(() => {
-        router.replace('/resume')
+        router.replace('/dashboard')
       })
       .finally(() => {
         setLoading(false)

--- a/services/seung/src/app/interview/page.tsx
+++ b/services/seung/src/app/interview/page.tsx
@@ -18,6 +18,7 @@ function InterviewContent() {
   const [messages, setMessages] = useState<Message[]>([])
   const [sessionComplete, setSessionComplete] = useState(false)
   const [loading, setLoading] = useState(true)
+  const [totalQuestions, setTotalQuestions] = useState(0)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isGeneratingReport, setIsGeneratingReport] = useState(false)
@@ -34,7 +35,7 @@ function InterviewContent() {
 
   useEffect(() => {
     if (!sessionId) {
-      router.replace('/resume')
+      router.replace('/dashboard')
       return
     }
 
@@ -45,7 +46,7 @@ function InterviewContent() {
     fetch(`/api/interview/session?${new URLSearchParams({ sessionId })}`)
       .then((r) => {
         if (!r.ok) {
-          router.replace('/resume')
+          router.replace('/dashboard')
           return null
         }
         return r.json()
@@ -81,12 +82,13 @@ function InterviewContent() {
         }
         setMessages(initialMessages)
         setSessionComplete(data.sessionComplete ?? false)
+        setTotalQuestions(data.totalQuestions ?? 0)
         // URL param 없이 접근(새로고침 등)할 때 session DB 값으로 복원
         if (data.interviewMode === 'practice') setInterviewMode('practice')
         setLoading(false)
       })
       .catch(() => {
-        router.replace('/resume')
+        router.replace('/dashboard')
       })
   }, [sessionId, router, searchParams])
 
@@ -237,8 +239,14 @@ function InterviewContent() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="border-b border-gray-200 bg-white px-6 py-4">
+      <header className="border-b border-gray-200 bg-white px-6 py-4 flex items-center justify-between">
         <h1 className="text-lg font-bold text-gray-900">MirAI — 패널 면접</h1>
+        <button
+          onClick={() => router.push('/dashboard')}
+          className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+        >
+          나가기
+        </button>
       </header>
       <main className="mx-auto max-w-2xl px-6 py-8 space-y-6">
         <InterviewChat
@@ -253,6 +261,7 @@ function InterviewContent() {
           onRetry={handleRetry}
           onNextQuestion={handleNextQuestion}
           practiceSubmitting={practiceSubmitting}
+          totalQuestions={totalQuestions}
         />
         {submitError && (
           <p role="alert" className="text-sm text-red-600 text-center px-4">

--- a/services/seung/src/app/report/page.tsx
+++ b/services/seung/src/app/report/page.tsx
@@ -33,14 +33,14 @@ function ReportContent() {
 
   useEffect(() => {
     if (!reportId) {
-      router.replace('/resume')
+      router.replace('/dashboard')
       return
     }
 
     fetch(`/api/report?reportId=${reportId}`)
       .then((r) => {
         if (!r.ok) {
-          router.replace('/resume')
+          router.replace('/dashboard')
           return null
         }
         return r.json()
@@ -50,7 +50,7 @@ function ReportContent() {
         setReport(data)
       })
       .catch(() => {
-        router.replace('/resume')
+        router.replace('/dashboard')
       })
       .finally(() => {
         setLoading(false)
@@ -147,11 +147,6 @@ function ReportContent() {
               <p className="text-sm text-gray-700">{fb.feedback}</p>
             </div>
           ))}
-        </section>
-
-        {/* growthCurve 플레이스홀더 */}
-        <section className="rounded-xl border border-dashed border-gray-300 bg-white p-6 text-center shadow-sm">
-          <p className="text-sm text-gray-400">성장 곡선은 추후 업데이트 예정입니다.</p>
         </section>
 
         {/* 홈으로 */}

--- a/services/seung/src/components/AnswerInput.tsx
+++ b/services/seung/src/components/AnswerInput.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState, useEffect } from 'react'
+
 const MAX_LENGTH = 5000
 
 type Props = {
@@ -9,16 +11,25 @@ type Props = {
 }
 
 export default function AnswerInput({ onSubmit, disabled = false, hidden = false }: Props) {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (value.trim()) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [value])
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    const fd = new FormData(e.currentTarget)
-    const raw = fd.get('answer')
-    const answer = (typeof raw === 'string' ? raw : '').trim()
+    const answer = value.trim()
     if (!answer) return
     onSubmit(answer)
-    e.currentTarget.reset()
-    const counter = e.currentTarget.querySelector('[data-char-counter]')
-    if (counter) counter.textContent = `0 / ${MAX_LENGTH}`
+    setValue('')
   }
 
   if (hidden) return null
@@ -27,19 +38,17 @@ export default function AnswerInput({ onSubmit, disabled = false, hidden = false
     <form onSubmit={handleSubmit} className="space-y-2">
       <textarea
         name="answer"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
         maxLength={MAX_LENGTH}
         disabled={disabled}
         placeholder="답변을 입력하세요..."
         className="w-full rounded-xl border border-gray-300 p-4 text-sm focus:border-gray-500 focus:outline-none disabled:bg-gray-50"
         rows={4}
-        onChange={(e) => {
-          const counter = e.currentTarget.closest('form')?.querySelector('[data-char-counter]')
-          if (counter) counter.textContent = `${e.currentTarget.value.length} / ${MAX_LENGTH}`
-        }}
       />
       <div className="flex items-center justify-between">
-        <span data-char-counter className="text-xs text-gray-400">
-          0 / {MAX_LENGTH}
+        <span className="text-xs text-gray-400">
+          {value.length} / {MAX_LENGTH}
         </span>
         <button
           type="submit"

--- a/services/seung/src/components/InterviewChat.tsx
+++ b/services/seung/src/components/InterviewChat.tsx
@@ -37,6 +37,7 @@ type Props = {
   onRetry?: () => void
   onNextQuestion?: () => void
   practiceSubmitting?: boolean
+  totalQuestions?: number
 }
 
 export default function InterviewChat({
@@ -51,9 +52,28 @@ export default function InterviewChat({
   onRetry,
   onNextQuestion,
   practiceSubmitting,
+  totalQuestions,
 }: Props) {
+  const answerCount = messages.filter((m) => m.type === 'answer').length
+
   return (
     <div className="space-y-4">
+      {(totalQuestions ?? 0) > 0 && (
+        <p className="text-sm text-gray-400 text-right">
+          {answerCount} / {totalQuestions} 답변 완료
+        </p>
+      )}
+      {!sessionComplete && answerCount >= 5 && onReport && (
+        <div className="flex justify-end">
+          <button
+            onClick={onReport}
+            disabled={isGeneratingReport}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+          >
+            {isGeneratingReport ? '리포트 생성 중...' : '리포트 생성하기'}
+          </button>
+        </div>
+      )}
       {messages.map((msg, index) => {
         if (msg.type === 'question') {
           const q = msg.data

--- a/services/seung/src/lib/types.ts
+++ b/services/seung/src/lib/types.ts
@@ -144,6 +144,8 @@ export type DashboardResumeItem = {
   hasReport: boolean
   reportId: string | null
   hasDiagnosis: boolean
+  inProgressSessionId: string | null
+  reports: { id: string; sessionId: string; createdAt: string }[]
 }
 
 export type DashboardResponse = {

--- a/services/seung/tests/api/dashboard.test.ts
+++ b/services/seung/tests/api/dashboard.test.ts
@@ -24,7 +24,9 @@ const mockResumes = [
     sessions: [
       {
         id: 'session-1',
-        report: { id: 'report-1' },
+        sessionComplete: true,
+        updatedAt: new Date('2026-01-01T10:00:00Z'),
+        report: { id: 'report-1', createdAt: new Date('2026-01-01T11:00:00Z') },
       },
     ],
   },
@@ -36,6 +38,23 @@ const mockResumes = [
     diagnosisResult: null,
     createdAt: new Date('2026-01-02T00:00:00Z'),
     sessions: [],
+  },
+  {
+    id: 'resume-3',
+    userId: 'user-1',
+    fileName: 'inprogress_resume.pdf',
+    resumeText: '진행 중인 면접이 있는 자소서입니다.',
+    questions: [],
+    diagnosisResult: null,
+    createdAt: new Date('2026-01-03T00:00:00Z'),
+    sessions: [
+      {
+        id: 'session-2',
+        sessionComplete: false,
+        updatedAt: new Date('2026-01-03T09:00:00Z'),
+        report: null,
+      },
+    ],
   },
 ]
 
@@ -56,8 +75,9 @@ describe('GET /api/dashboard', () => {
     expect(response.status).toBe(200)
 
     const body = await response.json()
-    expect(body.resumes).toHaveLength(2)
+    expect(body.resumes).toHaveLength(3)
 
+    // resume-1: 완료 세션 + 리포트 있음
     expect(body.resumes[0].id).toBe('resume-1')
     expect(body.resumes[0].sessionCount).toBe(1)
     expect(body.resumes[0].hasReport).toBe(true)
@@ -65,14 +85,55 @@ describe('GET /api/dashboard', () => {
     expect(body.resumes[0].hasDiagnosis).toBe(true)
     expect(body.resumes[0].createdAt).toBe('2026-01-01T00:00:00.000Z')
     expect(body.resumes[0].fileName).toBe('backend_resume.pdf')
+    expect(body.resumes[0].reports).toHaveLength(1)
+    expect(body.resumes[0].reports[0].id).toBe('report-1')
+    expect(body.resumes[0].inProgressSessionId).toBeNull()
 
+    // resume-2: 세션 없음
     expect(body.resumes[1].id).toBe('resume-2')
     expect(body.resumes[1].sessionCount).toBe(0)
     expect(body.resumes[1].hasReport).toBe(false)
     expect(body.resumes[1].reportId).toBeNull()
     expect(body.resumes[1].hasDiagnosis).toBe(false)
+    expect(body.resumes[1].reports).toHaveLength(0)
+    expect(body.resumes[1].inProgressSessionId).toBeNull()
     // fileName null → 폴백 문자열 생성 확인
     expect(body.resumes[1].fileName).toMatch(/^자소서/)
+
+    // resume-3: 진행 중 세션 있음
+    expect(body.resumes[2].id).toBe('resume-3')
+    expect(body.resumes[2].inProgressSessionId).toBe('session-2')
+    expect(body.resumes[2].reports).toHaveLength(0)
+  })
+
+  it('sessionComplete=false이지만 리포트가 있는 세션도 inProgressSessionId에 포함된다', async () => {
+    const mockResumesWithEarlyReport = [
+      {
+        id: 'resume-4',
+        userId: 'user-1',
+        fileName: 'early_report_resume.pdf',
+        resumeText: '조기 리포트가 생성된 진행 중 세션입니다.',
+        questions: [],
+        diagnosisResult: null,
+        createdAt: new Date('2026-01-04T00:00:00Z'),
+        sessions: [
+          {
+            id: 'session-3',
+            sessionComplete: false,
+            updatedAt: new Date('2026-01-04T09:00:00Z'),
+            report: { id: 'report-2', createdAt: new Date('2026-01-04T10:00:00Z') },
+          },
+        ],
+      },
+    ]
+    mockPrisma.resume.findMany.mockResolvedValueOnce(mockResumesWithEarlyReport)
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(body.resumes[0].inProgressSessionId).toBe('session-3')
+    expect(body.resumes[0].reports).toHaveLength(1)
+    expect(body.resumes[0].reports[0].id).toBe('report-2')
   })
 
   it('미인증 → 401', async () => {

--- a/services/seung/tests/api/interview-session.test.ts
+++ b/services/seung/tests/api/interview-session.test.ts
@@ -32,6 +32,7 @@ const mockSession = {
   currentPersonaLabel: 'HR 면접관',
   currentQuestionType: 'main',
   history: [],
+  questionsQueue: [{ persona: 'tech_lead', type: 'main' }, { persona: 'executive', type: 'main' }],
   sessionComplete: false,
   interviewMode: 'real',
 }
@@ -52,6 +53,8 @@ describe('GET /api/interview/session', () => {
     expect(body.currentQuestion).toBe('자기소개를 해주세요.')
     expect(body.currentPersona).toBe('hr')
     expect(body.sessionComplete).toBe(false)
+    // history=0, queue=2, sessionComplete=false → totalQuestions=3
+    expect(body.totalQuestions).toBe(3)
   })
 
   it('sessionId 누락 시 400 반환', async () => {

--- a/services/seung/tests/api/report-generate.test.ts
+++ b/services/seung/tests/api/report-generate.test.ts
@@ -117,17 +117,24 @@ describe('POST /api/report/generate', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('sessionComplete=false → 400 "면접이 아직 완료되지 않았습니다."', async () => {
+  it('sessionComplete=false여도 엔진 호출 → report.create → { reportId } (201)', async () => {
     mockPrisma.interviewSession.findUnique.mockResolvedValueOnce({
       ...mockSession,
       sessionComplete: false,
     })
+    mockPrisma.report.findFirst.mockResolvedValueOnce(null)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockEngineResponse,
+    })
+    mockPrisma.report.create.mockResolvedValueOnce({ id: 'report-2' })
 
     const response = await POST(makeRequest({ sessionId: 'session-1' }))
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(201)
     const body = await response.json()
-    expect(body.error).toBe('면접이 아직 완료되지 않았습니다.')
-    expect(mockFetch).not.toHaveBeenCalled()
+    expect(body.reportId).toBe('report-2')
+    expect(mockFetch).toHaveBeenCalledOnce()
   })
 
   it('기존 Report 있음 → findFirst hit → 기존 reportId (200), mockFetch 미호출', async () => {

--- a/services/seung/tests/components/AnswerInput.test.tsx
+++ b/services/seung/tests/components/AnswerInput.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AnswerInput from '@/components/AnswerInput'
+
+describe('AnswerInput', () => {
+  it('기본 렌더: textarea와 제출 버튼이 표시된다', () => {
+    render(<AnswerInput onSubmit={vi.fn()} />)
+    expect(screen.getByPlaceholderText('답변을 입력하세요...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '답변 제출' })).toBeInTheDocument()
+  })
+
+  it('hidden=true이면 렌더되지 않는다', () => {
+    render(<AnswerInput onSubmit={vi.fn()} hidden={true} />)
+    expect(screen.queryByPlaceholderText('답변을 입력하세요...')).not.toBeInTheDocument()
+  })
+
+  it('텍스트 입력 시 글자 수 카운터가 업데이트된다', async () => {
+    render(<AnswerInput onSubmit={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('답변을 입력하세요...')
+    await userEvent.type(textarea, '안녕')
+    expect(screen.getByText(/^2 \/ 5000$/)).toBeInTheDocument()
+  })
+
+  it('제출 후 textarea가 비워진다', async () => {
+    render(<AnswerInput onSubmit={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('답변을 입력하세요...')
+    await userEvent.type(textarea, '테스트 답변')
+    fireEvent.submit(textarea.closest('form')!)
+    expect((textarea as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('빈 textarea 제출 시 onSubmit이 호출되지 않는다', async () => {
+    const onSubmit = vi.fn()
+    render(<AnswerInput onSubmit={onSubmit} />)
+    const textarea = screen.getByPlaceholderText('답변을 입력하세요...')
+    fireEvent.submit(textarea.closest('form')!)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  describe('beforeunload 이탈 경고', () => {
+    let addEventListenerSpy: ReturnType<typeof vi.spyOn>
+    let removeEventListenerSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+      removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    })
+
+    afterEach(() => {
+      addEventListenerSpy.mockRestore()
+      removeEventListenerSpy.mockRestore()
+    })
+
+    it('컴포넌트 마운트 시 beforeunload 이벤트가 등록된다', () => {
+      render(<AnswerInput onSubmit={vi.fn()} />)
+      expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+    })
+
+    it('textarea에 내용이 있을 때 beforeunload 핸들러가 e.preventDefault를 호출한다', async () => {
+      render(<AnswerInput onSubmit={vi.fn()} />)
+      const textarea = screen.getByPlaceholderText('답변을 입력하세요...')
+      await userEvent.type(textarea, '작성 중인 답변')
+
+      const event = new Event('beforeunload') as BeforeUnloadEvent
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+      window.dispatchEvent(event)
+      expect(preventDefaultSpy).toHaveBeenCalled()
+    })
+
+    it('textarea가 비어있을 때 beforeunload 핸들러가 e.preventDefault를 호출하지 않는다', () => {
+      render(<AnswerInput onSubmit={vi.fn()} />)
+
+      const event = new Event('beforeunload') as BeforeUnloadEvent
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+      window.dispatchEvent(event)
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/services/seung/tests/components/InterviewChat.test.tsx
+++ b/services/seung/tests/components/InterviewChat.test.tsx
@@ -119,6 +119,69 @@ describe('InterviewChat', () => {
 
     expect(screen.queryByText('꼬리질문')).not.toBeInTheDocument()
   })
+
+  it('totalQuestions > 0이면 진행률 텍스트가 표시된다', () => {
+    const messages: Message[] = [
+      {
+        id: 'q1',
+        type: 'question',
+        data: { persona: 'hr', personaLabel: 'HR 면접관', question: '질문1', type: 'main' },
+      },
+      { id: 'a1', type: 'answer', text: '답변1' },
+    ]
+
+    render(
+      <InterviewChat messages={messages} sessionComplete={false} totalQuestions={10} />
+    )
+
+    expect(screen.getByText('1 / 10 답변 완료')).toBeInTheDocument()
+  })
+
+  it('totalQuestions가 없으면 진행률 텍스트가 표시되지 않는다', () => {
+    render(
+      <InterviewChat messages={[]} sessionComplete={false} />
+    )
+
+    expect(screen.queryByText(/답변 완료/)).not.toBeInTheDocument()
+  })
+
+  it('answerCount >= 5이고 sessionComplete=false이면 리포트 버튼이 표시된다', () => {
+    const messages: Message[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `a${i}`,
+      type: 'answer' as const,
+      text: `답변${i}`,
+    }))
+
+    render(
+      <InterviewChat
+        messages={messages}
+        sessionComplete={false}
+        onReport={vi.fn()}
+        isGeneratingReport={false}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '리포트 생성하기' })).toBeInTheDocument()
+  })
+
+  it('answerCount < 5이고 sessionComplete=false이면 리포트 버튼이 표시되지 않는다', () => {
+    const messages: Message[] = Array.from({ length: 4 }, (_, i) => ({
+      id: `a${i}`,
+      type: 'answer' as const,
+      text: `답변${i}`,
+    }))
+
+    render(
+      <InterviewChat
+        messages={messages}
+        sessionComplete={false}
+        onReport={vi.fn()}
+        isGeneratingReport={false}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: '리포트 생성하기' })).not.toBeInTheDocument()
+  })
 })
 
 describe('practice 모드 피드백 UI', () => {


### PR DESCRIPTION
## 이슈 배경

면접 진행 중 이탈 수단 부재, 오류 시 잘못된 페이지(`/resume`)로 리다이렉트, 진행률 미표시, 조기 리포트 생성 불가, 이탈 경고 없음, 대시보드에서 진행 중 세션 복귀 불가, 리포트 1개만 접근 가능 등 핵심 기능 구현 후 실사용에서 발견된 UX 흐름 문제 8가지를 수정한다.

## 완료 기준 (AC)

- [x] 면접 헤더에 "나가기" 버튼 추가 → /dashboard 이동
- [x] 리포트 생성 조건 완화: sessionComplete 게이트 제거, answerCount >= 5 시 버튼 노출
- [x] 면접 진행률 표시 — 답변 완료 수 / 총 질문 수
- [x] 에러·파라미터 누락 리다이렉트 수정: 3개 파일 9곳 `/resume` → `/dashboard`
- [x] report 페이지 growthCurve 플레이스홀더 숨김
- [x] 대시보드 진행 중 세션 "이어하기" 버튼
- [x] AnswerInput beforeunload 이탈 경고 (textarea 내용 있을 때만)
- [x] 대시보드 리포트 복수 접근: reports 배열 기반 목록 표시

## 작업 내역

| 파일 | 변경 내용 |
|------|-----------|
| `src/app/interview/page.tsx` | 리다이렉트 3곳 수정, 나가기 버튼 추가, `totalQuestions` state 추가 |
| `src/app/report/page.tsx` | 리다이렉트 3곳 수정, growthCurve 섹션 삭제 |
| `src/app/diagnosis/page.tsx` | 리다이렉트 3곳 수정 |
| `src/app/api/report/generate/route.ts` | `sessionComplete` 게이트 블록 제거 |
| `src/app/api/interview/session/route.ts` | `questionsQueue` select 추가, `totalQuestions` 계산·반환 |
| `src/app/api/dashboard/route.ts` | 타입 가드 filter, `reports[]`·`inProgressSessionId` 반환 |
| `src/components/InterviewChat.tsx` | `totalQuestions` prop, 진행률 표시, answerCount>=5 리포트 버튼 |
| `src/components/AnswerInput.tsx` | controlled textarea 전환, `beforeunload` useEffect 등록 |
| `src/lib/types.ts` | `DashboardResumeItem`에 `inProgressSessionId`, `reports[]` 추가 |
| `src/app/dashboard/page.tsx` | 이어하기 버튼, `reports.map()` 기반 리포트 목록 |
| `tests/components/AnswerInput.test.tsx` | 신규 — 8개 |

**핵심 결정:**
- `answerCount`는 API/props가 아닌 InterviewChat 내부에서 `messages` 기반 계산
- Prisma 타입 가드로 `filter` 후 `s.report` non-null 보장 (`!` assertion 미사용)
- `inProgressSessionId` 조건에서 `s.report === null` 제거 — 조기 리포트 생성 세션도 이어하기 대상

**테스트:** Vitest 138/138 통과 (15파일)

Closes #171