### PR TITLE
feat: [lww] Phase 1 소셜 로그인 (카카오·구글·이메일) + 익명→인증 마이그레이션 (#179)

### DIFF
--- a/docs/work/done/000179-lww-social-login/00_issue.md
+++ b/docs/work/done/000179-lww-social-login/00_issue.md
@@ -1,0 +1,86 @@
+# feat: [lww] Phase 1 — 소셜 로그인 (카카오·구글) 구현
+
+## 사용자 관점 목표
+취준생이 AI 면접 체험 후 카카오·구글·이메일 계정으로 간편하게 가입해 면접 결과를 영구 저장하고, 이후 재방문 시 히스토리를 이어볼 수 있다.
+
+## 배경
+MVP 완료(#116) 후 Phase 1 첫 기능. 현재 비로그인 상태로 면접 완료 시 결과가 로컬에만 저장되어 재방문 시 유실된다. 소셜 로그인으로 "선 체험 후 가입" 루프를 완성하고 D7 리텐션 목표(25%)를 위한 기반을 구축한다.
+
+## 완료 기준
+- [x] 카카오·구글 OAuth 로그인/로그아웃 작동 (콜백 처리 포함)
+- [x] 이메일 가입/로그인 작동 (이메일 확인 링크 포함)
+- [x] 로그인 후 면접 세션이 해당 사용자 계정(`auth.uid()`)에 연결 저장
+- [x] 비로그인 상태로 면접 완료 시 "저장하려면 로그인" CTA 표시
+- [x] `middleware.ts`에서 Supabase 세션 자동 갱신 처리 (`getUser()`)
+- [x] 히스토리 탭(`/interview`)에서 내 면접 세션 목록 표시
+- [x] `profiles` 테이블 + RLS 마이그레이션 완료
+
+## 구현 플랜
+1. Supabase Dashboard — 카카오·구글 OAuth provider 활성화, redirect URL 등록
+2. `middleware.ts` 업데이트 — 기존 rate limiter에 `getUser()` 세션 갱신 병합
+3. `/login` 페이지 + `/api/auth/callback` 라우트 생성
+4. `profiles` 테이블 + RLS 마이그레이션 (Supabase SQL Editor)
+5. 면접 완료 후 비로그인 상태 감지 → "저장하려면 로그인" CTA 컴포넌트 추가
+6. 히스토리 탭 — `interview_sessions` 쿼리 시 `user_id = auth.uid()` 필터 적용
+
+## 참고
+- Supabase Auth 클라이언트 패턴: `services/lww/src/lib/supabase/server.ts`, `browser.ts` (#100에서 구현 완료)
+- seung 서비스 Auth 구현 참고: `services/seung/src/lib/supabase/`
+- 환경변수: `KAKAO_CLIENT_ID/SECRET`, `GOOGLE_CLIENT_ID/SECRET`, `NEXT_PUBLIC_SITE_URL`
+
+## 개발 체크리스트
+- [x] 테스트 코드 포함
+- [x] `services/lww/.ai.md` 최신화
+- [x] 불변식 위반 없음 (인증은 서비스에서만, 엔진은 무관)
+
+---
+
+## 작업 내역
+
+### 2026-03-22 (구현 완료)
+
+**현황**: 7/7 완료
+
+#### middleware.ts
+- rate limiter 전용에서 Supabase `getUser()` 세션 갱신을 병합
+- matcher를 API 전용 → 전체 라우트로 확장 (Supabase SSR 공식 권장 패턴)
+- **익명 우선 원칙**: 비로그인 사용자 리다이렉트 절대 금지 — getUser() 결과 무시, 갱신만 수행
+
+#### app/auth/callback/route.ts (신규)
+- OAuth 코드 교환(`exchangeCodeForSession`) + Open Redirect 방어 (`next` 파라미터 검증)
+- `lww_anon_id` 쿠키를 읽어 `migrate_anon_to_user(p_anon_id, p_user_id)` RPC 호출 — 익명 면접 세션을 로그인 계정에 원자적으로 이전
+
+#### app/auth/confirm/route.ts (신규)
+- 이메일 확인 링크(`token_hash`) 처리 — `verifyOtp` 후 `safeRedirect`로 이동
+
+#### app/(main)/login/page.tsx (신규)
+- 소셜 탭(카카오·구글 OAuth) + 이메일 탭(가입/로그인) 전환 UI
+- `?error=oauth`, `?error=invalid_link` 쿼리 파라미터로 에러 배너 표시
+
+#### app/api/interview/start|answer|end/route.ts (수정)
+- `getCurrentUserId()` 헬퍼(`lib/supabase/get-current-user-id.ts`)로 로그인 상태 감지
+- dual-write: 로그인이면 `user_id = auth.uid()`, 비로그인이면 `user_id = null`
+- 인증 오류가 발생해도 익명 기능은 정상 동작 (graceful fallback)
+
+#### components/interview/SaveAccountCTA.tsx (신규)
+- 리포트 페이지에서 비로그인 상태 감지 후 "결과를 영구 저장하려면 로그인하세요" 배너 표시
+- `/login?next=/report/${sessionId}` 링크로 로그인 후 원래 리포트로 복귀
+
+#### app/(main)/interview/page.tsx (수정)
+- Client Component → Server Component 전환
+- 로그인: `user_id` 기준 Supabase 쿼리 / 비로그인: `lww_anon_id` 쿠키 + service client로 `anonymous_id` 쿼리
+- `toHistory()` 헬퍼로 DB 결과 → `InterviewRecord[]` 변환 (중복 제거)
+
+#### DB 마이그레이션 (Supabase Dashboard 수동 실행)
+- `profiles` 테이블 + RLS 정책 (`read own`, `update own`)
+- `handle_new_user` 트리거 (`set search_path = public` 필수)
+- `migrate_anon_to_user(p_anon_id, p_user_id)` RPC
+
+#### 테스트
+- `tests/e2e/auth-flow.spec.ts`: 12/12 pass (로그인 UI, OAuth 에러 처리, Open Redirect 방어, 익명 우선 원칙)
+- `tests/e2e/anon-save-cta.spec.ts`: 2/2 pass (면접 완료 → CTA 표시, 직접 접근 → CTA 표시)
+- `src/app/api/interview/__tests__/start.test.ts`: 단위 테스트 mock 추가
+
+#### 문서
+- `docs/work/active/000179-lww-social-login/migrate.sql`: DB 마이그레이션 전체 SQL
+- `docs/work/active/000179-lww-social-login/oauth-setup.md`: 카카오·구글 OAuth 설정 가이드

--- a/docs/work/done/000179-lww-social-login/01_plan.md
+++ b/docs/work/done/000179-lww-social-login/01_plan.md
@@ -1,0 +1,581 @@
+# [#179] feat: [lww] Phase 1 — 소셜 로그인 (카카오·구글) 구현 — 구현 계획
+
+> 작성: 2026-03-21 | 아키텍처: Architect(Opus) + Critic(Opus) 검토 완료
+
+---
+
+## 완료 기준
+
+- [ ] 카카오·구글 OAuth 로그인/로그아웃 작동 (콜백 처리 포함)
+- [ ] 이메일 가입/로그인 작동 (이메일 확인 링크 포함)
+- [ ] 로그인 후 면접 세션이 해당 사용자 계정(`auth.uid()`)에 연결 저장
+- [ ] 비로그인 상태로 면접 완료 시 "저장하려면 로그인" CTA 표시
+- [ ] `middleware.ts`에서 Supabase 세션 자동 갱신 처리 (`getUser()`)
+- [ ] 히스토리 탭(`/interview`)에서 내 면접 세션 목록 표시
+- [ ] `profiles` 테이블 + RLS 마이그레이션 완료
+- [ ] 테스트 코드 포함
+- [ ] `services/lww/.ai.md` 최신화
+- [ ] 불변식 위반 없음 (인증은 서비스에서만, 엔진은 무관)
+
+---
+
+## 아키텍처 핵심 결정
+
+### LWW 고유 원칙 (SIW/Seung과 다른 점)
+
+| 항목 | SIW/Seung | LWW |
+|------|-----------|-----|
+| 기본 상태 | 로그인 필수 | **익명 우선** |
+| 미들웨어 리다이렉트 | 비로그인 → `/login` 강제 | **절대 리다이렉트 금지** |
+| 세션 추적 | user_id만 | **anon_id + user_id 병행** |
+| 콜백 역할 | 로그인 후 대시보드 이동 | **로그인 + 익명 세션 마이그레이션** |
+
+### 핵심 결정사항
+
+1. **콜백 경로**: `services/lww/src/app/auth/callback/route.ts` (NOT `/api/auth/callback`)
+   - `/api/` 아래는 REST 데이터 엔드포인트. OAuth 콜백은 브라우저 리다이렉트 대상 → `app/auth/callback/`
+2. **익명→인증 마이그레이션**: 서버 사이드 콜백에서 Supabase RPC 함수로 원자적 처리
+3. **anon_id 쿠키**: 로그인 후에도 유지 (삭제 안 함) — 로그아웃 후 익명 연속성 보장
+4. **미들웨어**: rate limiter 먼저 → `getUser()` 세션 갱신 (리다이렉트 없음)
+5. **API 라우트 dual-write**: `createClient()` + `getUser()` 추가, 로그인 상태면 `user_id`도 저장
+6. **히스토리 탭**: Server Component, 인증 상태에 따라 쿼리 분기
+
+---
+
+## 구현 계획
+
+### Step 0: DB 마이그레이션 (Supabase SQL Editor — 수동 실행)
+
+**파일**: Supabase Dashboard → SQL Editor
+
+```sql
+-- 1. profiles 테이블 (dev_spec.md:478-523 기준)
+create table if not exists profiles (
+  id          uuid references auth.users(id) on delete cascade primary key,
+  email       text,
+  full_name   text,
+  avatar_url  text,
+  created_at  timestamptz default now()
+);
+alter table profiles enable row level security;
+create policy "profiles_select_own" on profiles for select using (auth.uid() = id);
+create policy "profiles_update_own" on profiles for update using (auth.uid() = id);
+
+-- 2. auth.users 생성 시 profiles 자동 삽입 트리거
+create or replace function handle_new_user()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into profiles (id) values (new.id) on conflict do nothing;
+  return new;
+end;
+$$;
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure handle_new_user();
+
+-- 3. 익명→인증 마이그레이션 RPC 함수 (원자적 트랜잭션 보장)
+create or replace function migrate_anon_to_user(p_anon_id text, p_user_id uuid)
+returns void language plpgsql security definer as $$
+begin
+  update interview_sessions
+    set user_id = p_user_id
+    where anonymous_id = p_anon_id and user_id is null;
+  update reports
+    set user_id = p_user_id
+    where anonymous_id = p_anon_id and user_id is null;
+end;
+$$;
+```
+
+**주의**: `interview_sessions`과 `reports` 테이블에 이미 `user_id uuid` 컬럼이 존재하는지 확인 (dev_spec.md:412, 448). 없으면 `ALTER TABLE ... ADD COLUMN user_id uuid references auth.users(id)` 먼저 실행.
+
+---
+
+### Step 1: Supabase Dashboard OAuth Provider 활성화 (수동)
+
+1. Supabase Dashboard → Authentication → Providers
+2. **Google**: Client ID/Secret 입력
+   - Redirect URL: `{NEXT_PUBLIC_SITE_URL}/auth/callback`
+3. **Kakao**: Client ID/Secret 입력
+   - Redirect URL: `{NEXT_PUBLIC_SITE_URL}/auth/callback`
+4. 환경변수 확인: `NEXT_PUBLIC_SITE_URL` (`.env.local`)
+
+---
+
+### Step 2: middleware.ts 업데이트
+
+**파일**: `services/lww/src/middleware.ts`
+
+**변경 내용**:
+- 기존 rate limiter 로직 유지 (순서 변경 없음)
+- rate limit 통과 후 Supabase 세션 갱신 추가
+- **절대 익명 사용자 리다이렉트 금지**
+- matcher 전체 경로로 확장 (static 제외)
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+// rate limiter (기존 코드 유지)
+const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
+const RATE_LIMIT = 10;
+const WINDOW_MS = 60 * 1000;
+
+function getClientIP(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 1. Rate limit (API routes only)
+  if (pathname.startsWith("/api/interview/") || pathname.startsWith("/api/resume/")) {
+    const ip = getClientIP(request);
+    const now = Date.now();
+    const key = `${ip}:${pathname.split("/").slice(0, 4).join("/")}`;
+    const current = rateLimitMap.get(key);
+    if (!current || now > current.resetTime) {
+      rateLimitMap.set(key, { count: 1, resetTime: now + WINDOW_MS });
+    } else if (current.count >= RATE_LIMIT) {
+      return NextResponse.json(
+        { message: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+        { status: 429, headers: { "Retry-After": String(Math.ceil((current.resetTime - Date.now()) / 1000)) } }
+      );
+    } else {
+      current.count++;
+    }
+  }
+
+  // 2. Supabase 세션 갱신 (전체 경로)
+  // LWW는 익명 우선: user가 없어도 절대 리다이렉트하지 않는다
+  let supabaseResponse = NextResponse.next({ request });
+  try {
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() { return request.cookies.getAll(); },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+            supabaseResponse = NextResponse.next({ request });
+            cookiesToSet.forEach(({ name, value, options }) =>
+              supabaseResponse.cookies.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
+    await supabase.auth.getUser(); // 세션 갱신 목적만 (결과 무시)
+  } catch {
+    // auth 인프라 장애 시에도 익명 기능은 정상 동작해야 함
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};
+```
+
+---
+
+### Step 3: `/auth/callback` Route Handler 생성
+
+**파일**: `services/lww/src/app/auth/callback/route.ts` (새 파일)
+
+**역할**:
+1. OAuth code → session 교환
+2. 기존 익명 세션을 인증 사용자에 원자적 연결 (RPC)
+3. `next` 파라미터로 안전한 리다이렉트
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  // Open Redirect 방어
+  const safeRedirect = next.startsWith("/") && !next.startsWith("//") ? next : "/";
+
+  if (!code) {
+    return NextResponse.redirect(`${origin}/login?error=oauth`);
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error || !data.user) {
+    return NextResponse.redirect(`${origin}/login?error=oauth`);
+  }
+
+  // 익명 세션 마이그레이션 (RPC — 원자적 트랜잭션)
+  const cookieStore = await cookies();
+  const anonId = cookieStore.get("lww_anon_id")?.value;
+  if (anonId) {
+    const serviceClient = createServiceClient();
+    const { error: migrateError } = await serviceClient.rpc("migrate_anon_to_user", {
+      p_anon_id: anonId,
+      p_user_id: data.user.id,
+    });
+    if (migrateError) {
+      // 마이그레이션 실패는 치명적 오류가 아님 — 로그만 기록
+      console.error("[auth/callback] 세션 마이그레이션 실패:", migrateError);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}${safeRedirect}`);
+}
+```
+
+**엣지케이스**:
+- `anonId` 없음 (새 기기, 쿠키 삭제): 마이그레이션 스킵 — 정상 동작
+- 이미 다른 계정에 연결된 세션: RPC 내 `user_id IS NULL` 조건으로 재연결 방지
+- 마이그레이션 실패: 로그인은 성공, 세션은 익명으로 남음 (허용된 결과)
+
+---
+
+### Step 4: `/login` 페이지 생성
+
+**파일**: `services/lww/src/app/(main)/login/page.tsx` (새 파일)
+
+**역할**: 카카오·구글 OAuth + 이메일 가입/로그인, 에러 표시
+
+**이메일 인증 흐름**:
+- 가입(`signUp`): 확인 이메일 발송 → 사용자가 링크 클릭 → `/auth/confirm` 라우트 처리
+- 로그인(`signInWithPassword`): 즉시 세션 발급 (콜백 불필요)
+- 탭/토글로 "소셜 로그인 | 이메일" 전환
+
+```typescript
+"use client";
+
+import { createClient } from "@/lib/supabase/browser";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+
+function LoginContent() {
+  const supabase = createClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") ?? "/";
+  const hasError = searchParams.get("error") === "oauth";
+
+  const [tab, setTab] = useState<"social" | "email">("social");
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+
+  const handleKakao = () =>
+    supabase.auth.signInWithOAuth({ provider: "kakao", options: { redirectTo } });
+  const handleGoogle = () =>
+    supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo } });
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (mode === "signin") {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) { setMessage(error.message); return; }
+      router.push(next.startsWith("/") && !next.startsWith("//") ? next : "/");
+    } else {
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          emailRedirectTo: `${window.location.origin}/auth/confirm?next=${encodeURIComponent(next)}`,
+        },
+      });
+      if (error) { setMessage(error.message); return; }
+      setMessage("확인 이메일을 발송했습니다. 받은편지함을 확인해주세요.");
+    }
+  };
+
+  return (
+    <div>
+      {hasError && <p>로그인 중 오류가 발생했습니다. 다시 시도해주세요.</p>}
+      {/* 탭 전환 */}
+      <div>
+        <button onClick={() => setTab("social")}>소셜 로그인</button>
+        <button onClick={() => setTab("email")}>이메일</button>
+      </div>
+      {tab === "social" ? (
+        <>
+          <button onClick={handleKakao}>카카오로 계속하기</button>
+          <button onClick={handleGoogle}>구글로 계속하기</button>
+        </>
+      ) : (
+        <form onSubmit={handleEmailSubmit}>
+          <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="이메일" required />
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="비밀번호" required />
+          {message && <p>{message}</p>}
+          <button type="submit">{mode === "signin" ? "로그인" : "가입하기"}</button>
+          <button type="button" onClick={() => setMode(m => m === "signin" ? "signup" : "signin")}>
+            {mode === "signin" ? "계정이 없으신가요? 가입하기" : "이미 계정이 있으신가요? 로그인"}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
+  );
+}
+```
+
+**로그아웃**: 클라이언트 `supabase.auth.signOut()` 후 홈 이동.
+
+---
+
+### Step 4.5: `/auth/confirm` Route Handler 생성 (이메일 확인용)
+
+**파일**: `services/lww/src/app/auth/confirm/route.ts` (새 파일)
+
+**역할**: 이메일 가입 확인 링크 처리 (`token_hash` + `type` 파라미터)
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { EmailOtpType } from "@supabase/supabase-js";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const token_hash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+  const next = searchParams.get("next") ?? "/";
+
+  const safeRedirect = next.startsWith("/") && !next.startsWith("//") ? next : "/";
+
+  if (!token_hash || !type) {
+    return NextResponse.redirect(`${origin}/login?error=invalid_link`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.verifyOtp({ token_hash, type });
+
+  if (error) {
+    return NextResponse.redirect(`${origin}/login?error=invalid_link`);
+  }
+
+  return NextResponse.redirect(`${origin}${safeRedirect}`);
+}
+```
+
+**흐름**: 사용자 이메일 클릭 → `/auth/confirm?token_hash=...&type=signup&next=/` → `verifyOtp()` → 세션 발급 → `safeRedirect`
+
+---
+
+### Step 5: interview API 라우트 dual-write
+
+**대상 파일**:
+- `services/lww/src/app/api/interview/start/route.ts`
+- `services/lww/src/app/api/interview/answer/route.ts`
+- `services/lww/src/app/api/interview/end/route.ts`
+
+**패턴** (각 라우트 공통):
+
+```typescript
+// 기존 createServiceClient() 유지
+// 추가: 로그인 상태 감지
+import { createClient } from "@/lib/supabase/server";
+
+// POST 핸들러 내부에서:
+const userClient = await createClient();
+const { data: { user } } = await userClient.auth.getUser();
+const userId = user?.id ?? null; // 비로그인이면 null
+
+// DB insert/update 시:
+await supabase.from("interview_sessions").insert({
+  // ... 기존 필드들 ...
+  anonymous_id: anonymousId,
+  user_id: userId,  // 로그인이면 auth.uid(), 비로그인이면 null
+});
+```
+
+**주의**: `createClient()`와 `createServiceClient()` 동시 사용. `getUser()`는 인증 상태 확인 전용, 실제 DB 쓰기는 service client로.
+
+---
+
+### Step 6: "저장하려면 로그인" CTA 컴포넌트
+
+**파일**: `services/lww/src/components/interview/SaveAccountCTA.tsx` (새 파일)
+
+**조건**: 면접 완료 UI에서 비로그인 상태일 때 표시
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/browser";
+import Link from "next/link";
+
+interface SaveAccountCTAProps {
+  sessionId: string;
+}
+
+export function SaveAccountCTA({ sessionId }: SaveAccountCTAProps) {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      setIsLoggedIn(!!data.user);
+    });
+  }, []);
+
+  if (isLoggedIn !== false) return null; // 로그인 상태 또는 로딩 중
+
+  return (
+    <div>
+      <p>면접 결과를 영구 저장하려면 로그인하세요</p>
+      <Link href={`/login?next=/report/${sessionId}`}>
+        로그인 / 가입하기
+      </Link>
+    </div>
+  );
+}
+```
+
+**연결 위치**: 리포트 페이지 또는 면접 완료 UI 컴포넌트에 `<SaveAccountCTA sessionId={sessionId} />` 추가.
+
+---
+
+### Step 7: 히스토리 탭 Server Component 전환
+
+**파일**: `services/lww/src/app/(main)/interview/page.tsx`
+
+**DB → UI 데이터 매핑**:
+
+| DB 컬럼 (interview_sessions) | UI `InterviewRecord` 필드 | 변환 |
+|-------------------------------|---------------------------|------|
+| `id` | `id` | 직접 사용 |
+| `created_at` | `date` | `new Date(created_at).toLocaleDateString('ko-KR')` |
+| `job_category` (쉼표 구분 문자열) | `jobCategories: string[]` | `.split(", ")` |
+| `reports[0].total_score` | `score` | JOIN 후 추출 |
+
+**구현 패턴**:
+
+```typescript
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
+
+export default async function InterviewPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  let sessions = [];
+  if (user) {
+    // 로그인: user_id 기준 쿼리
+    const { data } = await supabase
+      .from("interview_sessions")
+      .select("id, created_at, job_category, reports(total_score)")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false });
+    sessions = data ?? [];
+  } else {
+    // 비로그인: anon_id 기준 (service client, RLS 우회)
+    const cookieStore = await cookies();
+    const anonId = cookieStore.get("lww_anon_id")?.value;
+    if (anonId && /^[0-9a-f-]{36}$/.test(anonId)) { // UUID 형식 검증
+      const serviceClient = createServiceClient();
+      const { data } = await serviceClient
+        .from("interview_sessions")
+        .select("id, created_at, job_category, reports(total_score)")
+        .eq("anonymous_id", anonId)
+        .order("created_at", { ascending: false });
+      sessions = data ?? [];
+    }
+  }
+
+  const history = sessions.map(s => ({
+    id: s.id,
+    date: new Date(s.created_at).toLocaleDateString("ko-KR"),
+    jobCategories: (s.job_category as string).split(", "),
+    score: (s.reports as { total_score: number }[])?.[0]?.total_score ?? 0,
+  }));
+
+  return (
+    // 기존 JSX 구조 유지, history는 props로 전달
+    // "use client" 제거, useState/useEffect 제거
+    ...
+  );
+}
+```
+
+---
+
+### Step 8: 테스트 코드
+
+**파일**: `services/lww/src/app/auth/callback/__tests__/route.test.ts` (새 파일)
+
+**테스트 케이스**:
+1. `code` 없음 → `/login?error=oauth` 리다이렉트
+2. `exchangeCodeForSession` 실패 → `/login?error=oauth` 리다이렉트
+3. 성공 + `anonId` 있음 → `migrate_anon_to_user` RPC 호출 + `next` 리다이렉트
+4. 성공 + `anonId` 없음 → RPC 호출 안 함 + `/` 리다이렉트
+5. Open Redirect 방어: `next=//evil.com` → `/` 리다이렉트
+6. 마이그레이션 RPC 실패 → 로그인은 성공, 에러 로그 기록
+
+**파일**: `services/lww/src/middleware.test.ts` (새 파일)
+
+**테스트 케이스**:
+1. Rate limit 초과 → 429 반환
+2. Rate limit 정상 → Supabase 세션 갱신 후 통과
+3. Supabase 오류 → 세션 갱신 실패해도 요청 통과 (익명 기능 보호)
+
+---
+
+### Step 9: `services/lww/.ai.md` 최신화
+
+**파일**: `services/lww/.ai.md`
+
+추가할 내용:
+- Phase 1 소셜 로그인 아키텍처 (익명 우선 원칙)
+- auth 관련 파일 목록: `app/auth/callback/route.ts`, `app/(main)/login/page.tsx`
+- dual-write 패턴 설명
+- `migrate_anon_to_user` RPC 함수 위치 및 목적
+
+---
+
+## 파일 변경 요약
+
+| 파일 | 작업 | 우선순위 |
+|------|------|---------|
+| Supabase SQL Editor | profiles 테이블, migrate_anon_to_user RPC | 최우선 |
+| `src/middleware.ts` | 세션 갱신 추가, matcher 확장 | 최우선 |
+| `src/app/auth/callback/route.ts` | 신규 생성 | 최우선 |
+| `src/app/auth/confirm/route.ts` | 신규 생성 (이메일 확인) | 최우선 |
+| `src/app/(main)/login/page.tsx` | 신규 생성 (소셜 + 이메일 탭) | 높음 |
+| `src/app/api/interview/start/route.ts` | dual-write 추가 | 높음 |
+| `src/app/api/interview/answer/route.ts` | dual-write 추가 | 높음 |
+| `src/app/api/interview/end/route.ts` | dual-write 추가 | 높음 |
+| `src/components/interview/SaveAccountCTA.tsx` | 신규 생성 | 높음 |
+| `src/app/(main)/interview/page.tsx` | Server Component 전환 | 높음 |
+| `src/app/auth/callback/__tests__/route.test.ts` | 신규 생성 | 중간 |
+| `src/middleware.test.ts` | 신규 생성 | 중간 |
+| `services/lww/.ai.md` | 최신화 | 완료 후 |
+
+---
+
+## 알려진 제약사항
+
+- **공유 기기 시나리오**: User A 로그아웃 → User B 로그인 시 User A의 `anon_id` 쿠키가 남아 있으면 User B 계정에 User A의 익명 세션이 연결될 수 있음. RPC의 `user_id IS NULL` 가드로 부분 완화. 전면 해결은 Phase 2 (쿠키 로테이션) 과제.
+- **카카오 OAuth**: Supabase에서 Kakao provider 활성화 후 별도 Kakao Developers 앱 등록 필요.

--- a/docs/work/done/000179-lww-social-login/migrate.sql
+++ b/docs/work/done/000179-lww-social-login/migrate.sql
@@ -1,0 +1,95 @@
+-- LWW Phase 1 DB 마이그레이션
+-- Supabase SQL Editor에서 실행: https://supabase.com/dashboard/project/fcrwejqinsmyyqpisepv/sql/new
+
+-- ① interview_sessions
+create table if not exists interview_sessions (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid references auth.users(id) on delete set null,
+  anonymous_id    text not null,
+  job_category    text not null,
+  persona_id      uuid,
+  status          text not null default 'in_progress'
+                    check (status in ('in_progress', 'completed', 'abandoned')),
+  questions       jsonb not null default '[]',
+  answers         jsonb not null default '[]',
+  history         jsonb not null default '[]',
+  questions_queue jsonb not null default '[]',
+  report_id       uuid,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+alter table interview_sessions enable row level security;
+
+-- ② reports
+create table if not exists reports (
+  id             uuid primary key default gen_random_uuid(),
+  session_id     uuid not null references interview_sessions(id) on delete cascade,
+  user_id        uuid references auth.users(id) on delete set null,
+  anonymous_id   text not null,
+  status         text not null default 'processing'
+                   check (status in ('processing', 'completed', 'failed')),
+  total_score    integer,
+  axis_scores    jsonb,
+  axis_feedbacks jsonb,
+  summary        text,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now()
+);
+alter table reports enable row level security;
+
+-- ③ profiles
+create table if not exists profiles (
+  id                   uuid primary key references auth.users(id) on delete cascade,
+  name                 text,
+  avatar_url           text,
+  type                 text not null default 'jobseeker'
+                         check (type in ('jobseeker', 'professional', 'ai_persona')),
+  job_category         text,
+  prep_stage           text,
+  coins                integer not null default 0,
+  streak               integer not null default 0,
+  last_active_at       timestamptz,
+  onboarding_completed boolean not null default false,
+  verification_status  text not null default 'none'
+                         check (verification_status in (
+                           'none', 'email_verified', 'document_pending', 'document_verified'
+                         )),
+  verified_at          timestamptz,
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+alter table profiles enable row level security;
+
+create policy "read own profile"
+  on profiles for select to authenticated
+  using (id = auth.uid());
+
+create policy "update own profile"
+  on profiles for update to authenticated
+  using (id = auth.uid());
+
+create or replace function handle_new_user()
+returns trigger language plpgsql security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id) values (new.id) on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure handle_new_user();
+
+-- ④ migrate_anon_to_user RPC
+create or replace function migrate_anon_to_user(p_anon_id text, p_user_id uuid)
+returns void language plpgsql security definer as $$
+begin
+  update interview_sessions set user_id = p_user_id
+    where anonymous_id = p_anon_id and user_id is null;
+  update reports set user_id = p_user_id
+    where anonymous_id = p_anon_id and user_id is null;
+end;
+$$;

--- a/docs/work/done/000179-lww-social-login/oauth-setup.md
+++ b/docs/work/done/000179-lww-social-login/oauth-setup.md
@@ -1,0 +1,114 @@
+# LWW OAuth 설정 가이드
+
+> 작성: 2026-03-22
+> Supabase 프로젝트: `fcrwejqinsmyyqpisepv`
+
+---
+
+## 공통 개념
+
+LWW는 Supabase Auth를 통해 OAuth를 처리한다. OAuth 흐름은 다음과 같다:
+
+```
+브라우저 → Supabase Auth → 카카오/구글 → 다시 Supabase → /auth/callback (Next.js)
+```
+
+따라서 카카오/구글 개발자 콘솔의 **Redirect URI**는 Next.js 주소가 아니라 **Supabase 내부 콜백 URL**을 써야 한다:
+
+```
+https://fcrwejqinsmyyqpisepv.supabase.co/auth/v1/callback
+```
+
+---
+
+## 1. DB 마이그레이션
+
+**Supabase SQL Editor**: `https://supabase.com/dashboard/project/fcrwejqinsmyyqpisepv/sql/new`
+
+`migrate.sql` 파일 전체 복사 → 붙여넣기 → Run
+
+> ⚠️ `handle_new_user` 트리거 함수는 반드시 `set search_path = public` 포함해야 함.
+> 없으면 "relation profiles does not exist" 오류 발생.
+
+---
+
+## 2. 카카오 OAuth
+
+### 2-1. 카카오 개발자 콘솔 설정
+
+1. `https://developers.kakao.com` → 내 애플리케이션 → 애플리케이션 추가
+2. **앱 설정 → 플랫폼 → Web** → 사이트 도메인 추가:
+   ```
+   http://localhost:3000
+   https://your-production-domain.com
+   ```
+3. **제품 설정 → 카카오 로그인** → 활성화 ON
+4. **카카오 로그인 → Redirect URI** 추가:
+   ```
+   https://fcrwejqinsmyyqpisepv.supabase.co/auth/v1/callback
+   ```
+5. **카카오 로그인 → 보안** → Client Secret 코드 생성
+   > 보안 탭이 안 보이면 카카오 로그인 활성화 먼저 확인
+6. **앱 설정 → 앱 키** → REST API 키 복사
+
+### 2-2. Supabase에 등록
+
+`https://supabase.com/dashboard/project/fcrwejqinsmyyqpisepv/auth/providers` → Kakao
+
+| 항목 | 값 |
+|------|-----|
+| Client ID | 카카오 REST API 키 |
+| Client Secret | 카카오 보안 탭의 Client Secret 코드 |
+
+→ Save
+
+---
+
+## 3. 구글 OAuth
+
+### 3-1. Google Cloud Console 설정
+
+1. `https://console.cloud.google.com` → 프로젝트 선택 또는 생성
+2. **APIs & Services → Credentials → + CREATE CREDENTIALS → OAuth client ID**
+3. Application type: **Web application**
+4. **Authorized redirect URIs** 추가:
+   ```
+   https://fcrwejqinsmyyqpisepv.supabase.co/auth/v1/callback
+   ```
+5. 생성 후 **Client ID**, **Client Secret** (클라이언트 보안 비밀번호) 복사
+
+### 3-2. Supabase에 등록
+
+`https://supabase.com/dashboard/project/fcrwejqinsmyyqpisepv/auth/providers` → Google
+
+| 항목 | 값 |
+|------|-----|
+| Client ID | Google OAuth Client ID |
+| Client Secret | Google 클라이언트 보안 비밀번호 |
+
+→ Save
+
+---
+
+## 4. 이메일 인증 설정
+
+`https://supabase.com/dashboard/project/fcrwejqinsmyyqpisepv/auth/settings`
+
+- **Confirm email**: ON (프로덕션 필수)
+- 로컬 테스트 시 OFF 하면 이메일 확인 없이 즉시 로그인 가능
+
+---
+
+## 5. 트러블슈팅
+
+### "relation profiles does not exist"
+- `handle_new_user` 함수에 `set search_path = public` 누락
+- `migrate.sql`의 최신 버전으로 함수 재생성
+
+### "Client Secret Code is required" (Supabase Kakao 설정)
+- 카카오 보안 탭에서 Client Secret 생성 필수
+- 카카오 로그인 활성화 후 보안 탭 노출됨
+
+### OAuth 콜백 후 `/login?error=oauth` 리다이렉트
+- Supabase Auth Logs 확인: `https://supabase.com/dashboard/project/fcrwejqinsmyyqpisepv/auth/logs`
+- Redirect URI 불일치 여부 확인 (카카오/구글 콘솔과 Supabase URL 일치해야 함)

--- a/services/lww/.ai.md
+++ b/services/lww/.ai.md
@@ -1,6 +1,6 @@
 # services/lww/ — lww 서비스 (카카오톡 채팅 UI 모바일 AI 모의면접)
 
-> 최종 업데이트: 2026-03-19 (이슈 #116 MVP 프론트엔드 구현 + E2E 품질 검증 완료)
+> 최종 업데이트: 2026-03-21 (이슈 #179 Phase 1 — 소셜 로그인 + 이메일 가입/로그인 구현)
 > 관련 스펙: `docs/specs/lww/` | 기획서: `docs/whitepaper/lww/proposal.md`
 
 ## 목적
@@ -16,11 +16,17 @@
 | **Phase 1** | 2026-03-27 | 소셜 로그인, 자소서 업로드, 코인 시스템, 게임화 |
 | **Phase 2+3** | 2026-04-01 | 커뮤니티, 페르소나 마켓, 쪽지, 채용 매칭 |
 
-## 구현 현황 (MVP 완료, 이슈 #116)
+## 구현 현황
 
+### MVP (완료, 이슈 #116)
 **브랜드 컬러**: Teal #0D9488 (옵션 B 확정)
 **빌드**: ✅ 11개 라우트, tsc 0 errors
 **E2E 품질**: ✅ Playwright 자동화 10라운드 실행 → 3회 연속 PASS (디자이너/프론트/백엔드/UX 4인 전문가 패널 검토)
+
+### Phase 1 — 소셜 로그인 (이슈 #179, 2026-03-21)
+**인증 방식**: 카카오·구글 OAuth + 이메일 가입/로그인 (Supabase Auth)
+**아키텍처 원칙**: 익명 우선 — 미들웨어에서 비로그인 사용자 리다이렉트 절대 금지
+**익명→인증 마이그레이션**: 로그인 콜백에서 `migrate_anon_to_user` RPC 호출 (원자적 트랜잭션)
 **중요**: Tailwind v4에서 `bg-[--color-primary]` 임의값 문법이 포화 색상 변수에 적용 안 됨 → 하드코딩 `bg-[#0D9488]` 사용. `--color-background`, `--color-muted` 등 무채색 변수는 정상 동작.
 
 ### UI/UX 확정 사항 (E2E 검증 완료)
@@ -38,14 +44,18 @@
 ```
 / (main 그룹)          온보딩 슬라이더 → 재방문 시 /onboarding 리다이렉트
 /onboarding            직군(최대 3개) + 취준 단계 선택 → 면접 시작
-/interview             면접 히스토리 탭 (EmptyState or 카드 목록)
+/login                 소셜(카카오·구글) + 이메일 가입/로그인 (Phase 1)
+/interview             면접 히스토리 탭 (Server Component — Supabase DB 쿼리)
 /interview/[sessionId] 카카오톡 스타일 채팅 면접 UI
 /report/[sessionId]    결과 리포트 (점수 + 피드백 + 오브 미리보기)
 /resume                자소서 PDF 업로드 → 예상 질문
 
-/api/interview/start   POST: 면접 시작 (sessionId 생성)
+/auth/callback         GET: OAuth 코드 교환 + 익명 세션 마이그레이션 (Phase 1)
+/auth/confirm          GET: 이메일 확인 링크 처리 (token_hash) (Phase 1)
+
+/api/interview/start   POST: 면접 시작 (sessionId 생성, dual-write user_id)
 /api/interview/answer  POST: 답변 제출 → 다음 질문 반환
-/api/interview/end     POST: 리포트 동기 생성 (maxDuration=110)
+/api/interview/end     POST: 리포트 동기 생성 (maxDuration=110, dual-write user_id)
 /api/resume/questions  POST: PDF → 예상 질문
 ```
 
@@ -97,14 +107,35 @@ lww/
 
 ## 인증·DB·스토리지
 
-- **MVP**: 인증 없음 — `anonymousId`(로컬 UUID)로 세션 식별
-- **Phase 1 인증**: Supabase Auth (카카오·구글 OAuth)
-  - 클라이언트: `@supabase/ssr` createBrowserClient
-  - 서버: createServerClient + `middleware.ts` (`getUser()`로 세션 갱신 필수)
+### 인증 아키텍처 (Phase 1, 이슈 #179)
+
+**익명 우선 원칙**: LWW는 SIW/Seung과 달리 미들웨어에서 비로그인 사용자를 `/login`으로 리다이렉트하지 않는다.
+
+| 구성 요소 | 역할 |
+|-----------|------|
+| `middleware.ts` | rate limit → Supabase `getUser()` 세션 갱신 (리다이렉트 없음) |
+| `app/auth/callback/route.ts` | OAuth 코드 교환 + `migrate_anon_to_user` RPC |
+| `app/auth/confirm/route.ts` | 이메일 확인 링크 처리 (`verifyOtp`) |
+| `app/(main)/login/page.tsx` | 소셜(카카오·구글) + 이메일 탭 로그인 UI |
+| `components/interview/SaveAccountCTA.tsx` | 비로그인 면접 완료 후 로그인 유도 배너 |
+
+**익명→인증 마이그레이션**:
+1. OAuth 로그인 완료 → `/auth/callback` 호출
+2. `lww_anon_id` 쿠키 읽기
+3. `migrate_anon_to_user(p_anon_id, p_user_id)` RPC 실행 (Supabase SQL 트랜잭션)
+4. `interview_sessions` + `reports` 양쪽 `user_id` 원자적 업데이트
+
+**dual-write 패턴** (interview API 라우트):
+- `createClient()` + `getUser()` → `userId` 감지
+- 로그인이면 `user_id = auth.uid()`, 비로그인이면 `user_id = null`
+- `anonymous_id`는 항상 유지 (로그인 후에도 anon cookie 삭제 안 함)
+
+### DB
+
 - **DB**: Supabase PostgreSQL (스키마: `docs/specs/lww/dev_spec.md` §DB 스키마)
-  - MVP 테이블: `interview_sessions`, `reports`
-  - Phase 1 테이블: `profiles`, `coin_transactions`
-  - RLS 정책: 비로그인은 `anonymousId` 검증, 로그인은 `auth.uid()` 검증
+  - 테이블: `interview_sessions`, `reports`, `profiles`
+  - RLS 정책: 비로그인은 `anonymous_id` 검증, 로그인은 `auth.uid()` 검증
+  - Supabase RPC: `migrate_anon_to_user(p_anon_id text, p_user_id uuid)` — 원자적 마이그레이션
 - **스토리지**: Supabase Storage — 버킷명 `SUPABASE_STORAGE_BUCKET` 환경변수 (하드코딩 금지)
 - **보안**: `SUPABASE_SERVICE_ROLE_KEY`는 서버 전용 — `NEXT_PUBLIC_` 절대 금지
 

--- a/services/lww/src/app/(interview)/report/[sessionId]/page.tsx
+++ b/services/lww/src/app/(interview)/report/[sessionId]/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { TopBar } from "@/components/layout/TopBar";
 import type { ReportResponse } from "@/lib/types";
+import { SaveAccountCTA } from "@/components/interview/SaveAccountCTA";
 
 export default function ReportPage() {
   const params = useParams<{ sessionId: string }>();
@@ -126,6 +127,9 @@ export default function ReportPage() {
           <OrbPreviewCard />
         </div>
       </main>
+
+      {/* 비로그인 로그인/가입 유도 CTA */}
+      <SaveAccountCTA sessionId={sessionId} />
 
       {/* 하단 CTA */}
       <div

--- a/services/lww/src/app/(main)/interview/page.tsx
+++ b/services/lww/src/app/(main)/interview/page.tsx
@@ -1,6 +1,5 @@
-"use client";
-
-import { useEffect, useState } from "react";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
 import { Mic } from "lucide-react";
 import { EmptyState } from "@/components/common/EmptyState";
 import { InterviewHistoryCard } from "@/components/interview/InterviewHistoryCard";
@@ -13,16 +12,49 @@ interface InterviewRecord {
   score: number;
 }
 
-export default function InterviewPage() {
-  const [history, setHistory] = useState<InterviewRecord[]>([]);
+type SessionRow = { id: string; created_at: string; job_category: string; reports: { total_score: number }[] | null };
 
-  useEffect(() => {
-    // localStorage에서 면접 기록 읽기 (MVP)
-    try {
-      const stored = localStorage.getItem("interview_history");
-      if (stored) setHistory(JSON.parse(stored));
-    } catch {}
-  }, []);
+function toHistory(data: SessionRow[] | null): InterviewRecord[] {
+  return (data ?? []).map(s => ({
+    id: s.id,
+    date: new Date(s.created_at).toLocaleDateString("ko-KR"),
+    jobCategories: (s.job_category as string).split(", "),
+    score: s.reports?.[0]?.total_score ?? 0,
+  }));
+}
+
+export default async function InterviewPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  let history: InterviewRecord[] = [];
+
+  if (user) {
+    // 로그인: user_id 기준 쿼리
+    const { data } = await supabase
+      .from("interview_sessions")
+      .select("id, created_at, job_category, reports(total_score)")
+      .eq("user_id", user.id)
+      .eq("status", "completed")
+      .order("created_at", { ascending: false });
+
+    history = toHistory(data as SessionRow[]);
+  } else {
+    // 비로그인: anon_id 기준 (service client, RLS 우회)
+    const cookieStore = await cookies();
+    const anonId = cookieStore.get("lww_anon_id")?.value;
+    if (anonId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(anonId)) {
+      const serviceClient = createServiceClient();
+      const { data } = await serviceClient
+        .from("interview_sessions")
+        .select("id, created_at, job_category, reports(total_score)")
+        .eq("anonymous_id", anonId)
+        .eq("status", "completed")
+        .order("created_at", { ascending: false });
+
+      history = toHistory(data as SessionRow[]);
+    }
+  }
 
   return (
     <div className="flex flex-col min-h-[100dvh] bg-gray-50">
@@ -60,14 +92,6 @@ export default function InterviewPage() {
             {history.map(record => (
               <InterviewHistoryCard key={record.id} record={record} />
             ))}
-            {history.length < 3 && (
-              <div className="mt-4 flex flex-col items-center gap-2 py-6 opacity-60">
-                <span className="text-2xl">💪</span>
-                <p className="text-xs text-gray-400 text-center leading-relaxed">
-                  면접을 더 많이 쌓을수록<br />성장이 눈에 보여요!
-                </p>
-              </div>
-            )}
           </div>
         )}
       </main>

--- a/services/lww/src/app/(main)/login/page.tsx
+++ b/services/lww/src/app/(main)/login/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/browser";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+
+function LoginContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") ?? "/";
+  const hasError = searchParams.get("error") === "oauth" || searchParams.get("error") === "invalid_link";
+
+  const [tab, setTab] = useState<"social" | "email">("social");
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const safeNext = next.startsWith("/") && !next.startsWith("//") ? next : "/";
+  const redirectTo = `${typeof window !== "undefined" ? window.location.origin : ""}/auth/callback?next=${encodeURIComponent(safeNext)}`;
+
+  // createClient()는 핸들러 내부에서만 호출 (SSR 프리렌더링 시 env var 없음)
+  const handleKakao = async () => {
+    setLoading(true);
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "kakao",
+      options: { redirectTo },
+    });
+  };
+
+  const handleGoogle = async () => {
+    setLoading(true);
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo },
+    });
+  };
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage("");
+    const supabase = createClient();
+
+    try {
+      if (mode === "signin") {
+        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error) {
+          setMessage(error.message === "Invalid login credentials" ? "이메일 또는 비밀번호가 올바르지 않습니다." : error.message);
+          return;
+        }
+        router.push(safeNext);
+      } else {
+        const { error } = await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: `${typeof window !== "undefined" ? window.location.origin : ""}/auth/confirm?next=${encodeURIComponent(safeNext)}`,
+          },
+        });
+        if (error) {
+          setMessage(error.message);
+          return;
+        }
+        setMessage("확인 이메일을 발송했습니다. 받은편지함을 확인해주세요.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-[calc(100dvh-56px-64px)] bg-gray-50 px-5 py-8">
+      <div className="flex flex-col gap-2 mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">로그인 / 가입</h1>
+        <p className="text-sm text-gray-500">면접 결과를 영구 저장하고 히스토리를 확인하세요</p>
+      </div>
+
+      {hasError && (
+        <div className="mb-4 px-4 py-3 rounded-xl bg-red-50 text-red-600 text-sm">
+          로그인 중 오류가 발생했습니다. 다시 시도해주세요.
+        </div>
+      )}
+
+      {/* 탭 */}
+      <div className="flex gap-1 mb-6 bg-gray-100 rounded-xl p-1">
+        <button
+          onClick={() => setTab("social")}
+          className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-all ${
+            tab === "social" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500"
+          }`}
+        >
+          소셜 로그인
+        </button>
+        <button
+          onClick={() => setTab("email")}
+          className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-all ${
+            tab === "email" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500"
+          }`}
+        >
+          이메일
+        </button>
+      </div>
+
+      {tab === "social" ? (
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={handleKakao}
+            disabled={loading}
+            className="w-full h-12 rounded-xl font-semibold text-gray-900 flex items-center justify-center gap-2 disabled:opacity-60"
+            style={{ backgroundColor: "#FEE500" }}
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 3C6.477 3 2 6.582 2 11c0 2.82 1.674 5.3 4.197 6.865L5.09 21.34a.375.375 0 0 0 .54.413l4.117-2.72C10.243 19.01 11.11 19.1 12 19.1c5.523 0 10-3.582 10-8.05S17.523 3 12 3z"/>
+            </svg>
+            카카오로 계속하기
+          </button>
+          <button
+            onClick={handleGoogle}
+            disabled={loading}
+            className="w-full h-12 rounded-xl font-semibold text-gray-700 bg-white border border-gray-200 flex items-center justify-center gap-2 disabled:opacity-60"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            구글로 계속하기
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* 로그인/가입 토글 */}
+          <div className="flex gap-1 bg-gray-100 rounded-xl p-1">
+            <button
+              onClick={() => { setMode("signin"); setMessage(""); }}
+              className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-all ${
+                mode === "signin" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500"
+              }`}
+            >
+              로그인
+            </button>
+            <button
+              onClick={() => { setMode("signup"); setMessage(""); }}
+              className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-all ${
+                mode === "signup" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500"
+              }`}
+            >
+              가입하기
+            </button>
+          </div>
+
+          <form onSubmit={handleEmailSubmit} className="flex flex-col gap-3">
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="이메일"
+              required
+              className="w-full h-12 px-4 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[#0D9488]"
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="비밀번호 (8자 이상)"
+              required
+              minLength={8}
+              className="w-full h-12 px-4 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[#0D9488]"
+            />
+
+            {message && (
+              <p className={`text-sm px-1 ${message.includes("발송") ? "text-[#0D9488]" : "text-red-500"}`}>
+                {message}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full h-12 rounded-xl font-semibold text-white disabled:opacity-60"
+              style={{ backgroundColor: "#0D9488" }}
+            >
+              {loading ? "처리 중..." : mode === "signin" ? "로그인" : "가입하기"}
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
+  );
+}

--- a/services/lww/src/app/api/interview/__tests__/start.test.ts
+++ b/services/lww/src/app/api/interview/__tests__/start.test.ts
@@ -5,6 +5,32 @@ vi.mock("@/lib/engine-client", () => ({
   engineFetch: vi.fn(),
 }));
 
+// anon-cookie mock (cookies() 호출이 테스트 환경에서 동작하지 않음)
+vi.mock("@/lib/anon-cookie", () => ({
+  getOrCreateAnonId: vi.fn().mockResolvedValue({ anonymousId: "test-anon-uuid", isNew: false }),
+  setAnonCookie: vi.fn((response: Response) => response),
+  getAnonId: vi.fn().mockResolvedValue("test-anon-uuid"),
+}));
+
+// supabase/server mock (createClient, createServiceClient)
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    }),
+  }),
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    },
+  }),
+}));
+
 import { engineFetch } from "@/lib/engine-client";
 import { POST } from "../start/route";
 

--- a/services/lww/src/app/api/interview/answer/route.ts
+++ b/services/lww/src/app/api/interview/answer/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { engineFetch } from "@/lib/engine-client";
 import { getAnonId } from "@/lib/anon-cookie";
 import { createServiceClient } from "@/lib/supabase/server";
+import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
 
 export const runtime = "nodejs";
 
@@ -75,6 +76,7 @@ export async function POST(request: Request) {
     if (!anonymousId) {
       return Response.json({ message: "세션이 유효하지 않습니다." }, { status: 401 });
     }
+    const userId = await getCurrentUserId();
     const supabase = createServiceClient();
     const newHistoryItem = {
       question: currentQuestion,

--- a/services/lww/src/app/api/interview/end/route.ts
+++ b/services/lww/src/app/api/interview/end/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { engineFetch } from "@/lib/engine-client";
 import { getAnonId } from "@/lib/anon-cookie";
 import { createServiceClient } from "@/lib/supabase/server";
+import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
 
 export const runtime = "nodejs";
 export const maxDuration = 110;
@@ -55,12 +56,14 @@ export async function POST(request: Request) {
     if (!anonymousId) {
       return Response.json({ message: "세션이 유효하지 않습니다." }, { status: 401 });
     }
+    const userId = await getCurrentUserId();
     const supabase = createServiceClient();
     const { data: reportRow, error: reportErr } = await supabase
       .from("reports")
       .insert({
         session_id: sessionId,
         anonymous_id: anonymousId,
+        user_id: userId,
         status: "completed",
         total_score: report.totalScore,
         axis_scores: report.axisScores,

--- a/services/lww/src/app/api/interview/start/route.ts
+++ b/services/lww/src/app/api/interview/start/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { engineFetch } from "@/lib/engine-client";
 import { getOrCreateAnonId, setAnonCookie } from "@/lib/anon-cookie";
 import { createServiceClient } from "@/lib/supabase/server";
+import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
 
 export const runtime = "nodejs";
 
@@ -43,10 +44,12 @@ export async function POST(request: Request) {
     const data = await resp.json();
     // MVP: 5문항 제한 (첫 질문 1 + 큐 4)
     const { anonymousId, isNew } = await getOrCreateAnonId();
+    const userId = await getCurrentUserId();
     const supabase = createServiceClient();
     const { error: dbError } = await supabase.from("interview_sessions").insert({
       id: sessionId,
       anonymous_id: anonymousId,
+      user_id: userId,        // ← 추가 (로그인이면 auth.uid(), 아니면 null)
       job_category: jobCategories.join(", "),
       questions: [data.firstQuestion, ...(data.questionsQueue ?? []).slice(0, 4)],
       history: [],

--- a/services/lww/src/app/auth/callback/__tests__/route.test.ts
+++ b/services/lww/src/app/auth/callback/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock은 파일 최상단으로 호이스팅됨 — import보다 먼저 선언
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
+
+const mockCreateClient = vi.mocked(createClient);
+const mockCreateServiceClient = vi.mocked(createServiceClient);
+const mockCookies = vi.mocked(cookies);
+
+function makeRequest(url: string) {
+  return new NextRequest(url);
+}
+
+describe("GET /auth/callback", () => {
+  const origin = "http://localhost:3000";
+  const mockExchangeCodeForSession = vi.fn();
+  const mockRpc = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateClient.mockResolvedValue({
+      auth: { exchangeCodeForSession: mockExchangeCodeForSession },
+    } as never);
+    mockCreateServiceClient.mockReturnValue({
+      rpc: mockRpc,
+    } as never);
+    mockCookies.mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: "test-anon-id-12345" }),
+    } as never);
+  });
+
+  it("code 없으면 /login?error=oauth 리다이렉트", async () => {
+    const req = makeRequest(`${origin}/auth/callback`);
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(`${origin}/login?error=oauth`);
+  });
+
+  it("exchangeCodeForSession 실패 시 /login?error=oauth 리다이렉트", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      data: { user: null },
+      error: new Error("invalid"),
+    });
+    const req = makeRequest(`${origin}/auth/callback?code=bad-code`);
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(`${origin}/login?error=oauth`);
+  });
+
+  it("성공 + anonId 있으면 migrate_anon_to_user RPC 호출 후 / 리다이렉트", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ error: null });
+
+    const req = makeRequest(`${origin}/auth/callback?code=valid-code`);
+    const res = await GET(req);
+
+    expect(mockRpc).toHaveBeenCalledWith("migrate_anon_to_user", {
+      p_anon_id: "test-anon-id-12345",
+      p_user_id: "user-123",
+    });
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(`${origin}/`);
+  });
+
+  it("next 파라미터로 safeRedirect", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ error: null });
+
+    const req = makeRequest(`${origin}/auth/callback?code=valid-code&next=%2Freport%2Fabc`);
+    const res = await GET(req);
+    expect(res.headers.get("location")).toBe(`${origin}/report/abc`);
+  });
+
+  it("Open Redirect 방어: next=//evil.com → / 리다이렉트", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ error: null });
+
+    const req = makeRequest(`${origin}/auth/callback?code=valid-code&next=%2F%2Fevil.com`);
+    const res = await GET(req);
+    expect(res.headers.get("location")).toBe(`${origin}/`);
+  });
+
+  it("마이그레이션 RPC 실패해도 로그인은 성공", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ error: new Error("rpc failed") });
+
+    const req = makeRequest(`${origin}/auth/callback?code=valid-code`);
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(`${origin}/`);
+  });
+});

--- a/services/lww/src/app/auth/callback/route.ts
+++ b/services/lww/src/app/auth/callback/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  // Open Redirect 방어
+  const safeRedirect = next.startsWith("/") && !next.startsWith("//") ? next : "/";
+
+  if (!code) {
+    return NextResponse.redirect(`${origin}/login?error=oauth`);
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error || !data.user) {
+    return NextResponse.redirect(`${origin}/login?error=oauth`);
+  }
+
+  // 익명 세션 마이그레이션 (RPC — 원자적 트랜잭션)
+  const cookieStore = await cookies();
+  const anonId = cookieStore.get("lww_anon_id")?.value;
+  if (anonId) {
+    const serviceClient = createServiceClient();
+    const { error: migrateError } = await serviceClient.rpc("migrate_anon_to_user", {
+      p_anon_id: anonId,
+      p_user_id: data.user.id,
+    });
+    if (migrateError) {
+      // 마이그레이션 실패는 치명적 오류가 아님 — 로그만 기록
+      console.error("[auth/callback] 세션 마이그레이션 실패:", migrateError);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}${safeRedirect}`);
+}

--- a/services/lww/src/app/auth/confirm/route.ts
+++ b/services/lww/src/app/auth/confirm/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { EmailOtpType } from "@supabase/supabase-js";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const token_hash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+  const next = searchParams.get("next") ?? "/";
+
+  // Open Redirect 방어
+  const safeRedirect = next.startsWith("/") && !next.startsWith("//") ? next : "/";
+
+  if (!token_hash || !type) {
+    return NextResponse.redirect(`${origin}/login?error=invalid_link`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.verifyOtp({ token_hash, type });
+
+  if (error) {
+    return NextResponse.redirect(`${origin}/login?error=invalid_link`);
+  }
+
+  return NextResponse.redirect(`${origin}${safeRedirect}`);
+}

--- a/services/lww/src/components/interview/SaveAccountCTA.tsx
+++ b/services/lww/src/components/interview/SaveAccountCTA.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/browser";
+import Link from "next/link";
+
+interface SaveAccountCTAProps {
+  sessionId: string;
+}
+
+export function SaveAccountCTA({ sessionId }: SaveAccountCTAProps) {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      setIsLoggedIn(!!data.user);
+    });
+  }, []);
+
+  // 로딩 중이거나 로그인 상태면 표시 안 함
+  if (isLoggedIn !== false) return null;
+
+  return (
+    <div className="mx-5 my-4 p-4 rounded-2xl border border-[#0D9488]/20 bg-[#0D9488]/5">
+      <div className="flex flex-col gap-3">
+        <div>
+          <p className="text-sm font-semibold text-gray-900">결과를 영구 저장하려면 로그인하세요</p>
+          <p className="text-xs text-gray-500 mt-0.5">로그인하면 이 면접 결과가 내 계정에 저장됩니다</p>
+        </div>
+        <Link
+          href={`/login?next=/report/${sessionId}`}
+          className="w-full h-10 rounded-xl text-sm font-semibold text-white flex items-center justify-center"
+          style={{ backgroundColor: "#0D9488" }}
+        >
+          로그인 / 가입하기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/services/lww/src/lib/supabase/get-current-user-id.ts
+++ b/services/lww/src/lib/supabase/get-current-user-id.ts
@@ -1,0 +1,15 @@
+import { createClient } from "./server";
+
+/**
+ * 현재 요청의 로그인 사용자 ID를 반환한다.
+ * 비로그인이거나 인증 오류 시 null 반환 — 익명 기능은 정상 동작 유지.
+ */
+export async function getCurrentUserId(): Promise<string | null> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    return user?.id ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/services/lww/src/middleware.ts
+++ b/services/lww/src/middleware.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
 
-// In-memory rate limiter (개발/MVP 용)
-// Production: Upstash Redis 교체 권장
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-
-const RATE_LIMIT = 10; // requests per window
-const WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT = 10;
+const WINDOW_MS = 60 * 1000;
 
 function getClientIP(request: NextRequest): string {
   return (
@@ -15,15 +13,14 @@ function getClientIP(request: NextRequest): string {
   );
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Rate limit only API routes
+  // 1. Rate limit (API routes only)
   if (pathname.startsWith("/api/interview/") || pathname.startsWith("/api/resume/")) {
     const ip = getClientIP(request);
     const now = Date.now();
     const key = `${ip}:${pathname.split("/").slice(0, 4).join("/")}`;
-
     const current = rateLimitMap.get(key);
     if (!current || now > current.resetTime) {
       rateLimitMap.set(key, { count: 1, resetTime: now + WINDOW_MS });
@@ -33,7 +30,7 @@ export function middleware(request: NextRequest) {
         {
           status: 429,
           headers: {
-            "Retry-After": String(Math.ceil((current.resetTime - now) / 1000)),
+            "Retry-After": String(Math.ceil((current.resetTime - Date.now()) / 1000)),
           },
         }
       );
@@ -42,9 +39,38 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next();
+  // 2. Supabase 세션 갱신 (전체 경로, LWW는 절대 리다이렉트 금지)
+  let supabaseResponse = NextResponse.next({ request });
+  try {
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+            supabaseResponse = NextResponse.next({ request });
+            cookiesToSet.forEach(({ name, value, options }) =>
+              supabaseResponse.cookies.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
+    // 세션 갱신 목적만 — 결과 무시, 익명 사용자 리다이렉트 절대 금지
+    await supabase.auth.getUser();
+  } catch {
+    // auth 인프라 장애 시에도 익명 기능은 정상 동작해야 함
+  }
+
+  return supabaseResponse;
 }
 
 export const config = {
-  matcher: ["/api/interview/:path*", "/api/resume/:path*"],
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
 };

--- a/services/lww/tests/e2e/anon-save-cta.spec.ts
+++ b/services/lww/tests/e2e/anon-save-cta.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "@playwright/test";
+
+const FAKE_SESSION_ID = "e2e-anon-save-cta-test-0000-000000000001";
+const FAKE_REPORT_ID = "e2e-anon-report-0000-000000000001";
+
+test.describe("비로그인 면접 완료 → 로그인/가입 유도 CTA", () => {
+  test.beforeEach(async ({ page }) => {
+    // ── API mock ──────────────────────────────────────────────
+    // /api/interview/start
+    await page.route("**/api/interview/start", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId: FAKE_SESSION_ID,
+          firstQuestion: { question: "자기소개를 해주세요.", persona: "hr" },
+          questionsQueue: [],
+        }),
+      });
+    });
+
+    // /api/interview/answer — 4번째 답변에서 sessionComplete: true
+    let answerCount = 0;
+    await page.route("**/api/interview/answer", async (route) => {
+      answerCount++;
+      const isLast = answerCount >= 4;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          nextQuestion: isLast ? null : { question: `질문 ${answerCount + 1}`, persona: "hr" },
+          updatedQueue: [],
+          sessionComplete: isLast,
+        }),
+      });
+    });
+
+    // /api/interview/end — report 객체를 반환해야 자동 리다이렉트 동작
+    await page.route("**/api/interview/end", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          report: {
+            totalScore: 72,
+            axisFeedbacks: [],
+            summary: "E2E 테스트 리포트입니다.",
+          },
+        }),
+      });
+    });
+
+    // report API (리포트 페이지에서 호출하는 경우 대비)
+    await page.route("**/api/report/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          totalScore: 72,
+          axisFeedbacks: [],
+          summary: "E2E 테스트 리포트입니다.",
+        }),
+      });
+    });
+  });
+
+  test("면접 완료 후 리포트 페이지에서 로그인 CTA 표시", async ({ page }) => {
+    // 1. 온보딩 스킵
+    await page.addInitScript(() => {
+      window.localStorage.setItem("onboarding_done", "true");
+    });
+
+    // 2. 직군 선택 → 면접 시작
+    await page.goto("/onboarding");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator("button").filter({ hasText: "IT/개발" }).click();
+    await page.locator("button").filter({ hasText: "면접 준비 중" }).click();
+
+    const startBtn = page.locator("button").filter({ hasText: "면접 시작" });
+    await expect(startBtn).toBeEnabled({ timeout: 5000 });
+    await startBtn.click();
+
+    // 3. 면접 화면 진입
+    await page.waitForURL(`**/interview/${FAKE_SESSION_ID}`, { timeout: 15000 });
+    await expect(page.locator("text=자기소개를 해주세요.")).toBeVisible({ timeout: 10000 });
+
+    // 4. 답변 4번 제출 → 4번째에서 sessionComplete: true → 자동 리다이렉트
+    const textarea = page.locator("textarea");
+    for (let i = 0; i < 4; i++) {
+      await expect(textarea).toBeEnabled({ timeout: 10000 });
+      await textarea.click();
+      await textarea.fill(`테스트 답변 ${i + 1}입니다. 충분한 내용을 작성합니다.`);
+      await textarea.press("Enter");
+      if (i < 3) {
+        // 다음 질문 렌더링 대기 (마지막 답변 전까지)
+        await page.waitForTimeout(500);
+      }
+    }
+
+    // 5. endInterview() 자동 리다이렉트 대기
+    await page.waitForURL(`**/report/${FAKE_SESSION_ID}`, { timeout: 15000 });
+
+    // 6. 비로그인 상태 → 로그인/가입 CTA 표시 확인
+    await expect(
+      page.locator("text=결과를 영구 저장하려면 로그인하세요")
+    ).toBeVisible({ timeout: 10000 });
+
+    // 7. CTA 링크가 /login 으로 향하는지 확인
+    const loginLink = page.locator("a[href*='/login']");
+    await expect(loginLink.first()).toBeVisible();
+  });
+
+  test("리포트 페이지 직접 접근 시 비로그인 CTA 표시", async ({ page }) => {
+    // sessionStorage에 리포트 데이터 주입 (Client Component가 읽는 키)
+    await page.addInitScript((sessionId) => {
+      window.sessionStorage.setItem(`report_${sessionId}`, JSON.stringify({
+        totalScore: 75,
+        axisFeedbacks: [],
+        summary: "테스트 리포트입니다.",
+      }));
+    }, FAKE_SESSION_ID);
+
+    await page.goto(`/report/${FAKE_SESSION_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    // 비로그인 상태 → SaveAccountCTA 렌더링 확인
+    await expect(
+      page.locator("text=결과를 영구 저장하려면 로그인하세요")
+    ).toBeVisible({ timeout: 5000 });
+
+    // 로그인 링크가 올바른 next 파라미터 포함하는지 확인
+    const loginLink = page.locator(`a[href*='/login?next=/report/${FAKE_SESSION_ID}']`);
+    await expect(loginLink).toBeVisible();
+  });
+});

--- a/services/lww/tests/e2e/auth-flow.spec.ts
+++ b/services/lww/tests/e2e/auth-flow.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+
+// ──────────────────────────────────────────────
+// 로그인 페이지 UI
+// ──────────────────────────────────────────────
+test.describe("로그인 페이지", () => {
+  test("소셜 탭 기본 렌더링", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.locator("h1")).toContainText("로그인 / 가입");
+    await expect(page.locator("text=카카오로 계속하기")).toBeVisible();
+    await expect(page.locator("text=구글로 계속하기")).toBeVisible();
+  });
+
+  test("이메일 탭 전환 시 폼 표시", async ({ page }) => {
+    await page.goto("/login");
+    await page.click("button:has-text('이메일')");
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toContainText("로그인");
+  });
+
+  test("이메일 탭 - 가입하기 토글", async ({ page }) => {
+    await page.goto("/login");
+    await page.click("button:has-text('이메일')");
+    // 로그인/가입 토글 버튼 클릭
+    await page.locator(".bg-gray-100 button:has-text('가입하기')").click();
+    await expect(page.locator('button[type="submit"]')).toContainText("가입하기");
+  });
+
+  test("?error=oauth 시 에러 배너 표시", async ({ page }) => {
+    await page.goto("/login?error=oauth");
+    await expect(
+      page.locator("text=로그인 중 오류가 발생했습니다")
+    ).toBeVisible();
+  });
+
+  test("?error=invalid_link 시 에러 배너 표시", async ({ page }) => {
+    await page.goto("/login?error=invalid_link");
+    await expect(
+      page.locator("text=로그인 중 오류가 발생했습니다")
+    ).toBeVisible();
+  });
+
+  test("소셜 탭으로 돌아오면 에러 배너 유지", async ({ page }) => {
+    await page.goto("/login?error=oauth");
+    // 소셜 탭 버튼 클릭해도 에러 배너는 유지
+    await page.click("button:has-text('소셜 로그인')");
+    await expect(
+      page.locator("text=로그인 중 오류가 발생했습니다")
+    ).toBeVisible();
+  });
+});
+
+// ──────────────────────────────────────────────
+// Open Redirect 방어
+// ──────────────────────────────────────────────
+test.describe("Open Redirect 방어 (/auth/callback)", () => {
+  test("next=//evil.com → / 로 리다이렉트", async ({ page }) => {
+    // code 없이 호출 → /login?error=oauth (code 없으면 콜백이 에러 처리)
+    // open redirect 방어는 코드에서 처리하므로 로직 확인
+    await page.goto("/auth/callback?code=invalid&next=%2F%2Fevil.com");
+    // Supabase exchangeCodeForSession 실패 → /login?error=oauth
+    await page.waitForURL(/\/login/, { timeout: 10000 });
+    expect(page.url()).not.toContain("evil.com");
+  });
+
+  test("code 없으면 /login?error=oauth 리다이렉트", async ({ page }) => {
+    await page.goto("/auth/callback");
+    await page.waitForURL(/\/login\?error=oauth/, { timeout: 10000 });
+    await expect(
+      page.locator("text=로그인 중 오류가 발생했습니다")
+    ).toBeVisible();
+  });
+});
+
+// ──────────────────────────────────────────────
+// 비로그인 익명 흐름 — SaveAccountCTA
+// ──────────────────────────────────────────────
+test.describe("비로그인 SaveAccountCTA", () => {
+  test("리포트 페이지 접근 시 로그인 CTA 링크 확인", async ({ page }) => {
+    // 존재하지 않는 sessionId로 접근해도 CTA가 렌더링되는지 확인
+    // (페이지가 404가 아닌 정상 렌더링 + CTA 표시)
+    const fakeSessionId = "00000000-0000-0000-0000-000000000001";
+    await page.goto(`/report/${fakeSessionId}`);
+
+    // CTA가 있으면 로그인 링크가 올바른지 확인
+    const ctaLink = page.locator(`a[href*="/login?next=/report/${fakeSessionId}"]`);
+    const ctaCount = await ctaLink.count();
+    if (ctaCount > 0) {
+      await expect(ctaLink.first()).toBeVisible();
+    }
+  });
+});
+
+// ──────────────────────────────────────────────
+// 미들웨어 — 비로그인 사용자 리다이렉트 없음
+// ──────────────────────────────────────────────
+test.describe("익명 우선 원칙 — 미들웨어 리다이렉트 없음", () => {
+  test("비로그인 상태로 / 접근 가능", async ({ page }) => {
+    await page.goto("/");
+    // /login으로 리다이렉트되면 안 됨
+    await page.waitForLoadState("networkidle");
+    expect(page.url()).not.toContain("/login");
+  });
+
+  test("비로그인 상태로 /onboarding 접근 가능", async ({ page }) => {
+    await page.goto("/onboarding");
+    await page.waitForLoadState("networkidle");
+    expect(page.url()).not.toContain("/login");
+  });
+
+  test("비로그인 상태로 /interview 접근 가능", async ({ page }) => {
+    await page.goto("/interview");
+    await page.waitForLoadState("networkidle");
+    expect(page.url()).not.toContain("/login");
+  });
+});


### PR DESCRIPTION
## 이슈 배경

MVP(#116) 완료 후 Phase 1 첫 기능. 현재 비로그인 면접 완료 시 결과가 로컬에만 저장되어 재방문 시 유실된다. 카카오·구글·이메일 소셜 로그인으로 "선 체험 후 가입" 루프를 완성하고, 익명 면접 세션을 로그인 계정에 원자적으로 이전한다.

## 완료 기준 (AC)

- [x] 카카오·구글 OAuth 로그인/로그아웃 작동 (콜백 처리 포함)
- [x] 이메일 가입/로그인 작동 (이메일 확인 링크 포함)
- [x] 로그인 후 면접 세션이 해당 사용자 계정(`auth.uid()`)에 연결 저장
- [x] 비로그인 상태로 면접 완료 시 "저장하려면 로그인" CTA 표시
- [x] `middleware.ts`에서 Supabase 세션 자동 갱신 처리 (`getUser()`)
- [x] 히스토리 탭(`/interview`)에서 내 면접 세션 목록 표시
- [x] `profiles` 테이블 + RLS 마이그레이션 완료

## 작업 내역

- **middleware.ts**: rate limiter + Supabase `getUser()` 세션 갱신 병합. 익명 우선 원칙 — 비로그인 리다이렉트 절대 금지
- **app/auth/callback/route.ts** (신규): OAuth 코드 교환 + Open Redirect 방어 + `migrate_anon_to_user` RPC로 익명 세션 원자적 이전
- **app/auth/confirm/route.ts** (신규): 이메일 확인 링크 처리 (`verifyOtp`)
- **app/(main)/login/page.tsx** (신규): 소셜(카카오·구글) + 이메일 탭 전환 로그인 UI
- **interview API routes**: `getCurrentUserId()` 헬퍼로 dual-write — 로그인이면 `user_id = auth.uid()`, 비로그인이면 `null`
- **SaveAccountCTA.tsx** (신규): 리포트 페이지 비로그인 감지 → 로그인 유도 배너
- **interview/page.tsx**: Client → Server Component 전환, DB 쿼리 (로그인/익명 분기)
- **E2E 테스트**: `auth-flow.spec.ts` 12/12, `anon-save-cta.spec.ts` 2/2 pass
- **DB**: `profiles`, `migrate_anon_to_user` RPC, `handle_new_user` 트리거 (Supabase Dashboard 수동 실행)

Closes #179