### PR TITLE
fix: TypeScript 빌드 에러 수정 — dashboard implicit any · Prisma.InputJsonValue (#208)

### DIFF
--- a/docs/work/done/000208-ts-build-fix/00_issue.md
+++ b/docs/work/done/000208-ts-build-fix/00_issue.md
@@ -1,0 +1,49 @@
+# fix: [seung] TypeScript 빌드 에러 수정 — dashboard implicit any · Prisma.InputJsonValue
+
+## 사용자 관점 목표
+
+빌드 에러 없이 CI가 통과한다.
+
+## 배경
+
+`npm run build` 시 두 가지 타입 에러 발생. #171, #157에서 도입된 기존 코드 문제이며 #204와는 무관하다.
+
+## 완료 기준
+
+- [x] `src/app/api/dashboard/route.ts` implicit any 제거 (`let resumes` 타입 추론 실패)
+- [x] `src/app/api/resume/feedback/route.ts` `Prisma.InputJsonValue` 타입 참조 오류 수정
+- [x] `npx tsc --noEmit` 에러 0건
+
+## 에러 상세
+
+```
+src/app/api/dashboard/route.ts(30,31): error TS7006: Parameter 'resume' implicitly has an 'any' type.
+src/app/api/resume/feedback/route.ts(101,47): error TS2694: Namespace 'Prisma' has no exported member 'InputJsonValue'.
+```
+
+## 원인
+
+- `dashboard/route.ts`: `let resumes`를 try 블록 밖에서 타입 없이 선언 → Prisma 반환값 추론 불가
+- `resume/feedback/route.ts`: 설치된 Prisma client 버전에 `InputJsonValue` export 없음
+
+## 수정 방향 (참고)
+
+- `dashboard/route.ts`: `let resumes` → try 블록 안에서 `const resumes = await prisma...`로 이동
+- `resume/feedback/route.ts`: `Prisma.InputJsonValue` → `Prisma.JsonValue` 또는 `object`로 교체
+
+**작업 위치:** `services/seung`
+
+---
+
+## 작업 내역
+
+### `services/seung/src/app/api/dashboard/route.ts`
+
+`let resumes`를 타입 없이 선언하면 try 블록 안에서 Prisma가 반환값을 할당해도 TS가 이후 `.map((resume) => ...)` 콜백 파라미터를 추론할 수 없어 implicit any 에러가 발생했다.
+
+`Prisma.ResumeGetPayload<{ include: { sessions: { include: { report: true } } } }>` 기반의 `ResumeWithSessions` 타입 alias를 선언하고 `let resumes: ResumeWithSessions[]`로 어노테이션했다. Prisma의 관계 포함 쿼리 결과를 정확히 표현하는 타입이므로 런타임 동작 변경 없이 에러를 제거했다.
+
+### `services/seung/src/app/api/resume/feedback/route.ts`
+
+`Prisma.InputJsonValue`는 Prisma v6에서 export되지 않아 TS2694 에러가 발생했다. `data as object`로 교체했다. 이미 line 92–95의 가드에서 `data`가 non-null 일반 객체임을 확인하므로 런타임 안전성은 유지된다. 또한 타입 교체로 인해 불필요해진 `import { Prisma } from '@prisma/client'`를 제거했다.
+

--- a/docs/work/done/000208-ts-build-fix/01_plan.md
+++ b/docs/work/done/000208-ts-build-fix/01_plan.md
@@ -1,0 +1,95 @@
+# [#208] fix: [seung] TypeScript 빌드 에러 수정 — dashboard implicit any · Prisma.InputJsonValue — 구현 계획
+
+> 작성: 2026-03-23
+
+---
+
+## 완료 기준
+
+- [x] `src/app/api/dashboard/route.ts` implicit any 제거 (`let resumes` 타입 추론 실패)
+- [x] `src/app/api/resume/feedback/route.ts` `Prisma.InputJsonValue` 타입 참조 오류 수정
+- [x] `npx tsc --noEmit` 에러 0건
+
+---
+
+## 구현 계획
+
+### 개요
+
+두 파일의 TypeScript 타입 에러를 최소 변경으로 수정한다. 런타임 동작은 변경하지 않는다.
+
+---
+
+### Step 1 — `dashboard/route.ts` implicit any 수정
+
+**파일:** `services/seung/src/app/api/dashboard/route.ts`
+
+**문제:** `let resumes`를 타입 없이 선언 → try 블록 안에서 Prisma 반환값을 할당해도 TS가 타입 추론 불가 → `.map((resume) => ...)` 콜백 파라미터가 implicit any
+
+**수정 방향:** `let resumes`에 명시적 타입 어노테이션 추가
+
+```ts
+// Before
+let resumes
+
+// After
+import type { Prisma } from '@prisma/client'
+
+let resumes: Awaited<ReturnType<typeof prisma.resume.findMany<{
+  include: { sessions: { include: { report: true }; orderBy: { createdAt: 'asc' } } }
+}>>>
+```
+
+또는 더 간단하게, try 블록에서 에러 시 early return하고 `const resumes = ...`를 try 블록 안에 두는 구조로 리팩토링:
+
+```ts
+// try 블록 안에서 const로 선언, 에러 시 return
+const resumes = await prisma.resume.findMany({ ... })
+// try 블록 끝에서 resumes 반환값 사용
+```
+
+→ **선택:** early return 방식이 더 단순하고 이슈 수정 방향과 일치 — try/catch 안에서 `const resumes`로 선언하고 정상 흐름을 try 안에 완성, catch에서 500 반환.
+
+---
+
+### Step 2 — `feedback/route.ts` Prisma.InputJsonValue 수정
+
+**파일:** `services/seung/src/app/api/resume/feedback/route.ts`
+
+**문제:** `Prisma.InputJsonValue`가 현재 설치된 Prisma client 버전에 export되지 않음
+
+**수정:** `Prisma.InputJsonValue` → `Prisma.JsonValue`로 교체
+
+```ts
+// Before
+data: { diagnosisResult: data as Prisma.InputJsonValue },
+
+// After
+data: { diagnosisResult: data as Prisma.JsonValue },
+```
+
+> 주의: `Prisma.JsonValue`도 없으면 `unknown` 또는 `object`로 fallback. 먼저 Prisma 버전 확인 후 결정.
+
+---
+
+### Step 3 — 타입 검증
+
+```bash
+cd services/seung && npx tsc --noEmit
+```
+
+에러 0건 확인.
+
+---
+
+### Step 4 — `.ai.md` 최신화
+
+수정 완료 후 해당 디렉토리 `.ai.md`에 변경 내용 반영.
+
+---
+
+### 주의사항
+
+- 런타임 동작 변경 없음 — 타입 어노테이션·캐스트만 수정
+- Prisma 버전에 따라 사용 가능한 타입명이 다를 수 있음 → Step 2 전에 `package.json`에서 Prisma 버전 확인
+- `InputJsonValue` vs `JsonValue`: Prisma v5+에서는 `InputJsonValue`가 제거됐을 가능성 있음

--- a/docs/work/done/000208-ts-build-fix/02_test.md
+++ b/docs/work/done/000208-ts-build-fix/02_test.md
@@ -1,0 +1,71 @@
+# [#208] fix: [seung] TypeScript 빌드 에러 수정 — 테스트 결과
+
+> 작성: 2026-03-23
+
+---
+
+## 최종 테스트 결과
+
+### TypeScript 타입 검사
+
+```
+npx tsc --noEmit → exit code 0 (에러 0건)
+```
+
+### Vitest 단위 테스트
+
+```
+Test Files  15 passed (15)
+Tests       147 passed (147)
+Duration    ~4.6s
+```
+
+**파일별 결과:**
+
+| 파일 | 테스트 수 | 결과 | 비고 |
+|------|-----------|------|------|
+| `tests/api/dashboard.test.ts` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/resume-feedback.test.ts` | 14 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/questions.test.ts` | 21 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/interview-start.test.ts` | 8 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/interview-answer.test.ts` | 13 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/interview-session.test.ts` | 8 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/report-generate.test.ts` | 12 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/report-get.test.ts` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/practice-feedback.test.ts` | 12 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/resume-diagnosis.test.ts` | 7 | ✅ 전체 통과 | 변경 없음 |
+| `tests/api/resume-delete.test.ts` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/components/InterviewChat.test.tsx` | 17 | ✅ 전체 통과 | 변경 없음 |
+| `tests/components/AnswerInput.test.tsx` | 8 | ✅ 전체 통과 | 변경 없음 |
+| `tests/components/QuestionList.test.tsx` | 5 | ✅ 전체 통과 | 변경 없음 |
+| `tests/components/UploadForm.test.tsx` | 7 | ✅ 전체 통과 | 변경 없음 |
+
+---
+
+## 상태 범례
+
+| 아이콘 | 의미 |
+|--------|------|
+| ⬜ | 미구현 |
+| 🔴 | RED — 테스트 작성 완료, 실패 확인 |
+| 🟢 | GREEN — 구현 완료, 테스트 통과 |
+| ✅ | DONE — 리팩토링 완료 |
+| ❌ | FAIL — 테스트 실패 (수정 필요) |
+
+---
+
+## 변경 파일 및 수정 내용
+
+### 수정 파일
+
+| 파일 | 변경 | 결과 |
+|------|------|------|
+| `src/app/api/dashboard/route.ts` | `let resumes: ResumeWithSessions[]` 명시적 타입 어노테이션 추가 (implicit any 제거) | ✅ |
+| `src/app/api/resume/feedback/route.ts` | `Prisma.InputJsonValue` → `object` (Prisma v6 미지원 타입 교체) | ✅ |
+
+---
+
+## 회귀 없음
+
+- 기존 147개 테스트 모두 통과
+- 신규 테스트 없음 (타입 어노테이션·캐스트만 수정, 런타임 동작 변경 없음)

--- a/services/seung/.ai.md
+++ b/services/seung/.ai.md
@@ -230,6 +230,10 @@ seung/
   - [x] `interview/session/route.ts`: Prisma resume join → `fileName` 응답 포함
   - [x] `interview/page.tsx`: 헤더에 자소서 파일명 표시 (null 시 미표시)
   - [x] Vitest 147개 전체 통과 (InterviewChat +4, interview-answer +1, interview-session +2, questions +2, report-generate +1, resume-feedback +1)
+- [x] TypeScript 빌드 에러 수정 (#208)
+  - [x] `api/dashboard/route.ts`: `let resumes: ResumeWithSessions[]` 명시적 타입 어노테이션 추가 (implicit any 제거)
+  - [x] `api/resume/feedback/route.ts`: `Prisma.InputJsonValue` → `object` (Prisma v6 미지원 타입 교체)
+  - [x] `npx tsc --noEmit` 에러 0건
 - [ ] 배포: EC2 + ALB + Route53 + HTTPS (#132)
   - [x] `GET /api/health` API 라우트 추가
   - [x] `deploy-seung.yml` GitHub Actions 워크플로우 작성

--- a/services/seung/src/app/api/dashboard/route.ts
+++ b/services/seung/src/app/api/dashboard/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { createClient } from '@/lib/supabase/server'
+
+type ResumeWithSessions = Prisma.ResumeGetPayload<{
+  include: { sessions: { include: { report: true } } }
+}>
 
 export async function GET() {
   const supabase = await createClient()
@@ -9,7 +14,7 @@ export async function GET() {
     return NextResponse.json({ error: '로그인이 필요합니다.' }, { status: 401 })
   }
 
-  let resumes
+  let resumes: ResumeWithSessions[]
   try {
     resumes = await prisma.resume.findMany({
       where: { userId: user.id },

--- a/services/seung/src/app/api/resume/feedback/route.ts
+++ b/services/seung/src/app/api/resume/feedback/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { createClient } from '@/lib/supabase/server'
 
@@ -98,7 +97,7 @@ export async function POST(request: NextRequest) {
   try {
     await prisma.resume.update({
       where: { id: resumeId },
-      data: { diagnosisResult: data as Prisma.InputJsonValue },
+      data: { diagnosisResult: data as object },
     })
   } catch (err) {
     console.error('[resume/feedback] DB update failed', { err })


### PR DESCRIPTION
## 이슈 배경

`npm run build` 시 두 가지 TypeScript 에러가 발생했다. `dashboard/route.ts`에서 `let resumes`를 타입 없이 선언해 Prisma 반환값 추론이 실패했고, `resume/feedback/route.ts`에서 Prisma v6에 존재하지 않는 `InputJsonValue` 타입을 참조했다. 두 에러 모두 #171, #157에서 도입된 기존 코드 문제다.

## 완료 기준 (AC)

- [x] `src/app/api/dashboard/route.ts` implicit any 제거 — `ResumeWithSessions` 타입 + `let resumes: ResumeWithSessions[]` 어노테이션으로 해결
- [x] `src/app/api/resume/feedback/route.ts` `Prisma.InputJsonValue` 타입 참조 오류 수정 — `object`로 교체, unused import 제거
- [x] `npx tsc --noEmit` 에러 0건 — 확인 완료

## 작업 내역

### `src/app/api/dashboard/route.ts`

`Prisma.ResumeGetPayload<{ include: { sessions: { include: { report: true } } } }>` 기반의 `ResumeWithSessions` 타입 alias를 선언하고 `let resumes: ResumeWithSessions[]`로 어노테이션했다. 런타임 동작 변경 없음.

### `src/app/api/resume/feedback/route.ts`

`Prisma.InputJsonValue` → `object`로 교체. line 92–95 가드에서 non-null 일반 객체임이 이미 보장되므로 런타임 안전성 유지. 불필요해진 `import { Prisma }` 제거.

Closes #208