### PR TITLE
fix: [engine] _check_followup required_keys 완화 · followupQuestion fallback 처리 (#210)

### DIFF
--- a/docs/work/done/000210-interview-answer-500/00_issue.md
+++ b/docs/work/done/000210-interview-answer-500/00_issue.md
@@ -1,0 +1,54 @@
+# fix: [engine] /interview/answer 500 에러 — _check_followup required_keys 완화
+
+## 목적
+`/api/interview/answer` 엔드포인트에서 간헐적으로 발생하는 500 에러 수정
+
+## 배경
+LLM이 `shouldFollowUp: false`로 판단할 때 `followupQuestion`, `followupType`, `reasoning` 키를 생략하고 응답하는 경우가 있음. `_check_followup`의 `required_keys`에 이 키들이 포함되어 있어 `parse_object`에서 `LLMError`가 발생하고 500 반환됨.
+
+재현 조건: 꼬리질문이 불필요하다고 LLM이 판단할 때 간헐적으로 발생.
+
+관련 파일: `engine/app/services/interview_service.py:68`
+
+## 완료 기준
+- [x] `_check_followup` `required_keys`를 `["shouldFollowUp"]`만으로 변경
+- [x] `shouldFollowUp: true`일 때 `followupQuestion` 키 누락 시 fallback 처리 추가
+- [x] `/interview/answer` 500 재현 케이스 유닛 테스트 추가
+
+## 구현 플랜
+1. `interview_service.py:68` — `required_keys=["shouldFollowUp"]`로 축소
+2. `process_answer` 136번 라인 `followup_data["followupQuestion"]` → `.get("followupQuestion", "")` fallback 처리
+3. `test_interview_service.py`에 `shouldFollowUp:false` + 키 누락 케이스 테스트 추가
+
+## 개발 체크리스트
+- [ ] 해당 디렉토리 .ai.md 최신화
+
+---
+
+## 작업 내역
+
+### 2026-03-24
+
+**현황**: 3/3 완료
+
+**완료된 항목**:
+- `_check_followup` `required_keys`를 `["shouldFollowUp"]`만으로 변경
+- `shouldFollowUp: true`일 때 `followupQuestion` 키 누락 시 fallback 처리 추가
+- `/interview/answer` 500 재현 케이스 유닛 테스트 추가
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 2개 (interview_service.py, test_interview_service.py)
+
+### 상세 내역
+
+**`engine/app/services/interview_service.py`**
+- `_check_followup` `required_keys` 4개 → `["shouldFollowUp"]` 1개로 축소: LLM이 `shouldFollowUp: false` 판단 시 나머지 키를 생략해도 파싱 에러 없이 통과
+- `process_answer` line 142: `followup_data["followupQuestion"]` → `.get("followupQuestion", "")`: `shouldFollowUp: true`이지만 followupQuestion 누락 시 빈 문자열로 안전 fallback
+- `generate_followup` line 186-188: `followupType`, `followupQuestion`, `reasoning` 직접 접근 → `.get()` fallback: `required_keys` 완화에 따른 일관성 확보
+
+**`engine/tests/unit/services/test_interview_service.py`**
+- `test_process_answer_no_500_when_followup_keys_missing`: `{"shouldFollowUp": false}` 만 반환해도 500 없이 다음 질문 반환 검증
+- `test_process_answer_followup_question_fallback_when_key_missing`: `{"shouldFollowUp": true}` 만 반환 시 `question=""` fallback 검증
+

--- a/docs/work/done/000210-interview-answer-500/01_plan.md
+++ b/docs/work/done/000210-interview-answer-500/01_plan.md
@@ -1,0 +1,49 @@
+# [#210] fix: [engine] /interview/answer 500 에러 — _check_followup required_keys 완화 — 구현 계획
+
+> 작성: 2026-03-23
+
+---
+
+## 완료 기준
+
+- [x] `_check_followup` `required_keys`를 `["shouldFollowUp"]`만으로 변경
+- [x] `shouldFollowUp: true`일 때 `followupQuestion` 키 누락 시 fallback 처리 추가
+- [x] `/interview/answer` 500 재현 케이스 유닛 테스트 추가
+
+---
+
+## 구현 계획
+
+### Step 1. `required_keys` 축소
+- `engine/app/services/interview_service.py:68`
+- `required_keys=["shouldFollowUp", "followupType", "followupQuestion", "reasoning"]` → `required_keys=["shouldFollowUp"]`
+
+### Step 2. `followupQuestion` fallback 처리
+- `process_answer` 함수 136번 라인 근처
+- `followup_data["followupQuestion"]` → `followup_data.get("followupQuestion", "")` 로 변경
+
+### Step 3. 유닛 테스트 추가
+- `engine/tests/unit/services/test_interview_service.py`
+- `shouldFollowUp: false` + 꼬리질문 키 누락 케이스 테스트 추가
+- `shouldFollowUp: true` + `followupQuestion` 키 누락 케이스 fallback 테스트 추가
+
+---
+
+## 해결 내용 (2026-03-24)
+
+### 문제
+LLM이 `shouldFollowUp: false`로 판단할 때 `followupQuestion`, `followupType`, `reasoning` 키를 응답에서 생략하는 경우가 있었다. `_check_followup`의 `_parse_object`가 이 키들을 `required_keys`로 요구하고 있어 키 누락 시 `LLMError` → 500 반환.
+
+### 근본 원인
+`required_keys`의 역할은 **파싱 필수 키 검증**인데, `shouldFollowUp: false`일 때 꼬리질문 관련 키는 실제로 사용되지 않음에도 불구하고 required로 선언되어 있었음.
+
+### 수정
+| 위치 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| `interview_service.py:68` | `required_keys=["shouldFollowUp", "followupType", "followupQuestion", "reasoning"]` | `required_keys=["shouldFollowUp"]` |
+| `interview_service.py:142` | `followup_data["followupQuestion"]` | `followup_data.get("followupQuestion", "")` |
+
+### 테스트
+- `test_process_answer_no_500_when_followup_keys_missing` — `{"shouldFollowUp": false}` 만 반환해도 500 없이 다음 질문 반환
+- `test_process_answer_followup_question_fallback_when_key_missing` — `{"shouldFollowUp": true}` 만 반환 시 `question=""` fallback 확인
+- 전체 19개 테스트 통과

--- a/engine/app/services/interview_service.py
+++ b/engine/app/services/interview_service.py
@@ -65,7 +65,7 @@ def _check_followup(
         .replace("{resume_text}", resumeText[:16000])
     )
     result = _call_llm(prompt, model=model, error_message="면접 진행 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.")
-    return _parse_object(result.content, required_keys=["shouldFollowUp", "followupType", "followupQuestion", "reasoning"]), result.usage, result.model
+    return _parse_object(result.content, required_keys=["shouldFollowUp"]), result.usage, result.model
 
 
 def start_interview(
@@ -139,7 +139,7 @@ def process_answer(
             nextQuestion=QuestionWithPersona(
                 persona=currentPersona,
                 personaLabel=PERSONA_LABELS[currentPersona],
-                question=followup_data["followupQuestion"],
+                question=followup_data.get("followupQuestion", ""),
                 type="follow_up",
             ),
             updatedQueue=list(questionsQueue),
@@ -183,7 +183,7 @@ def generate_followup(
     data, raw_usage, llm_model = _check_followup(question, answer, persona, resumeText, model=model)
 
     return FollowupResponse(
-        followupType=data["followupType"],
-        followupQuestion=data["followupQuestion"],
-        reasoning=data["reasoning"],
+        followupType=data.get("followupType", ""),
+        followupQuestion=data.get("followupQuestion", ""),
+        reasoning=data.get("reasoning", ""),
     ), _usage_to_metadata(raw_usage, llm_model)

--- a/engine/tests/unit/services/test_interview_service.py
+++ b/engine/tests/unit/services/test_interview_service.py
@@ -79,6 +79,8 @@ TECH_QUESTION_JSON = '{"question": "기술 스택을 설명해 주세요.", "per
 EXEC_QUESTION_JSON = '{"question": "5년 후 목표는?", "personaLabel": "경영진"}'
 FOLLOWUP_JSON = '{"shouldFollowUp": true, "followupType": "CLARIFY", "followupQuestion": "더 구체적으로 말씀해 주세요.", "reasoning": "답변이 모호합니다."}'
 NO_FOLLOWUP_JSON = '{"shouldFollowUp": false, "followupType": "CLARIFY", "followupQuestion": "...", "reasoning": "충분합니다."}'
+NO_FOLLOWUP_MINIMAL_JSON = '{"shouldFollowUp": false}'
+FOLLOWUP_NO_QUESTION_JSON = '{"shouldFollowUp": true}'
 
 
 def test_start_returns_first_hr_question():
@@ -161,6 +163,32 @@ def test_process_answer_skips_followup_at_max_followups():
     assert result.nextQuestion.type == "main"
     assert result.nextQuestion.persona == "tech_lead"
     assert result.sessionComplete is False
+
+
+def test_process_answer_no_500_when_followup_keys_missing():
+    """shouldFollowUp:false 시 나머지 키 누락해도 500 에러 없이 다음 질문 반환."""
+    from app.schemas import QueueItem, HistoryItem
+    queue = [QueueItem(persona="tech_lead", type="main")]
+    history = [HistoryItem(persona="hr", personaLabel="HR 담당자", question="질문", answer="답변")]
+    with patch("app.services.llm_client.OpenAI", return_value=make_mock_llm_side_effect([NO_FOLLOWUP_MINIMAL_JSON, TECH_QUESTION_JSON])):
+        from app.services.interview_service import process_answer
+        result, _ = process_answer("이력서", history, queue, "현재 질문", "hr", "답변")
+    assert result.nextQuestion is not None
+    assert result.nextQuestion.persona == "tech_lead"
+    assert result.sessionComplete is False
+
+
+def test_process_answer_followup_question_fallback_when_key_missing():
+    """shouldFollowUp:true 이지만 followupQuestion 키 누락 시 빈 문자열로 fallback."""
+    from app.schemas import QueueItem, HistoryItem
+    queue = [QueueItem(persona="tech_lead", type="main")]
+    history = [HistoryItem(persona="hr", personaLabel="HR 담당자", question="질문", answer="답변")]
+    with patch("app.services.llm_client.OpenAI", return_value=make_mock_llm(FOLLOWUP_NO_QUESTION_JSON)):
+        from app.services.interview_service import process_answer
+        result, _ = process_answer("이력서", history, queue, "현재 질문", "hr", "모호한 답변")
+    assert result.nextQuestion is not None
+    assert result.nextQuestion.type == "follow_up"
+    assert result.nextQuestion.question == ""
 
 
 def test_process_answer_session_complete_at_max_turns():


### PR DESCRIPTION
## 이슈 배경

`/api/interview/answer` 엔드포인트에서 LLM이 `shouldFollowUp: false`로 판단할 때 `followupQuestion`, `followupType`, `reasoning` 키를 생략하는 경우가 있었다. `_check_followup`의 `required_keys`에 이 키들이 포함되어 있어 `_parse_object`에서 `LLMError`가 발생하고 500을 반환하는 간헐적 버그가 있었다.

## 완료 기준 (AC)

- [x] `_check_followup` `required_keys`를 `["shouldFollowUp"]`만으로 변경
- [x] `shouldFollowUp: true`일 때 `followupQuestion` 키 누락 시 fallback 처리 추가
- [x] `/interview/answer` 500 재현 케이스 유닛 테스트 추가

## 작업 내역

**`engine/app/services/interview_service.py`**
- `_check_followup` `required_keys` 4개 → `["shouldFollowUp"]` 1개로 축소: LLM이 `shouldFollowUp: false` 판단 시 나머지 키를 생략해도 파싱 에러 없이 통과
- `process_answer`: `followup_data["followupQuestion"]` → `.get("followupQuestion", "")` fallback 추가
- `generate_followup`: `followupType`, `followupQuestion`, `reasoning` 직접 접근 → `.get()` fallback으로 일관성 확보

**`engine/tests/unit/services/test_interview_service.py`**
- `test_process_answer_no_500_when_followup_keys_missing`: `{"shouldFollowUp": false}` 만 반환해도 500 없이 다음 질문 반환 검증
- `test_process_answer_followup_question_fallback_when_key_missing`: `{"shouldFollowUp": true}` 만 반환 시 `question=""` fallback 검증
- 전체 19개 테스트 통과

Closes #210