### PR TITLE
fix: [seung] dashboard diagnosisResult 타입 에러 수정 (#226)

### DIFF
--- a/docs/work/done/000226-seung-dashboard-fix/00_issue.md
+++ b/docs/work/done/000226-seung-dashboard-fix/00_issue.md
@@ -1,0 +1,47 @@
+# fix: [seung] dashboard route.ts diagnosisResult 타입 에러 — 빌드 차단
+
+## 문제
+
+\`services/seung/src/app/api/dashboard/route.ts\` 의 \`ResumeWithSessions\` 타입에서 빌드 에러 발생.
+
+\`\`\`
+Type error: Type 'JsonValue' is not assignable to type 'object | null'.
+  Type 'string' is not assignable to type 'object'.
+\`\`\`
+
+PR #217 머지 후 \`deploy-seung.yml\` 자동 트리거 → Docker 빌드 실패 → main 배포 차단 중.
+
+## 원인
+
+\`diagnosisResult: object | null\` 타입이 Prisma가 반환하는 \`JsonValue\` (string 포함)와 불일치.
+
+## 수정 내용
+
+\`\`\`ts
+// before
+diagnosisResult: object | null
+
+// after
+diagnosisResult: unknown
+\`\`\`
+
+\`diagnosisResult\`는 \`!== null\` 체크에만 사용되므로 \`unknown\`으로 충분.
+
+## 완료 기준
+
+- [x] \`npx tsc --noEmit\` 에러 0건
+- [ ] \`deploy-seung.yml\` 빌드 성공
+
+---
+
+## 작업 내역
+
+`services/seung/src/app/api/dashboard/route.ts` 의 `ResumeWithSessions` 타입에서
+`diagnosisResult: object | null` → `diagnosisResult: unknown` 으로 1줄 수정.
+
+Prisma의 `JsonValue` 타입은 `string | number | boolean | object | null` 의 유니온이므로
+`object | null` 로 좁히면 타입 불일치 에러가 발생한다.
+`diagnosisResult` 는 `!== null` 체크에만 사용되므로 `unknown` 으로 충분하며,
+이것이 TypeScript에서 권장하는 타입 안전한 방식이다.
+
+수정 후 `tsc --noEmit` 에러 0건 확인.

--- a/docs/work/done/000226-seung-dashboard-fix/01_plan.md
+++ b/docs/work/done/000226-seung-dashboard-fix/01_plan.md
@@ -1,0 +1,19 @@
+# [#226] fix: [seung] dashboard route.ts diagnosisResult 타입 에러 — 구현 계획
+
+> 작성: 2026-03-24
+
+---
+
+## 완료 기준
+
+- [ ] `npx tsc --noEmit` 에러 0건
+- [ ] `deploy-seung.yml` 빌드 성공
+
+---
+
+## 구현 계획
+
+`services/seung/src/app/api/dashboard/route.ts` 의 `ResumeWithSessions` 타입에서
+`diagnosisResult: object | null` → `diagnosisResult: unknown` 으로 변경.
+
+`diagnosisResult`는 `!== null` 체크에만 사용되므로 `unknown`으로 충분.

--- a/docs/work/done/000226-seung-dashboard-fix/02_test.md
+++ b/docs/work/done/000226-seung-dashboard-fix/02_test.md
@@ -1,0 +1,29 @@
+# [#226] 테스트 결과
+
+> 작성: 2026-03-24
+
+---
+
+## 테스트 항목
+
+| # | 항목 | 결과 |
+|---|------|------|
+| 1 | `npx tsc --noEmit` 에러 0건 | ✅ 통과 |
+| 2 | `deploy-seung.yml` 빌드 성공 | 미확인 (CI 트리거 후 확인) |
+
+---
+
+## 실행 방법
+
+```bash
+cd services/seung
+./node_modules/.bin/tsc --noEmit
+```
+
+---
+
+## 비고
+
+- `services/seung/src/app/api/dashboard/route.ts:16`의 `diagnosisResult: object | null` → `unknown` 변경
+- `diagnosisResult !== null` 체크에만 사용되므로 `unknown`으로 충분
+- node_modules 미설치 상태였으므로 `npm install` 후 tsc 실행

--- a/services/seung/src/app/api/dashboard/route.ts
+++ b/services/seung/src/app/api/dashboard/route.ts
@@ -13,7 +13,7 @@ type ResumeWithSessions = {
   id: string
   createdAt: Date
   fileName: string | null
-  diagnosisResult: object | null
+  diagnosisResult: unknown
   sessions: SessionWithReport[]
 }
 


### PR DESCRIPTION
## 이슈 배경

PR #217 머지 후 `deploy-seung.yml` Docker 빌드가 실패하며 main 배포가 차단됐습니다.
`ResumeWithSessions` 타입의 `diagnosisResult: object | null` 이 Prisma의 `JsonValue` (string 포함 유니온)와 불일치해 TypeScript 빌드 에러가 발생했습니다.

## 완료 기준 (AC)

- [x] `npx tsc --noEmit` 에러 0건 — 수정 후 tsc 통과 확인
- [ ] `deploy-seung.yml` 빌드 성공 _(CI 트리거 후 확인)_

## 작업 내역

`services/seung/src/app/api/dashboard/route.ts:16` 에서 `diagnosisResult: object | null` → `diagnosisResult: unknown` 으로 1줄 수정.

Prisma의 `JsonValue`는 `string | number | boolean | object | null` 유니온이므로 `object | null` 로 좁히면 타입 불일치가 발생한다. `diagnosisResult` 는 `!== null` 체크에만 사용되므로 `unknown` 으로 충분하며, TypeScript 권장 방식이다.

Closes #226