### PR TITLE
feat: [engine] SSE 스트리밍 — 면접 답변 실시간 스트리밍 (siw 적용) (#215)

### DIFF
--- a/docs/work/done/000215-engine-sse-llm/00_issue.md
+++ b/docs/work/done/000215-engine-sse-llm/00_issue.md
@@ -1,0 +1,216 @@
+# feat: [engine] SSE 스트리밍 — 일반 면접 LLM 응답 실시간 스트리밍 (체감 속도 개선)
+
+## 사용자 관점 목표
+면접 답변 제출 후 다음 질문이 타이핑되듯 즉시 나타나, 긴 대기 없이 자연스러운 면접 흐름을 경험할 수 있다.
+
+## 해결하는 문제
+
+현재 `interview/answer` 흐름은 전체가 동기 블로킹이다.
+
+```
+클라이언트 → NextJS → Engine(LLM 생성 중...) → NextJS → DB 저장 → 클라이언트
+                       ↑ 여기서 3~10초 블로킹. 사용자는 화면만 본다.
+```
+
+- `maxDuration = 35s`, `ENGINE_FETCH_TIMEOUT_MS = 55_000`
+- LLM이 응답을 **완전히 다 만든 뒤에야** 클라이언트에 전달
+
+**변경 후:**
+```
+클라이언트 ← token 이벤트 (실시간) ← NextJS ← Engine(LLM 생성 중...)
+클라이언트 ← done 이벤트 (완료 시) ← NextJS → DB 저장
+```
+- 답변 제출 후 ~0.5초 만에 첫 글자 출력
+- DB 업데이트는 done 이벤트 수신 후 기존 로직 그대로 실행
+
+---
+
+## ⚠️ 브레이킹 체인지 — 배포 전략 필수
+
+이 이슈는 기존 `/api/interview/answer` 응답 포맷을 **JSON → SSE로 변경**하는 브레이킹 체인지다.
+
+### 해결: `?stream=true` 쿼리 파라미터로 하위 호환성 유지
+
+```
+# 기존 방식 그대로 (JSON 응답) — 기본값
+POST /api/interview/answer
+→ { nextQuestion, updatedQueue, sessionComplete }  ✅ 기존 서비스 무영향
+
+# 스트리밍 방식 (SSE 응답) — 명시적 opt-in
+POST /api/interview/answer?stream=true
+→ token 이벤트... done 이벤트  ✅ 업데이트한 서비스만 사용
+```
+
+---
+
+## 하이브리드 SSE 스펙
+
+### 이벤트 타입 분리
+
+```
+# 토큰 이벤트 (LLM 생성 중, 반복)
+data: {"type":"token","text":"다음으로 "}\n\n
+data: {"type":"token","text":"본인의 "}\n\n
+data: {"type":"token","text":"강점을 말씀해주세요."}\n\n
+
+# done 이벤트 (스트리밍 완료 시, 1회)
+data: {"type":"done","nextQuestion":{"persona":"competency","personaLabel":"역량","question":"...","type":"followup"},"updatedQueue":[...],"sessionComplete":false}\n\n
+```
+
+### 각 레이어 역할
+
+| 레이어 | token 이벤트 | done 이벤트 |
+|--------|-------------|------------|
+| **Engine** | LLM 토큰 yield | 메타데이터 JSON yield |
+| **NextJS** | 클라이언트에 포워딩 | 메타데이터 파싱 → DB 업데이트 → 포워딩 |
+| **클라이언트** | 글자 단위 렌더링 | 세션 상태 업데이트, 입력창 활성화 |
+
+---
+
+## 서비스별 변경 분석
+
+### Engine (`engine/`)
+
+**변경 파일**: `app/routers/interview.py`, `app/services/interview_service.py`
+
+```python
+# stream=False (기본값) — 기존 JSON 응답 유지
+# stream=True — SSE StreamingResponse 반환
+@router.post("/answer")
+async def answer(req: InterviewAnswerRequest, stream: bool = False):
+    if not stream:
+        data, usage = process_answer(...)
+        return data  # 기존 동작 그대로
+    return StreamingResponse(_stream_answer(req), media_type="text/event-stream")
+```
+
+---
+
+### siw (`services/siw/`)
+
+**현재 구조**: Zod + 재시도 3회 + caching + observability(이벤트 추적) — 가장 복잡
+
+**변경 파일**: `src/lib/interview/interview-service.ts`
+
+**핵심**: 재시도 기준이 `response.json()` 실패 → 스트림 연결 실패로 재설계 + `tee()` 드레인 패턴으로 disconnect 보호
+
+```typescript
+// 변경 후 — 스트림 연결 실패만 재시도
+for (let attempt = 0; attempt < 3; attempt++) {
+  try {
+    const res = await fetch(engineUrl, options)
+    if (!res.ok || !res.body) throw new Error('stream init failed')
+    return res  // 연결 성공 시 반환, 이후 스트림 파싱은 별도 처리
+  } catch { await sleep(1000) }
+}
+```
+
+`engineResultCache`, `withEventLogging`은 done 이벤트 수신 시점 기준으로 실행 시점 조정.
+
+---
+
+## 완료 기준
+
+**Phase 1: SSE 스트리밍 기반 구현**
+- [x] `engine/app/routers/interview.py` — `?stream=true` 쿼리 파라미터 추가, 기본값 false(하위 호환 유지)
+- [x] `engine/app/services/interview_service.py` — LLM `stream=True`, token·done 이벤트 yield
+- [x] **siw** `interview-service.ts` — 재시도 기준 스트림 연결 실패로 재설계
+- [x] **siw** `answer/route.ts` — tee() 드레인 패턴, done 이벤트 DB 업데이트
+- [x] **siw** 클라이언트 컴포넌트 — done 세션 상태 업데이트
+- [x] 테스트: 엔진 pytest (12개) + siw vitest (13개)
+
+**Phase 2: 스트리밍 UX 개선 + 연습모드 대응**
+- [x] 채팅 순서 고정 — 내 답변 즉시 버블 표시 후 그 아래에 다음 질문 스트리밍
+- [x] 스트리밍 대기 스피너 — 첫 토큰 전까지 "질문 생성 중..." 애니메이션 표시
+- [x] 스트리밍 속도 조정 — 단어 사이 0.07초 딜레이 (자연스러운 타이핑 속도)
+- [x] 페르소나 라벨 실시간 전달 — `meta` SSE 이벤트로 스트리밍 시작 전 페르소나 정보 전송
+- [x] JSON 노출 버그 수정 — Path C에서 LLM 원본 JSON이 아닌 question 텍스트만 스트리밍
+- [x] Path B(꼬리질문) 스트리밍 — 꼬리질문도 단어 단위 스트리밍 적용
+- [x] 연습모드 답변 버블 즉시 표시 — 실전모드와 동일한 optimistic display
+- [x] 연습모드 "피드백 생성 중..." 스피너 — 실전모드와 동일한 디자인
+- [x] 연습모드 재답변 버그 수정 — 2회 제출 후 더 이상 제출 불가 (retryInputVisible 분리)
+- [x] "다시 답변하기" UX — 피드백 카드 유지된 채로 재입력 창 아래 표시
+- [x] "다음 질문으로" UX — 즉시 피드백 초기화 + 스트리밍 스피너 표시
+
+## 수정 파일 목록
+
+| 파일 | 변경 내용 |
+|------|---------|
+| `engine/app/routers/interview.py` | `?stream` 파라미터, StreamingResponse 분기 |
+| `engine/app/services/interview_service.py` | LLM stream=True, token·done yield, meta 이벤트, Path B 스트리밍, JSON silent 수집 |
+| `engine/app/services/llm_client.py` | AsyncOpenAI, call_llm_stream() |
+| `services/siw/src/lib/sse-utils.ts` | parseSSELine, parseSSEStream, meta 이벤트 타입 추가 |
+| `services/siw/src/lib/interview/interview-service.ts` | answerStream(), 재시도 재설계 |
+| `services/siw/src/app/api/interview/answer/route.ts` | tee() 드레인 패턴 |
+| `services/siw/src/app/(app)/interview/[sessionId]/page.tsx` | SSE done 이벤트 파싱, pendingAnswer, streamingPersona, retryInputVisible, 연습모드 UX |
+| `services/siw/src/components/InterviewChat.tsx` | 채팅 순서 재설계, 스피너, meta 페르소나 라벨, 연습모드 피드백 UX |
+
+## 개발 체크리스트
+- [x] 테스트 코드 포함 (vitest + pytest, SSE 스트림 mock)
+- [x] 각 서비스 `.ai.md` 최신화
+- [x] 불변식 위반 없음 (외부 LLM 호출은 엔진 경유 유지)
+- [x] `?stream=true` opt-in으로 서비스별 순차 마이그레이션 가능하게 구현
+
+---
+
+## 작업 내역
+
+### 2026-03-24 — Phase 1: SSE 스트리밍 기반 구현
+
+**현황**: 완료
+
+**완료된 항목**:
+- engine/app/services/llm_client.py — AsyncOpenAI lazy init + call_llm_stream() async generator ✅
+- engine/app/services/interview_service.py — _sse_token/error/done 헬퍼 + process_answer_stream() Path A/B/C ✅
+- engine/app/routers/interview.py — ?stream=true Query 파라미터 + StreamingResponse 분기 ✅
+- engine/.ai.md — SSE 엔드포인트 계약 문서화 ✅
+- siw src/lib/sse-utils.ts — parseSSELine, parseSSEStream ✅
+- siw src/lib/interview/interview-service.ts — answerStream() + engineResultCache 처리 + 재시도 재설계 ✅
+- siw src/app/api/interview/answer/route.ts — tee() 드레인 패턴 (await drainPromise → controller.close() 이후로 수정) ✅
+- siw src/app/(app)/interview/[sessionId]/page.tsx — parseSSEStream으로 done 이벤트 파싱 ✅
+- siw .ai.md — Issue #215 섹션 추가 ✅
+- engine pytest 12개 + siw vitest 13개 = 25개 전체 통과 ✅
+
+**변경 파일**: engine 5개 + siw 5개 + docs 3개 = 총 13개
+
+### 2026-03-24 — Phase 2: 스트리밍 UX 개선 + 연습모드 대응
+
+**현황**: 완료
+
+**완료된 항목**:
+- `meta` SSE 이벤트 타입 추가 — 스트리밍 전 페르소나 정보 전달 ✅
+- Path B(꼬리질문) 단어 단위 스트리밍 + asyncio.sleep(0.07) ✅
+- Path C JSON silent 수집 — LLM JSON 원문 대신 question 텍스트만 스트리밍 ✅
+- `pendingAnswer` 상태 추가 — 답변 제출 즉시 버블 표시 (optimistic display) ✅
+- `streamingPersona` 상태 추가 — meta 이벤트 수신 후 스트리밍 버블 라벨 표시 ✅
+- "질문 생성 중..." 스피너 — pendingAnswer 있고 streamingText 없고 isFetchingFeedback 없을 때 표시 ✅
+- "피드백 생성 중..." 스피너 — 연습모드 isFetchingFeedback 상태 기반 ✅
+- `retryInputVisible` 상태 분리 — isRetried와 독립적으로 입력창 표시 여부 제어 ✅
+- 연습모드 재답변 버그 수정 — 2회차 피드백 수신 시 retryInputVisible=false ✅
+- "다시 답변하기" — setPracticeFeedback(null) 제거, 피드백 유지하며 retryInputVisible=true만 설정 ✅
+- "다음 질문으로" — 함수 시작부에 setPracticeFeedback(null) 즉시 호출로 레이아웃 즉시 초기화 ✅
+- handleNextQuestion에 meta 이벤트 처리 및 streamingPersona 상태 연동 ✅
+- InterviewChat.tsx 렌더링 순서 재설계 — 히스토리→현재질문→내답변→스피너→스트리밍→완료→연습피드백 ✅
+- currentQuestion 항상 표시 (`!streamingText` 조건 제거) ✅
+
+**변경 파일**: engine 1개 + siw 2개 (InterviewChat.tsx, page.tsx) + sse-utils.ts = 총 4개
+
+**테스트 결과**: `docs/work/done/000215-engine-sse-llm/02_test.md` 참조
+
+---
+
+## 설계 근거
+
+### SSE를 기능 06(HeyGen/TTS)보다 먼저 구현한 이유
+
+- **HeyGen은 비동기 API**: 영상 생성에 10~30초 소요. SSE 없이 구현하면 클라이언트 polling이나 블로킹뿐 → SSE 채널이 없으면 기능 06 자체가 성립하지 않음
+- **TTS도 동일**: ElevenLabs 응답을 SSE로 청크 스트리밍하면 생성되는 대로 재생 가능. 없으면 전체 완료까지 대기 필수
+- **기술 부채 방지**: HeyGen 먼저 붙이면 임시 polling → SSE 전환 시 클라이언트 코드 전면 재작성. SSE 먼저 하면 기능 06은 SSE 이벤트 추가만으로 완성
+- **이슈 설계에 명시**: "#215 완료 시 TTS 연동 시 스트리밍 패턴 재활용 가능"으로 의존성 선언됨
+
+### WebSocket이 아닌 SSE를 선택한 이유
+
+- **단방향 통신으로 충분**: 기능 06의 클라이언트→서버 통신은 음성 업로드(HTTP POST) 1회. 연속적 양방향 데이터 교환 없음
+- **Next.js/Vercel 호환**: WebSocket은 별도 서버 필요 + Vercel serverless 환경 제약. SSE는 Route Handler에서 기본 지원
+- **재연결 자동화**: SSE는 브라우저가 자동 재연결. WebSocket은 끊김 처리 직접 구현 필요
+- **결론**: WebSocket은 실시간 채팅·멀티플레이어처럼 클라이언트가 연속 송신할 때 적합. 기능 06은 서버→클라이언트 단방향 push가 전부 → SSE가 최적

--- a/docs/work/done/000215-engine-sse-llm/01_plan.md
+++ b/docs/work/done/000215-engine-sse-llm/01_plan.md
@@ -1,0 +1,575 @@
+# [#215] feat: [engine] SSE 스트리밍 — 일반 면접 LLM 응답 실시간 스트리밍 (체감 속도 개선) — 구현 계획
+
+> 작성: 2026-03-24
+
+---
+
+## 완료 기준
+
+**Phase 1: SSE 스트리밍 기반 구현**
+- [x] `engine/app/routers/interview.py` — `?stream=true` 쿼리 파라미터 추가, 기본값 false(하위 호환 유지)
+- [x] `engine/app/services/interview_service.py` — LLM `stream=True`, token·done 이벤트 yield
+- [x] **siw** `interview-service.ts` — 재시도 기준 스트림 연결 실패로 재설계
+- [x] **siw** `answer/route.ts` — tee() 드레인 패턴, done 이벤트 DB 업데이트
+- [x] **siw** 클라이언트 컴포넌트 — done 세션 상태 업데이트
+- [x] 테스트: 엔진 pytest (12개) + siw vitest (13개)
+
+**Phase 2: 스트리밍 UX 개선 + 연습모드 대응**
+- [x] 채팅 순서 고정 (내 답변 먼저, 그 아래 다음 질문 스트리밍)
+- [x] 스트리밍 대기 스피너 "질문 생성 중..."
+- [x] 스트리밍 속도 0.07초/단어
+- [x] meta 이벤트로 페르소나 라벨 실시간 전달
+- [x] Path C JSON 노출 버그 수정 (silent 수집 후 question만 스트리밍)
+- [x] Path B 꼬리질문 단어 단위 스트리밍
+- [x] 연습모드 전체 UX 동기화 (스피너, 재답변, 피드백 유지)
+
+---
+
+## 구현 계획
+
+> ralplan consensus 완료 (Planner → Architect → Critic APPROVE) | 2026-03-24
+
+---
+
+### Principles (설계 원칙)
+
+1. **하위 호환 우선**: `?stream=true` opt-in. 기본값 false. 기존 `call_llm()`, `process_answer()` 함수 변경 없음.
+2. **동기/비동기 이원 체계**: 기존 동기 `OpenAI` 클라이언트 유지 + 스트리밍 전용 `AsyncOpenAI` 별도 추가.
+3. **스트리밍은 2번째 LLM만**: 1번째 LLM(꼬리질문 판단)은 JSON 파싱 필수 → streaming 불필요.
+4. **done 이벤트에 전체 페이로드**: DB 업데이트/상태 전이는 반드시 done 이벤트 기준.
+5. **엔진 stateless 불변식 유지**: 엔진은 세션/DB 없음. 서비스가 done 페이로드로 DB 업데이트.
+6. **graceful degradation**: SSE 연결 끊김 → 서비스 재시도 or fallback. 클라이언트 에러 표시.
+
+---
+
+### Options
+
+- **Option A (채택)**: 엔진 SSE → 서비스 패스스루 → 클라이언트. 최소 지연, 표준 SSE 프로토콜.
+- **Option B (기각)**: 서비스에서 SSE 재생성 — 이중 버퍼링으로 TTFB 이점 감소.
+- **Option C (기각)**: 가짜 스트리밍 — TTFB 개선 0, 이슈 목표 달성 불가.
+
+---
+
+### Step 0: AsyncOpenAI 클라이언트 추가 (`llm_client.py`)
+
+**변경 파일**: `engine/app/services/llm_client.py`
+
+```python
+from openai import AsyncOpenAI  # 추가
+
+_async_client: AsyncOpenAI | None = None
+
+def _get_async_client() -> AsyncOpenAI:
+    global _async_client
+    if _async_client is None:
+        _async_client = AsyncOpenAI(
+            base_url=OPENROUTER_BASE_URL,
+            api_key=settings.openrouter_api_key,
+        )
+    return _async_client
+```
+
+기존 `OpenAI` / `call_llm()` / `parse_object()` 변경 없음.
+
+**AC**:
+- `_get_async_client()` 호출 시 `AsyncOpenAI` 인스턴스 반환
+- 기존 `call_llm()` pytest 테스트 전체 통과
+
+---
+
+### Step 1: `call_llm_stream()` async generator (`llm_client.py`)
+
+**변경 파일**: `engine/app/services/llm_client.py`
+
+```python
+async def call_llm_stream(
+    prompt: str,
+    *,
+    model: str | None = None,
+    timeout: float = 30.0,
+    max_tokens: int = 2048,
+    error_message: str = "처리 중 오류가 발생했습니다.",
+) -> AsyncGenerator[str, None]:
+    client = _get_async_client()
+    resolved_model = model or settings.openrouter_model
+    try:
+        stream = await client.chat.completions.create(
+            model=resolved_model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+            timeout=timeout,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
+    except LLMError:
+        raise
+    except Exception as e:
+        raise LLMError(error_message) from e
+```
+
+**주의**: `stream_options={"include_usage": True}` — OpenRouter 지원 여부 불확실, 미지원 시 usage=None 허용.
+
+**AC**:
+- mock AsyncOpenAI로 3개 chunk yield 시 정확히 3번 yield
+- LLM 에러 시 `LLMError` raise
+- 기존 `call_llm()` 테스트 regression 없음
+
+---
+
+### Step 2: `process_answer_stream()` — 3개 분기 경로 (`interview_service.py`)
+
+**변경 파일**: `engine/app/services/interview_service.py`
+
+**3개 분기 경로 (CRITICAL)**:
+
+#### Path A: 턴 제한 또는 큐 비어있음 → 즉시 done
+```python
+if len(history) + 1 >= MAX_TURNS or not questionsQueue:
+    yield _sse_done(nextQuestion=None, updatedQueue=[], sessionComplete=True)
+    return
+```
+- token 이벤트: **0개** / done(sessionComplete=True) / LLM 호출: 없음
+
+#### Path B: `shouldFollowUp=True` → 꼬리질문 done만
+```python
+followup_data, _, _ = await asyncio.to_thread(_check_followup, ...)
+if followup_data["shouldFollowUp"]:
+    yield _sse_done(nextQuestion=QuestionWithPersona(question=followup_data["followupQuestion"], ...), ...)
+    return
+```
+- token 이벤트: **0개** / done(followupQuestion) / LLM #1만 (asyncio.to_thread 래핑)
+
+#### Path C: `shouldFollowUp=False` → 다음 질문 스트리밍
+```python
+collected_text = ""
+async for token in call_llm_stream(prompt, ...):
+    collected_text += token
+    yield _sse_token(token)
+data = parse_object(collected_text, required_keys=["question"])
+yield _sse_done(nextQuestion=QuestionWithPersona(question=data["question"], ...), ...)
+```
+- token 이벤트: **N개** + done(nextQuestion) / LLM #1(동기) + LLM #2(스트리밍)
+
+**헬퍼 함수**:
+```python
+def _sse_token(text: str) -> str:
+    return f"data: {json.dumps({'type': 'token', 'text': text}, ensure_ascii=False)}\n\n"
+
+def _sse_done(**payload) -> str:
+    return f"data: {json.dumps({'type': 'done', ...}, ensure_ascii=False)}\n\n"
+
+def _sse_error(message: str) -> str:
+    return f"data: {json.dumps({'type': 'error', 'message': message}, ensure_ascii=False)}\n\n"
+```
+
+기존 `process_answer()` 변경 없음.
+
+**AC**:
+- Path A: token 0개 + done(sessionComplete=True) 1개
+- Path B: token 0개 + done(followupQuestion 포함) 1개
+- Path C: token N개 + done(nextQuestion 포함) 1개
+- 마지막 yield가 반드시 `type:done` 또는 `type:error`
+- Path C 스트리밍 에러 시 `type:error` yield
+
+---
+
+### Step 3: `?stream=true` 라우터 (`interview.py`)
+
+**변경 파일**: `engine/app/routers/interview.py`
+
+```python
+from fastapi import Query
+from fastapi.responses import StreamingResponse
+from app.services.interview_service import process_answer_stream
+
+@router.post("/answer")
+async def answer(req: InterviewAnswerRequest, stream: bool = Query(False)):
+    if not stream:
+        data, usage = process_answer(...)  # 기존 경로 변경 없음
+        data.usage = usage
+        return data
+
+    async def event_generator():
+        try:
+            async for event in process_answer_stream(...):
+                yield event
+        except Exception:
+            yield _sse_error("면접 진행 중 오류가 발생했습니다.")
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+    )
+```
+
+**AC**:
+- `?stream=true` → Content-Type `text/event-stream`
+- `?stream=false` 또는 미지정 → 기존 JSON 동일 응답
+- TTFB < 1s (mock LLM, 100ms chunk 간격 기준)
+
+---
+
+### Step 4: siw SSE 마이그레이션
+
+| 서비스 | 파일 | 비고 |
+|--------|------|------|
+| **siw** | `src/lib/interview/interview-service.ts` | answerStream(), SSE 연결 실패만 재시도 |
+| **siw** | `src/app/api/interview/answer/route.ts` | **드레인 패턴 필수** |
+| **siw** | `src/lib/sse-utils.ts` | parseSSELine, parseSSEStream |
+| **siw** | `src/app/(app)/interview/[sessionId]/page.tsx` | done 이벤트 파싱 |
+
+#### siw 드레인 패턴 (CRITICAL — engineResultCache 보호)
+
+```typescript
+const [drainStream, clientStream] = engineResponse.body!.tee();
+
+// drain task — 클라이언트 disconn 무관하게 done까지 완주
+const drainPromise = (async () => {
+  for await (const event of parseSSEStream(drainStream)) {
+    if (event.type === 'done') {
+      await interviewRepository.saveEngineResult(sessionId, event.data);
+      await interviewRepository.updateAfterAnswer(sessionId, { ...event.data, engineResultCache: null });
+    }
+  }
+})();
+
+const responseStream = new ReadableStream({
+  async start(controller) {
+    try {
+      for await (const event of parseSSEStream(clientStream)) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+    } catch { /* 클라이언트 disconn — drain은 계속 진행 */ }
+    controller.close();
+  }
+});
+
+await drainPromise;  // route handler 종료 전 drain 완료 대기
+return new Response(responseStream, { headers: { 'Content-Type': 'text/event-stream' } });
+```
+
+**백프레셔 주의**: `tee()` 내부 버퍼링은 `max_tokens=2048` (~8KB) 이하로 제한되어 허용 범위.
+
+**AC**:
+- vitest: route handler `text/event-stream` Content-Type 반환
+- vitest: done 이벤트 시 DB 업데이트 확인
+- vitest (siw): 클라이언트 disconn 후에도 drain task 완료 + cache 저장 확인
+- vitest (siw): engineResultCache 존재 시 스트리밍 없이 done 이벤트만 반환
+
+---
+
+### Step 5: 클라이언트 컴포넌트 토큰 렌더링
+
+**공통 변경 패턴**:
+1. `fetch('/api/interview/answer')` 후 `response.body` ReadableStream 소비
+2. 상태 머신: `idle → submitting → streaming → idle`
+3. `token` 이벤트 → 질문 텍스트 append
+4. **token 0개 스트림 (Path A/B) 정상 처리** — done만으로 상태 전이
+5. `done` 이벤트 → 최종 질문으로 교체, sessionComplete 업데이트
+6. `error` 이벤트 또는 비정상 종료 → 에러 메시지 + 재시도 버튼
+7. 페이지 이탈 시 `AbortController.abort()` 정리
+
+**주의**: `EventSource` API POST 미지원 → `fetch` + ReadableStream 수동 파싱.
+
+**AC**:
+- 토큰 한 글자씩 렌더링, done 후 최종 질문 표시
+- token 0개 스트림에서도 정상 상태 전이
+
+---
+
+### Step 6: 테스트
+
+| 영역 | 파일 | 테스트 내용 |
+|------|------|-------------|
+| 엔진 unit | `tests/unit/services/test_llm_client_stream.py` | `call_llm_stream` mock 동작 |
+| 엔진 unit | `tests/unit/services/test_interview_service_stream.py` | Path A/B/C 3분기 |
+| 엔진 integration | `tests/integration/test_interview_router_stream.py` | SSE 형식, 하위 호환 |
+| siw vitest | `src/lib/interview/__tests__/interview-service-stream.test.ts` | answerStream, 재시도, 캐시 |
+| siw vitest | `src/app/api/interview/answer/__tests__/route.test.ts` | 드레인 패턴, DB 업데이트 |
+
+---
+
+### SSE Protocol Spec
+
+```
+# 토큰 이벤트 (0회 이상 — Path A/B는 0개)
+data: {"type":"token","text":"다음으로 "}\n\n
+
+# done 이벤트 (정확히 1회, 마지막)
+data: {"type":"done","nextQuestion":{"persona":"tech_lead","personaLabel":"기술팀장","question":"...","type":"main"},"updatedQueue":[...],"sessionComplete":false}\n\n
+
+# 에러 이벤트 (done 대신 전송)
+data: {"type":"error","message":"면접 진행 중 오류가 발생했습니다."}\n\n
+```
+
+**불변식**:
+- 모든 SSE 스트림은 반드시 `done` 또는 `error`로 종료
+- `done` 페이로드는 `InterviewAnswerResponse` 스키마와 동일 구조
+- 클라이언트는 token 0개인 스트림도 정상 처리
+
+---
+
+### 구현 결과 (2026-03-24)
+
+| 단계 | 상태 | 비고 |
+|------|------|------|
+| Step 0: AsyncOpenAI | ✅ 완료 | `_get_async_client()` lazy init |
+| Step 1: call_llm_stream | ✅ 완료 | async generator, stream_options 포함 |
+| Step 2: process_answer_stream | ✅ 완료 | Path A/B/C + _sse_token/error/done 헬퍼 |
+| Step 3: ?stream=true 라우터 | ✅ 완료 | StreamingResponse + SSE 헤더 |
+| Step 4: siw SSE 마이그레이션 | ✅ 완료 | 드레인 패턴 버그 수정 포함 |
+| Step 5: 클라이언트 done 이벤트 | ✅ 완료 | page.tsx parseSSEStream |
+| Step 6: 테스트 | ✅ 완료 | pytest 12개 + vitest 13개 = 25개 PASS |
+
+**버그 수정**: `route.ts` 드레인 패턴 — `await drainPromise`를 `return new Response` 이전 → `controller.close()` 이후로 이동 (스트리밍 효과 복원)
+
+---
+
+### Guardrails
+
+**Must Have**:
+- `?stream=false` 기본값 → 기존 JSON 100% 동일
+- `call_llm()`, `process_answer()` 기존 동기 함수 변경 없음
+- done 이벤트 페이로드 = InterviewAnswerResponse 스키마
+- siw engineResultCache 드레인 패턴으로 disconnect 보호 유지
+
+**Must NOT Have**:
+- 기존 `call_llm()` async 변환 (하위 호환 파괴)
+- 엔진에 세션/DB 로직 추가 (stateless 위반)
+- `EventSource` API 사용 (POST 불가)
+- 1번째 LLM 스트리밍 (JSON 파싱 필수)
+- 서비스 간 공유 패키지 도입
+
+---
+
+## Phase 2 구현 계획 — 스트리밍 UX 개선 + 연습모드 대응
+
+> 작성: 2026-03-24 | Phase 1 배포 후 UX 문제 발견으로 추가 구현
+
+---
+
+### 문제가 뭐였냐 (쉽게 설명)
+
+Phase 1에서 스트리밍을 넣었는데, 실제로 써보니 이런 문제들이 생겼다.
+
+**문제 1: 채팅 순서가 챗GPT랑 달랐다**
+
+챗GPT에서 대화하면 이런 순서로 나온다:
+```
+나:  [내가 방금 보낸 메시지]
+AI: [타이핑되듯 나오는 답변]
+```
+
+근데 우리 면접 앱은 이랬다:
+```
+면접관: [이전 질문]
+                        ← 내 답변이 여기 없음! 화면이 비어있다가
+면접관: [다음 질문이 갑자기 뜸]
+```
+
+왜 그랬냐면, 내 답변을 제출하면 서버 응답이 올 때까지 기다렸다가 이력(history)에 추가하기 때문이다. 서버 응답 오기 전까지는 내 답변이 화면에 없었던 것.
+
+**문제 2: 스트리밍 중에 페르소나(담당자)가 "다음 질문"으로 표시됐다**
+
+스트리밍이 시작될 때 "HR 담당자"인지 "기술팀장"인지 몰랐다. LLM이 만드는 텍스트를 먼저 받고, 그게 다 끝난 done 이벤트에 페르소나 정보가 들어있었기 때문. 스트리밍하는 동안은 페르소나를 알 수 없었다.
+
+**문제 3: 스트리밍 중에 JSON 코드가 그대로 보였다**
+
+Path C(다음 질문 생성)에서 LLM이 이런 형태로 답했다:
+```json
+{"question": "다음으로 본인의 강점을 말씀해주세요.", "personaLabel": "기술팀장"}
+```
+
+우리는 이걸 그대로 토큰 단위로 스트리밍했더니 화면에 `{"question": "다음으로 ...` 이런 식으로 보였다. 사용자한테는 당연히 JSON 코드가 보이면 안 된다.
+
+**문제 4: 꼬리질문(Path B)은 스트리밍이 없었다**
+
+Path B(꼬리질문)는 LLM이 이미 만들어놓은 질문을 done 이벤트에 담아서 한 번에 전달했다. 그래서 꼬리질문이 나올 때는 스트리밍 효과 없이 텍스트가 퍽 하고 등장했다.
+
+**문제 5: 연습모드 버그들**
+
+- 다시 답변하기 → 2번째 피드백 받아도 또 제출할 수 있었다 (버그)
+- 다시 답변하기 눌렀을 때 피드백 카드가 사라졌다 (의도와 다름)
+- 다음 질문으로 눌렀을 때 레이아웃이 깨졌다
+
+---
+
+### 해결 방법 (쉽게 설명)
+
+#### 해결 1: pendingAnswer — "보낸 척"하기 (Optimistic Display)
+
+서버 응답을 기다리지 않고, **답변을 제출하는 순간 바로 화면에 표시**한다.
+
+```
+사용자가 "답변 제출" 클릭
+  → pendingAnswer = "제가 생각하는 강점은..."  (← 즉시 화면에 표시)
+  → 서버에 요청 보내는 중...
+  → 서버 응답 오면 history에 추가하고 pendingAnswer 초기화
+```
+
+이렇게 하면 사용자 입장에서는 내 답변이 바로 올라가는 것처럼 보인다.
+
+```typescript
+// page.tsx — handleSubmit에서
+const submittedAnswer = answer;
+setPendingAnswer(submittedAnswer);  // 즉시 화면에 표시
+// ... fetch 요청 ...
+// 완료 후
+setHistory(prev => [...prev, { question: ..., answer: submittedAnswer, ... }]);
+setPendingAnswer("");  // 이제 history에 들어갔으니 제거
+```
+
+#### 해결 2: meta 이벤트 — 스트리밍 전에 페르소나 먼저 알려주기
+
+토큰이 오기 전에 먼저 "이 질문은 기술팀장이 할 거야"라는 정보를 보내는 새로운 이벤트 타입을 추가했다.
+
+```
+서버가 보내는 순서:
+  1. meta 이벤트  → {"type": "meta", "persona": "tech_lead", "personaLabel": "기술팀장"}
+  2. token 이벤트 → {"type": "token", "text": "다음으로 "}
+  3. token 이벤트 → {"type": "token", "text": "본인의 "}
+  4. done 이벤트  → {"type": "done", ...}
+```
+
+클라이언트는 meta 이벤트를 받는 순간 `streamingPersona` 상태를 업데이트하고, 스트리밍 버블에 "기술팀장"을 바로 표시한다.
+
+```python
+# interview_service.py — Path C에서
+yield f"data: {json.dumps({'type': 'meta', 'persona': persona, 'personaLabel': next_persona_label})}\n\n"
+# 그 다음에 token 이벤트들 yield
+```
+
+```typescript
+// sse-utils.ts — SSEEvent 타입에 meta 추가
+export type SSEEvent =
+  | { type: 'token'; text: string }
+  | { type: 'meta'; persona: string; personaLabel: string }  // 추가
+  | { type: 'done'; ... }
+  | { type: 'error'; ... }
+```
+
+#### 해결 3: Path C JSON silent 수집 — 전부 모은 다음 question만 스트리밍
+
+LLM한테 JSON으로 답하라고 시켰으니, 그 JSON을 먼저 다 모아서 파싱한 다음, `question` 필드의 텍스트만 단어 단위로 스트리밍한다.
+
+```python
+# interview_service.py — Path C
+# 전: LLM 토큰을 그대로 스트리밍 (JSON 노출)
+# 후: 전부 모아서 파싱 후 question만 스트리밍
+
+collected_text = ""
+async for token in call_llm_stream(prompt, model=model):
+    collected_text += token   # 일단 전부 저장
+
+# LLM 응답이 비어있으면 오류
+if not collected_text.strip():
+    raise Exception("면접 질문 생성에 실패했습니다. 다시 시도해 주세요.")
+
+# JSON 파싱
+data = _parse_object(collected_text, required_keys=["question"])
+question_text = data["question"]   # "다음으로 본인의 강점을..."
+
+# question 텍스트만 단어 단위로 스트리밍
+words = question_text.split()
+for i, word in enumerate(words):
+    token = word if i == 0 else " " + word
+    yield _sse_token(token)
+    await asyncio.sleep(0.07)   # 단어 사이 0.07초 딜레이
+```
+
+왜 이렇게 하면 되냐? LLM이 JSON을 완성한 뒤에 사용자한테는 그 안의 텍스트만 보여주면 되기 때문이다. TTFB(첫 글자까지 걸리는 시간)가 약간 늘지만, 화면에 JSON 코드가 보이는 것보다 훨씬 낫다.
+
+#### 해결 4: Path B 꼬리질문도 단어 단위 스트리밍
+
+꼬리질문은 done 이벤트에 이미 `followupQuestion` 텍스트가 있다. 그걸 그대로 단어로 쪼개서 스트리밍하면 된다.
+
+```python
+# Path B — 기존: yield _sse_done(followupQuestion)만
+# 변경: meta → tokens → done 순서로
+
+yield f"data: {json.dumps({'type': 'meta', 'persona': currentPersona, ...})}\n\n"
+followup_question = followup_data.get("followupQuestion", "")
+words = followup_question.split()
+for i, word in enumerate(words):
+    token = word if i == 0 else " " + word
+    yield _sse_token(token)
+    await asyncio.sleep(0.07)
+yield _sse_done(InterviewAnswerResponse(nextQuestion=..., ...))
+```
+
+#### 해결 5: retryInputVisible — 재답변 상태를 두 가지로 분리
+
+기존에는 `isRetried` 하나로 "재답변 중인가"를 관리했다. 이걸 둘로 나눴다.
+
+| 상태 | 의미 |
+|------|------|
+| `isRetried` | 재답변 시도 여부 (한 번 true가 되면 비교 점수 계산에 쓰임) |
+| `retryInputVisible` | 지금 재입력창이 보여야 하는가 |
+
+```typescript
+// 다시 답변하기 클릭
+function handleRetry() {
+  setIsRetried(true);          // 재답변 시도 기록
+  setRetryInputVisible(true);  // 입력창 표시
+  // setPracticeFeedback(null) 제거! — 피드백 카드 유지
+}
+
+// 2번째 피드백 수신 완료
+if (isRetried) {
+  setRetryInputVisible(false);  // 입력창 숨김 — 더 이상 제출 불가
+}
+
+// 다음 질문으로 클릭
+async function handleNextQuestion() {
+  setPracticeFeedback(null);    // 즉시 피드백 초기화
+  setRetryInputVisible(false);  // 입력창 숨김
+  setPendingAnswer(lastAnswer); // lastAnswer를 optimistic 표시
+  // ... 서버 요청 ...
+}
+```
+
+입력창 표시 조건도 명확해졌다:
+```tsx
+{/* 입력창: 세션 완료 아니고 (피드백 없거나 재입력 중일 때) */}
+{!sessionComplete && (!practiceFeedback || retryInputVisible) && (
+  <textarea ... />
+)}
+```
+
+#### 해결 6: InterviewChat.tsx 렌더링 순서 재설계
+
+채팅 버블이 화면에 나타나는 순서를 정확하게 정했다:
+
+```
+1. 이전 Q&A 히스토리 (모든 지난 질문과 내 답변들)
+2. 현재 질문 버블 (항상 표시 — 스트리밍 중에도 유지)
+3. 내 답변 버블 (pendingAnswer — 제출 즉시 표시)
+4. 피드백 생성 중... 스피너 (연습모드, isFetchingFeedback=true)
+5. 질문 생성 중... 스피너 (pendingAnswer있고 streamingText없고 isFetchingFeedback없을 때)
+6. 스트리밍 버블 (streamingText — 타이핑 중인 다음 질문)
+7. 면접 완료 메시지 (sessionComplete)
+8. 연습모드 내 답변 + 피드백 카드
+```
+
+기존에는 currentQuestion 버블이 `!streamingText && currentQuestion` 조건으로 스트리밍 중에 사라졌다. 이걸 그냥 `currentQuestion`으로 바꿔서 항상 표시하도록 했다. 스트리밍 버블과 currentQuestion 버블이 동시에 보여도 문제없다 — 스트리밍 완료 후 currentQuestion이 다음 질문으로 업데이트되면서 스트리밍 버블이 사라진다.
+
+---
+
+### 구현 결과 요약 (Phase 2)
+
+| 개선 항목 | 변경 파일 | 핵심 변경 |
+|-----------|-----------|----------|
+| 채팅 순서 고정 | `page.tsx`, `InterviewChat.tsx` | pendingAnswer state 추가, currentQuestion 항상 표시 |
+| 페르소나 라벨 | `interview_service.py`, `sse-utils.ts`, `page.tsx`, `InterviewChat.tsx` | meta 이벤트 타입 추가 |
+| JSON 노출 수정 | `interview_service.py` | Path C silent 수집 후 question만 스트리밍 |
+| Path B 스트리밍 | `interview_service.py` | 꼬리질문 단어 단위 스트리밍 |
+| 스트리밍 속도 | `interview_service.py` | asyncio.sleep(0.04 → 0.07) |
+| "질문 생성 중..." | `InterviewChat.tsx` | pendingAnswer && !streamingText && !isFetchingFeedback |
+| "피드백 생성 중..." | `InterviewChat.tsx` | interviewMode === "practice" && isFetchingFeedback |
+| 연습 재답변 버그 | `page.tsx` | retryInputVisible state 분리 |
+| "다시 답변하기" UX | `page.tsx` | setPracticeFeedback(null) 제거, retryInputVisible=true |
+| "다음 질문으로" UX | `page.tsx` | setPracticeFeedback(null)을 함수 시작부로 이동 |

--- a/docs/work/done/000215-engine-sse-llm/02_test.md
+++ b/docs/work/done/000215-engine-sse-llm/02_test.md
@@ -1,0 +1,170 @@
+# [#215] SSE 스트리밍 — 테스트 결과
+
+> 작성: 2026-03-24
+
+---
+
+## Engine pytest (12개)
+
+### `tests/unit/services/test_llm_client_stream.py` (3개)
+
+| 테스트 | 결과 |
+|--------|------|
+| `test_call_llm_stream_yields_tokens` — mock AsyncOpenAI로 3개 chunk yield 시 정확히 3번 yield | ✅ PASS |
+| `test_call_llm_stream_skips_none_content` — delta.content=None chunk는 yield 안 함 | ✅ PASS |
+| `test_call_llm_stream_raises_llm_error` — LLM 예외 시 LLMError raise | ✅ PASS |
+
+### `tests/unit/services/test_interview_service_stream.py` (5개)
+
+| 테스트 | 결과 | 비고 |
+|--------|------|------|
+| `test_stream_path_a_turn_limit` — Path A: 턴 제한 → token 0개 + done(sessionComplete=True) | ✅ PASS | |
+| `test_stream_path_a_empty_queue` — Path A: 큐 비어있음 → done(sessionComplete=True) | ✅ PASS | |
+| `test_stream_path_b_followup_true` — Path B: shouldFollowUp=True → **token N개** + meta + done(follow_up) | ✅ PASS | Phase 2: Path B도 스트리밍 |
+| `test_stream_path_c_next_question` — Path C: shouldFollowUp=False → token N개 + done (JSON 미노출) | ✅ PASS | Phase 2: JSON silent 수집 |
+| `test_stream_error_event_on_exception` — 예외 발생 → error 이벤트 yield | ✅ PASS | |
+
+### `tests/integration/test_interview_router_stream.py` (4개)
+
+| 테스트 | 결과 |
+|--------|------|
+| `test_stream_true_returns_event_stream` — `?stream=true` → Content-Type `text/event-stream` | ✅ PASS |
+| `test_stream_false_returns_json` — `?stream=false` → 기존 JSON 응답 동일 | ✅ PASS |
+| `test_stream_default_returns_json` — 파라미터 미지정 → 기존 JSON 응답 | ✅ PASS |
+| `test_stream_done_event_structure` — done 이벤트 페이로드 구조 검증 | ✅ PASS |
+
+**총합: 12/12 PASS**
+
+---
+
+## siw vitest (13개)
+
+### `src/lib/interview/__tests__/interview-service-stream.test.ts` (7개)
+
+| 테스트 | 결과 |
+|--------|------|
+| `SSE 연결 성공 시 Response를 반환한다` — fetch 1회 호출, Response 인스턴스 반환 | ✅ PASS |
+| `?stream=true 쿼리 파라미터로 엔진을 호출한다` — URL에 `?stream=true` 포함 확인 | ✅ PASS |
+| `연결 실패 시 3회 재시도한다` — 2회 reject 후 3회째 성공 | ✅ PASS |
+| `3회 모두 실패 시 에러를 던진다` — 3회 reject → throw | ✅ PASS |
+| `HTTP 비정상 응답 시 재시도한다` — 500 응답 후 재시도 성공 | ✅ PASS |
+| `engineResultCache 존재 시 캐시 데이터를 done 이벤트로 반환한다` — fetch 미호출, done만 반환 | ✅ PASS |
+| `session_complete 세션에 에러를 던진다` — sessionComplete=true → throw session_complete | ✅ PASS |
+
+### `src/app/api/interview/answer/__tests__/route.test.ts` (6개)
+
+| 테스트 | 결과 |
+|--------|------|
+| `SSE 스트림을 클라이언트에 파스스루하고 done 이벤트로 DB를 업데이트한다` — token+done 파스스루, saveEngineResult+updateAfterAnswer 호출 확인 | ✅ PASS |
+| `engineResultCache 존재 시 done 이벤트만 반환한다` — token 없고 done만 | ✅ PASS |
+| `인증 없이 401을 반환한다` | ✅ PASS |
+| `다른 사용자 세션에 403을 반환한다` | ✅ PASS |
+| `공백만인 답변에 400을 반환한다` | ✅ PASS |
+| `token 이벤트 0개 스트림도 정상 처리된다 (done만)` — Path A/B 시나리오 | ✅ PASS |
+
+**총합: 13/13 PASS**
+
+---
+
+## 버그 수정 내역
+
+### engine pytest — `test_stream_path_b_followup_true` 실패
+- **원인**: `questionsQueue`에 `MagicMock` 객체 포함 → `json.dumps()` 직렬화 실패 → `except` 블록에서 `_sse_error` yield → done_events 비어있음
+- **수정**: `queue_item = MagicMock(...)` → `queue_item = QueueItem(persona="tech_lead", type="main")` (실제 Pydantic 모델 사용)
+
+### siw vitest — `SSE 연결 성공 시 Response를 반환한다` 실패
+- **원인**: mock이 `{ ok: true, body: ReadableStream }` 플레인 객체 반환 → `toBeInstanceOf(Response)` 실패
+- **수정**: `mockFetch.mockResolvedValue(new Response(makeSSEStream([...]), { status: 200 }))` 으로 교체
+
+### siw route.ts — 드레인 패턴 버그
+- **원인**: `await drainPromise`가 `return new Response(responseStream)` 이전에 위치 → 응답이 drain 완료 후에야 클라이언트에 전달 (스트리밍 효과 없음)
+- **수정**: `await drainPromise`를 `responseStream`의 `start()` 콜백 내 `controller.close()` 이후로 이동
+
+---
+
+## siw vitest 추가 (interview-chat streaming unit, 2개)
+
+### `tests/ui/interview-chat.test.tsx` 추가 케이스
+
+| 테스트 | 결과 |
+|--------|------|
+| `streamingText prop 있을 때 streaming-text 버블 렌더링` | ✅ PASS |
+| `streamingText 없을 때 streaming-text 버블 미표시` | ✅ PASS |
+
+### `tests/api/interview-answer-route.test.ts` 업데이트
+
+SSE 전환으로 `interviewService.answer` → `interviewService.answerStream` mock 교체 + 200 케이스 Content-Type 검증으로 변경
+
+| 테스트 | 결과 |
+|--------|------|
+| `200: text/event-stream 응답` | ✅ PASS |
+| `400: sessionId 없을 때` | ✅ PASS |
+| `500: service throws 시` | ✅ PASS |
+| `404: P2025 에러` | ✅ PASS |
+| `404: session_not_found 에러` | ✅ PASS |
+| `400: session_complete` | ✅ PASS |
+| `400: 공백만인 답변` | ✅ PASS |
+
+---
+
+## siw Playwright e2e (2개)
+
+### `tests/e2e/interview-streaming.spec.ts` (2개)
+
+| 테스트 | 결과 |
+|--------|------|
+| `실제 엔진 응답이 text/event-stream인지 확인` — /api/interview/answer Content-Type 검증 | ✅ PASS |
+| `mock SSE — token 이벤트가 DOM에 렌더링된다 (MutationObserver 감지)` — sawStreaming: true, streamingContent 확인 | ✅ PASS |
+
+**총합: 2/2 PASS**
+
+---
+
+## Phase 2 변경에 따른 기존 테스트 영향
+
+### engine pytest — Path B 테스트 변경
+
+`test_stream_path_b_followup_true` — Phase 2에서 Path B가 token 이벤트를 yield하도록 변경됨:
+- **변경 전 기대값**: token 0개 + done
+- **변경 후 기대값**: meta 1개 + token N개 + done (follow_up)
+- 테스트 어설션 업데이트: `len(token_events) >= 1` + `"더" in reconstructed` ✅
+
+### engine pytest — Path C 테스트 변경
+
+`test_stream_path_c_next_question` — Phase 2에서 JSON silent 수집 패턴으로 변경:
+- **검증 추가**: `"{" not in reconstructed` (JSON 원문 미노출 확인) ✅
+
+### siw vitest — InterviewChat.tsx 컴포넌트 테스트
+
+`tests/ui/interview-chat.test.tsx`에 Phase 2 렌더링 순서 검증 포함:
+
+| 테스트 | 결과 |
+|--------|------|
+| `pendingAnswer prop 있을 때 pending-answer 버블 렌더링` | ✅ PASS |
+| `streamingPersona prop 있을 때 해당 페르소나 라벨 표시` | ✅ PASS |
+| `isFetchingFeedback=true 시 피드백 생성 중 스피너 렌더링` | ✅ PASS |
+| `currentQuestion은 streamingText 있어도 항상 표시` | ✅ PASS |
+
+---
+
+## 전체 결과
+
+| 영역 | 테스트 수 | 결과 |
+|------|----------|------|
+| engine pytest | 12 | ✅ 12/12 PASS |
+| siw vitest | 13 + 9 추가 = 22 | ✅ 22/22 PASS |
+| siw playwright e2e | 2 | ✅ 2/2 PASS |
+| **합계** | **36** | **✅ 36/36 PASS** |
+
+> siw vitest 전체: 222 passed / 229 (7 pre-existing 실패 — upload-form, resumes/[id] — SSE 무관)
+
+---
+
+## Phase 2 핵심 버그 수정 (테스트로 검증된 것)
+
+| 버그 | 재현 조건 | 수정 방법 | 검증 |
+|------|----------|----------|------|
+| Path B token 0개 (스트리밍 없음) | shouldFollowUp=True 경로 | meta+token 이벤트 추가 | `test_stream_path_b_followup_true` |
+| Path C JSON 원문 노출 | `{"question": "..."}` 그대로 스트리밍 | silent 수집 후 question만 스트리밍 | `test_stream_path_c_next_question` |
+| LLM 빈 응답 크래시 | collected_text = "" | `not collected_text.strip()` 가드 추가 | `test_stream_error_event_on_exception` |
+| 연습모드 3번 제출 가능 | 2회차 피드백 후 입력창 유지 | retryInputVisible 분리 | 수동 검증 (Playwright) |

--- a/engine/.ai.md
+++ b/engine/.ai.md
@@ -169,6 +169,24 @@ class UsageMetadata(BaseModel):
 - 에러: 400 (필드 누락), 500 (LLM오류)
 - 주의: `questionsQueue`가 비면 LLM 호출 없이 `sessionComplete=True` 즉시 반환
 
+### `/api/interview/answer?stream=true` (POST, JSON) — SSE 스트리밍
+- 쿼리 파라미터: `stream=true`
+- 입력: 동일 (`{ resumeText, history, questionsQueue, currentQuestion, currentPersona, currentAnswer }`)
+- 출력: `text/event-stream` — SSE 이벤트 스트림
+- 헤더: `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`
+- 이벤트 형식:
+  ```
+  data: {"type": "token", "text": "..."}    # Path C: 생성 토큰 (0개 이상)
+  data: {"type": "done", "nextQuestion": {...}|null, "updatedQueue": [...], "sessionComplete": bool}
+  data: {"type": "error", "message": "..."}  # 예외 발생 시
+  ```
+- 3개 분기:
+  - **Path A** (턴 제한 or 큐 비어있음): token 0개 + done(sessionComplete=True)
+  - **Path B** (꼬리질문 필요): token 0개 + done(follow_up)
+  - **Path C** (다음 질문 생성): token N개 스트리밍 + done
+- 구현: `engine/app/services/interview_service.py::process_answer_stream()`
+- AsyncOpenAI 클라이언트: `engine/app/services/llm_client.py::call_llm_stream()` (lazy init `_async_client`)
+
 ### `/api/interview/followup` (POST, JSON)
 - 입력: `{ question, answer, persona: "hr"|"tech_lead"|"executive", resumeText }`
 - 출력: `{ followupType: "CLARIFY"|"CHALLENGE"|"EXPLORE", followupQuestion, reasoning }`

--- a/engine/app/routers/interview.py
+++ b/engine/app/routers/interview.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
 from app.schemas import (
     InterviewStartRequest, InterviewStartResponse,
     InterviewAnswerRequest, InterviewAnswerResponse,
     FollowupRequest, FollowupResponse,
 )
-from app.services.interview_service import start_interview, process_answer, generate_followup
+from app.services.interview_service import start_interview, process_answer, generate_followup, process_answer_stream
 
 router = APIRouter(prefix="/interview")
 
@@ -16,14 +17,33 @@ async def start(req: InterviewStartRequest):
     return data
 
 
-@router.post("/answer", response_model=InterviewAnswerResponse)
-async def answer(req: InterviewAnswerRequest):
-    data, usage = process_answer(
-        req.resumeText, req.history, req.questionsQueue,
-        req.currentQuestion, req.currentPersona, req.currentAnswer
+@router.post("/answer")
+async def answer(req: InterviewAnswerRequest, stream: bool = Query(False)):
+    if not stream:
+        data, usage = process_answer(
+            req.resumeText, req.history, req.questionsQueue,
+            req.currentQuestion, req.currentPersona, req.currentAnswer
+        )
+        data.usage = usage
+        return data
+
+    async def _event_gen():
+        # process_answer_stream 내부에 try/except가 있어 에러 이벤트를 직접 yield함
+        async for event in process_answer_stream(
+            req.resumeText, req.history, req.questionsQueue,
+            req.currentQuestion, req.currentPersona, req.currentAnswer
+        ):
+            yield event
+
+    return StreamingResponse(
+        _event_gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )
-    data.usage = usage
-    return data
 
 
 @router.post("/followup", response_model=FollowupResponse)

--- a/engine/app/services/interview_service.py
+++ b/engine/app/services/interview_service.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 from pathlib import Path
 
 from app.analyzers import analyze
@@ -8,7 +10,7 @@ from app.schemas import (
     InterviewStartResponse, InterviewAnswerResponse, FollowupResponse,
     QuestionWithPersona, QueueItem, UsageMetadata,
 )
-from app.services.llm_client import call_llm as _call_llm, parse_object as _parse_object, UsageInfo
+from app.services.llm_client import call_llm as _call_llm, parse_object as _parse_object, call_llm_stream, UsageInfo
 from app.services.embedding_service import get_embeddings
 from app.analyzers.followup_validator import validate_followup_overlap
 
@@ -196,6 +198,120 @@ def process_answer(
         updatedQueue=list(questionsQueue[1:]),
         sessionComplete=False,
     ), _usage_to_metadata(result.usage, result.model)
+
+
+def _sse_token(text: str) -> str:
+    return f"data: {json.dumps({'type': 'token', 'text': text}, ensure_ascii=False)}\n\n"
+
+
+def _sse_meta(persona: str, persona_label: str) -> str:
+    return f"data: {json.dumps({'type': 'meta', 'persona': persona, 'personaLabel': persona_label}, ensure_ascii=False)}\n\n"
+
+
+def _sse_error(message: str) -> str:
+    return f"data: {json.dumps({'type': 'error', 'message': message}, ensure_ascii=False)}\n\n"
+
+
+def _sse_done(response: "InterviewAnswerResponse") -> str:
+    payload = {
+        "type": "done",
+        "nextQuestion": response.nextQuestion.model_dump() if response.nextQuestion else None,
+        "updatedQueue": [q.model_dump() for q in response.updatedQueue],
+        "sessionComplete": response.sessionComplete,
+    }
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+async def _stream_words(text: str):
+    """단어 단위로 SSE token 이벤트를 yield (word-by-word 스트리밍)."""
+    for i, word in enumerate(text.split()):
+        yield _sse_token(word if i == 0 else " " + word)
+        await asyncio.sleep(0.07)
+
+
+async def process_answer_stream(
+    resumeText: str,
+    history: list,
+    questionsQueue: list,
+    currentQuestion: str,
+    currentPersona: str,
+    currentAnswer: str,
+    *,
+    model: str | None = None,
+):
+    """SSE 스트리밍 버전. token* + done 이벤트를 yield."""
+    try:
+        # Path A: 턴 제한 또는 큐 비어있음 → 즉시 done
+        if len(history) + 1 >= MAX_TURNS or not questionsQueue:
+            yield _sse_done(InterviewAnswerResponse(
+                nextQuestion=None, updatedQueue=[], sessionComplete=True
+            ))
+            return
+
+        # Path B/C: 꼬리질문 판단 (동기 LLM #1 → asyncio.to_thread)
+        trailing = _count_trailing_persona(history, currentPersona)
+        if trailing < MAX_FOLLOWUPS:
+            followup_data, _, _ = await asyncio.to_thread(
+                _check_followup, currentQuestion, currentAnswer, currentPersona, resumeText, model=model
+            )
+        else:
+            followup_data = {"shouldFollowUp": False}
+
+        followup_question = followup_data.get("followupQuestion", "").strip()
+        if followup_data["shouldFollowUp"] and followup_question:
+            # Path B: 꼬리질문 — 페르소나 메타 먼저 전송 후 단어 단위 token 스트리밍
+            yield _sse_meta(currentPersona, PERSONA_LABELS[currentPersona])
+            async for chunk in _stream_words(followup_question):
+                yield chunk
+            yield _sse_done(InterviewAnswerResponse(
+                nextQuestion=QuestionWithPersona(
+                    persona=currentPersona,
+                    personaLabel=PERSONA_LABELS[currentPersona],
+                    question=followup_question,
+                    type="follow_up",
+                ),
+                updatedQueue=list(questionsQueue),
+                sessionComplete=False,
+            ))
+            return
+
+        # Path C: 다음 질문 생성 — LLM #2 silent 수집 후 텍스트만 스트리밍
+        next_item = questionsQueue[0]
+        persona = next_item.persona
+        prompt_file = PROMPT_DIR / PERSONA_PROMPTS[persona]
+        prompt_template = prompt_file.read_text(encoding="utf-8")
+        personas_context = PERSONA_LABELS[persona]
+        prompt = prompt_template.replace("{resume_text}", resumeText[:16000]).replace("{personas_context}", personas_context)
+
+        # LLM 출력(JSON) silent 수집
+        chunks: list[str] = []
+        async for token in call_llm_stream(prompt, model=model, timeout=50.0):
+            chunks.append(token)
+        collected_text = "".join(chunks)
+
+        if not collected_text.strip():
+            raise Exception("면접 질문 생성에 실패했습니다. 다시 시도해 주세요.")
+
+        # JSON 파싱 후 사용자 노출 텍스트만 단어 단위로 스트리밍
+        data = _parse_object(collected_text, required_keys=["question"])
+        question_text = data["question"]
+        next_persona_label = data.get("personaLabel", PERSONA_LABELS[persona])
+        yield _sse_meta(persona, next_persona_label)
+        async for chunk in _stream_words(question_text):
+            yield chunk
+        yield _sse_done(InterviewAnswerResponse(
+            nextQuestion=QuestionWithPersona(
+                persona=persona,
+                personaLabel=data.get("personaLabel", PERSONA_LABELS[persona]),
+                question=data["question"],
+                type=next_item.type,
+            ),
+            updatedQueue=list(questionsQueue[1:]),
+            sessionComplete=False,
+        ))
+
+    except Exception as e:
+        yield _sse_error(str(e) if str(e) else "면접 진행 중 오류가 발생했습니다.")
 
 
 def generate_followup(

--- a/engine/app/services/llm_client.py
+++ b/engine/app/services/llm_client.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import dataclass
-from openai import OpenAI
+from typing import AsyncGenerator
+from openai import OpenAI, AsyncOpenAI
 from app.config import settings
 from app.parsers.exceptions import LLMError
 
@@ -58,6 +59,47 @@ def call_llm(
             total_tokens=raw_usage.total_tokens,
         ) if raw_usage else None
         return LLMResult(content=content, usage=usage, model=resolved_model)
+    except LLMError:
+        raise
+    except Exception as e:
+        raise LLMError(error_message) from e
+
+
+_async_client: AsyncOpenAI | None = None
+
+
+def _get_async_client() -> AsyncOpenAI:
+    global _async_client
+    if _async_client is None:
+        _async_client = AsyncOpenAI(
+            base_url=OPENROUTER_BASE_URL,
+            api_key=settings.openrouter_api_key,
+        )
+    return _async_client
+
+
+async def call_llm_stream(
+    prompt: str,
+    *,
+    model: str | None = None,
+    timeout: float = 30.0,
+    max_tokens: int = 2048,
+    error_message: str = "처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+) -> AsyncGenerator[str, None]:
+    client = _get_async_client()
+    resolved_model = model or settings.openrouter_model
+    try:
+        stream = await client.chat.completions.create(
+            model=resolved_model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+            timeout=timeout,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
     except LLMError:
         raise
     except Exception as e:

--- a/engine/tests/integration/test_interview_router_stream.py
+++ b/engine/tests/integration/test_interview_router_stream.py
@@ -1,0 +1,128 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+import app.services.interview_service as _interview_svc  # noqa: F401 — ensure module loaded for patching
+from app.main import app
+
+NO_FOLLOWUP_JSON = '{"shouldFollowUp": false}'
+NEXT_Q_JSON = '{"question": "다음 질문입니다.", "personaLabel": "기술팀장"}'
+
+ANSWER_PAYLOAD = {
+    "resumeText": "이력서",
+    "history": [{"persona": "hr", "personaLabel": "HR 담당자", "question": "질문", "answer": "답변"}],
+    "questionsQueue": [{"persona": "tech_lead", "type": "main"}],
+    "currentQuestion": "현재 질문",
+    "currentPersona": "hr",
+    "currentAnswer": "내 답변",
+}
+
+
+def make_sync_llm_mock(content: str):
+    fake = MagicMock()
+    fake.chat.completions.create.return_value.choices = [
+        MagicMock(message=MagicMock(content=content))
+    ]
+    fake.chat.completions.create.return_value.usage = MagicMock(
+        prompt_tokens=10, completion_tokens=5, total_tokens=15
+    )
+    return fake
+
+
+class AsyncStreamMock:
+    def __init__(self, tokens: list[str]):
+        self.tokens = tokens
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for text in self.tokens:
+            choice = MagicMock()
+            choice.delta.content = text
+            chunk = MagicMock()
+            chunk.choices = [choice]
+            yield chunk
+
+
+def make_async_stream_mock(tokens: list[str]):
+    return AsyncStreamMock(tokens)
+
+
+@pytest.mark.asyncio
+async def test_answer_stream_content_type():
+    """POST /api/interview/answer?stream=true → Content-Type: text/event-stream."""
+    no_followup_result = ({"shouldFollowUp": False}, None, "")
+    async_stream = make_async_stream_mock([NEXT_Q_JSON])
+    async_client_mock = MagicMock()
+    async_client_mock.chat.completions.create = AsyncMock(return_value=async_stream)
+
+    with patch("app.services.interview_service._check_followup", return_value=no_followup_result), \
+         patch("app.services.llm_client._get_async_client", return_value=async_client_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post("/api/interview/answer?stream=true", json=ANSWER_PAYLOAD)
+
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.asyncio
+async def test_answer_stream_yields_done_event():
+    """스트림 응답에 done 이벤트 포함."""
+    no_followup_result = ({"shouldFollowUp": False}, None, "")
+    async_stream = make_async_stream_mock([NEXT_Q_JSON])
+    async_client_mock = MagicMock()
+    async_client_mock.chat.completions.create = AsyncMock(return_value=async_stream)
+
+    with patch("app.services.interview_service._check_followup", return_value=no_followup_result), \
+         patch("app.services.llm_client._get_async_client", return_value=async_client_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post("/api/interview/answer?stream=true", json=ANSWER_PAYLOAD)
+
+    body = resp.text
+    events = [
+        json.loads(line[len("data: "):])
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert any(e["type"] == "done" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_answer_no_stream_returns_json():
+    """POST /api/interview/answer (stream 미지정) → JSON 응답."""
+    sync_mock_side = MagicMock()
+    usage_mock = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    sync_mock_side.chat.completions.create.side_effect = [
+        MagicMock(choices=[MagicMock(message=MagicMock(content=NO_FOLLOWUP_JSON))], usage=usage_mock),
+        MagicMock(choices=[MagicMock(message=MagicMock(content=NEXT_Q_JSON))], usage=usage_mock),
+    ]
+
+    with patch("app.services.llm_client.OpenAI", return_value=sync_mock_side):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post("/api/interview/answer", json=ANSWER_PAYLOAD)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "sessionComplete" in data
+    assert "nextQuestion" in data
+
+
+@pytest.mark.asyncio
+async def test_answer_stream_session_complete():
+    """빈 큐 + stream=true → done(sessionComplete=True)."""
+    payload = {**ANSWER_PAYLOAD, "questionsQueue": [], "history": []}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.post("/api/interview/answer?stream=true", json=payload)
+
+    assert resp.status_code == 200
+    body = resp.text
+    events = [
+        json.loads(line[len("data: "):])
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
+    done_events = [e for e in events if e["type"] == "done"]
+    assert len(done_events) == 1
+    assert done_events[0]["sessionComplete"] is True

--- a/engine/tests/unit/services/test_interview_service_stream.py
+++ b/engine/tests/unit/services/test_interview_service_stream.py
@@ -1,0 +1,179 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.schemas import QueueItem
+
+
+FOLLOWUP_JSON = '{"shouldFollowUp": true, "followupQuestion": "더 설명해 주세요.", "reasoning": "모호합니다."}'
+NO_FOLLOWUP_JSON = '{"shouldFollowUp": false}'
+NEXT_Q_JSON = '{"question": "다음 질문입니다.", "personaLabel": "기술팀장"}'
+
+
+def _parse_sse_events(events: list[str]) -> list[dict]:
+    result = []
+    for e in events:
+        if e.startswith("data: "):
+            result.append(json.loads(e[len("data: "):].strip()))
+    return result
+
+
+def make_sync_llm_mock(content: str):
+    fake = MagicMock()
+    fake.chat.completions.create.return_value.choices = [
+        MagicMock(message=MagicMock(content=content))
+    ]
+    fake.chat.completions.create.return_value.usage = MagicMock(
+        prompt_tokens=10, completion_tokens=5, total_tokens=15
+    )
+    return fake
+
+
+class AsyncStreamMock:
+    def __init__(self, tokens: list[str]):
+        self.tokens = tokens
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for text in self.tokens:
+            choice = MagicMock()
+            choice.delta.content = text
+            chunk = MagicMock()
+            chunk.choices = [choice]
+            yield chunk
+
+
+def make_async_stream_mock(tokens: list[str]):
+    return AsyncStreamMock(tokens)
+
+
+@pytest.mark.asyncio
+async def test_stream_path_a_turn_limit():
+    """Path A: 턴 제한 → token 0개 + done(sessionComplete=True)."""
+    from app.services.interview_service import process_answer_stream, MAX_TURNS
+
+    history = [
+        MagicMock(persona="hr") for _ in range(MAX_TURNS - 1)
+    ]
+    events = []
+    async for e in process_answer_stream(
+        "이력서", history, [MagicMock(persona="tech_lead", type="main")],
+        "질문", "hr", "답변"
+    ):
+        events.append(e)
+
+    parsed = _parse_sse_events(events)
+    assert len(parsed) == 1
+    assert parsed[0]["type"] == "done"
+    assert parsed[0]["sessionComplete"] is True
+    assert parsed[0]["nextQuestion"] is None
+
+
+@pytest.mark.asyncio
+async def test_stream_path_a_empty_queue():
+    """Path A: 큐 비어있음 → done(sessionComplete=True)."""
+    from app.services.interview_service import process_answer_stream
+
+    events = []
+    async for e in process_answer_stream(
+        "이력서", [], [], "질문", "hr", "답변"
+    ):
+        events.append(e)
+
+    parsed = _parse_sse_events(events)
+    assert len(parsed) == 1
+    assert parsed[0]["type"] == "done"
+    assert parsed[0]["sessionComplete"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_path_b_followup_true():
+    """Path B: shouldFollowUp=True → 질문 텍스트 token N개 + done(follow_up)."""
+    from app.services.interview_service import process_answer_stream
+
+    followup_result = ({"shouldFollowUp": True, "followupQuestion": "더 설명해 주세요."}, None, "")
+    queue_item = QueueItem(persona="tech_lead", type="main")
+
+    with patch("app.services.interview_service._check_followup", return_value=followup_result), \
+         patch("asyncio.sleep", return_value=None):
+        events = []
+        async for e in process_answer_stream(
+            "이력서",
+            [MagicMock(persona="hr")],
+            [queue_item],
+            "질문", "hr", "모호한 답변"
+        ):
+            events.append(e)
+
+    parsed = _parse_sse_events(events)
+    token_events = [p for p in parsed if p["type"] == "token"]
+    done_events = [p for p in parsed if p["type"] == "done"]
+
+    # Path B도 이제 token 스트리밍: "더 설명해 주세요." = 4단어
+    assert len(token_events) >= 1
+    reconstructed = "".join(t["text"] for t in token_events)
+    assert "더" in reconstructed
+    assert len(done_events) == 1
+    assert done_events[0]["sessionComplete"] is False
+    assert done_events[0]["nextQuestion"]["type"] == "follow_up"
+
+
+@pytest.mark.asyncio
+async def test_stream_path_c_next_question():
+    """Path C: shouldFollowUp=False → JSON silent 수집 후 question 텍스트만 token N개 + done."""
+    from app.services.interview_service import process_answer_stream
+
+    no_followup_result = ({"shouldFollowUp": False}, None, "")
+    # LLM이 JSON 전체를 한 토큰으로 반환하는 시나리오
+    async_stream = make_async_stream_mock(['{"question": "다음 질문입니다.", "personaLabel": "기술팀장"}'])
+    async_client_mock = MagicMock()
+    async_client_mock.chat.completions.create = AsyncMock(return_value=async_stream)
+
+    queue_item = QueueItem(persona="tech_lead", type="main")
+
+    with patch("app.services.interview_service._check_followup", return_value=no_followup_result), \
+         patch("app.services.llm_client._get_async_client", return_value=async_client_mock), \
+         patch("asyncio.sleep", return_value=None):
+        events = []
+        async for e in process_answer_stream(
+            "이력서",
+            [MagicMock(persona="hr")],
+            [queue_item],
+            "질문", "hr", "구체적인 답변"
+        ):
+            events.append(e)
+
+    parsed = _parse_sse_events(events)
+    token_events = [p for p in parsed if p["type"] == "token"]
+    done_events = [p for p in parsed if p["type"] == "done"]
+
+    assert len(token_events) >= 1
+    # token은 JSON 키가 아닌 사람이 읽을 수 있는 텍스트여야 함
+    reconstructed = "".join(t["text"] for t in token_events)
+    assert "다음" in reconstructed
+    assert "{" not in reconstructed  # JSON 원문이 노출되지 않아야 함
+    assert len(done_events) == 1
+    assert done_events[0]["sessionComplete"] is False
+    assert done_events[0]["nextQuestion"]["question"] == "다음 질문입니다."
+
+
+@pytest.mark.asyncio
+async def test_stream_error_event_on_exception():
+    """예외 발생 → error 이벤트."""
+    from app.services.interview_service import process_answer_stream
+
+    queue_item = QueueItem(persona="tech_lead", type="main")
+
+    with patch("app.services.interview_service._check_followup", side_effect=Exception("LLM 오류")):
+        events = []
+        async for e in process_answer_stream(
+            "이력서",
+            [MagicMock(persona="hr")],
+            [queue_item],
+            "질문", "hr", "답변"
+        ):
+            events.append(e)
+
+    parsed = _parse_sse_events(events)
+    assert any(p["type"] == "error" for p in parsed)

--- a/engine/tests/unit/services/test_llm_client_stream.py
+++ b/engine/tests/unit/services/test_llm_client_stream.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class AsyncStreamMock:
+    """AsyncOpenAI streaming mock — chunks는 content 문자열 목록."""
+
+    def __init__(self, chunks: list[str]):
+        self.chunks = chunks
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for text in self.chunks:
+            choice = MagicMock()
+            choice.delta.content = text if text != "" else None
+            chunk = MagicMock()
+            chunk.choices = [choice] if text != "" else []
+            yield chunk
+
+
+def make_async_stream_mock(chunks: list[str]):
+    return AsyncStreamMock(chunks)
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_yields_3_chunks():
+    """3개 content chunk → 정확히 3번 yield."""
+    from app.services.llm_client import call_llm_stream
+
+    stream_mock = make_async_stream_mock(["안녕", "하세", "요"])
+    fake_client = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=stream_mock)
+
+    with patch("app.services.llm_client._get_async_client", return_value=fake_client):
+        tokens = []
+        async for token in call_llm_stream("테스트 프롬프트"):
+            tokens.append(token)
+
+    assert tokens == ["안녕", "하세", "요"]
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_skips_empty_content():
+    """빈 content chunk(None 또는 choices=[])는 yield 안 함."""
+    from app.services.llm_client import call_llm_stream
+
+    stream_mock = make_async_stream_mock(["첫", "", "번째"])
+    fake_client = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=stream_mock)
+
+    with patch("app.services.llm_client._get_async_client", return_value=fake_client):
+        tokens = []
+        async for token in call_llm_stream("테스트"):
+            tokens.append(token)
+
+    assert tokens == ["첫", "번째"]
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_raises_llm_error_on_exception():
+    """API 예외 → LLMError raise."""
+    from app.parsers.exceptions import LLMError
+    from app.services.llm_client import call_llm_stream
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(side_effect=Exception("API 오류"))
+
+    with patch("app.services.llm_client._get_async_client", return_value=fake_client):
+        with pytest.raises(LLMError):
+            async for _ in call_llm_stream("테스트"):
+                pass

--- a/services/siw/.ai.md
+++ b/services/siw/.ai.md
@@ -88,7 +88,7 @@ siw/
 │   │       │   └── sessions/route.ts     # GET → 완료된 세션 목록 (GrowthSession[])
 │   │       ├── interview/
 │   │       │   ├── start/route.ts        # POST → 면접 세션 시작
-│   │       │   ├── answer/route.ts       # POST → 답변 제출 + 다음 질문
+│   │       │   ├── answer/route.ts       # POST → SSE 스트림 (드레인 패턴) + done 이벤트 DB 업데이트
 │   │       │   ├── followup/route.ts     # POST → 꼬리질문 생성
 │   │       │   └── [sessionId]/
 │   │       │       └── complete/route.ts # PATCH → 면접 종료 (sessionComplete=true, 멱등성 보장)
@@ -211,6 +211,28 @@ ENABLE_RAG=            # RAG 활성화 여부 (optional — "true"로 설정 시
 - siw가 Prisma/Supabase로 면접 세션 상태 관리
 - engine 수정 없이 siw에서 세션 영속성 구현
 - RLS: Supabase에서 interview_sessions, resumes 테이블에 별도 SQL로 활성화 필요
+
+## SSE 스트리밍 (이슈 #215, 2026-03-24)
+
+`POST /api/interview/answer` — SSE 드레인 패턴으로 마이그레이션.
+
+**드레인 패턴**:
+- `engineResponse.body.tee()` → `[drainStream, clientStream]`
+- drain task: 클라이언트 disconnect 무관하게 `done` 이벤트까지 완주 → `saveEngineResult` + `updateAfterAnswer` 보장
+- client stream: 클라이언트에 SSE 파스스루
+- `await drainPromise` — route handler 종료 전 drain 완료 대기 (max_tokens=2048, tee() 버퍼 ~8KB 허용)
+
+**재시도 로직 변경** (`interviewService.answerStream`):
+- 기존: `resp.json()` 실패 시 3회 재시도
+- 변경: SSE 연결 자체 실패(HTTP 비정상/네트워크)만 재시도, 스트림 파싱 오류는 재시도 안 함
+
+**engineResultCache 처리**:
+- 캐시 존재 시: fetch 없이 캐시 데이터를 `done` 이벤트로 즉시 반환
+
+**SSE 이벤트 타입** (`src/lib/sse-utils.ts`): `token`, `done`, `error`
+
+**클라이언트** (`app/(app)/interview/[sessionId]/page.tsx`):
+- `parseSSEStream(res.body)` 로 `done` 이벤트에서 `nextQuestion`, `sessionComplete` 추출
 
 ## 작업 전 확인
 - `engine/.ai.md` — 엔진 API 계약 확인
@@ -412,6 +434,14 @@ ENABLE_RAG=            # RAG 활성화 여부 (optional — "true"로 설정 시
   - [x] tests/api/resumes-route.test.ts: /parse 미호출 + resumeText 전달 검증 2케이스 추가
   - [x] tests/ui/upload-form.test.tsx: 2-step UX 반영 7케이스로 전면 수정
   - [x] vitest 29/29 통과 (이슈 #162 관련 테스트 전부)
+- [x] Issue #215: SSE 스트리밍 — 면접 답변 실시간 스트리밍 (완료)
+  - [x] src/lib/sse-utils.ts: parseSSELine, parseSSEStream (async generator)
+  - [x] src/lib/interview/interview-service.ts: answerStream() — engineResultCache 캐시 hit 시 가짜 스트림, SSE 연결 실패만 3회 재시도
+  - [x] src/app/api/interview/answer/route.ts: tee() 드레인 패턴 — 클라이언트 disconnect 무관하게 done 이벤트 DB 업데이트 보장
+  - [x] src/app/(app)/interview/[sessionId]/page.tsx: parseSSEStream으로 done 이벤트 파싱, 세션 상태 업데이트
+  - [x] src/lib/interview/__tests__/interview-service-stream.test.ts: 7케이스
+  - [x] src/app/api/interview/answer/__tests__/route.test.ts: 6케이스
+  - [x] vitest 13/13 통과
 - [ ] Week 4: 특색 기능 + 배포
 
 ## 규칙 변경 시 컨펌 필요

--- a/services/siw/src/app/(app)/interview/[sessionId]/page.tsx
+++ b/services/siw/src/app/(app)/interview/[sessionId]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 import React, { useState, useEffect, useRef } from "react";
+import { flushSync } from "react-dom";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import InterviewChat from "@/components/InterviewChat";
 import type { QuestionWithPersona, HistoryItem, InterviewMode, PracticeFeedback } from "@/lib/types";
+import { parseSSEStream } from "@/lib/sse-utils";
 
 export default function InterviewSessionPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -23,7 +25,16 @@ export default function InterviewSessionPage() {
   const [lastScore, setLastScore] = useState<number | null>(null);
   const [practiceAnswer, setPracticeAnswer] = useState("");
   const [fetchingFeedback, setFetchingFeedback] = useState(false);
+  const [retryInputVisible, setRetryInputVisible] = useState(false);
+  const [streamingText, setStreamingText] = useState("");
+  const [streamingPersona, setStreamingPersona] = useState<{ persona: string; personaLabel: string } | null>(null);
+  const [pendingAnswer, setPendingAnswer] = useState("");
   const initialized = useRef(false);
+  const chatBottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    chatBottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [history, currentQuestion, streamingText]);
 
   useEffect(() => {
     if (initialized.current) return;
@@ -38,32 +49,66 @@ export default function InterviewSessionPage() {
     }
   }, [sessionId]);
 
+  async function consumeAnswerStream(body: ReadableStream<Uint8Array>) {
+    setStreamingText("");
+    let donePayload: { nextQuestion: QuestionWithPersona | null; sessionComplete: boolean } | null = null;
+    for await (const event of parseSSEStream(body)) {
+      if (event.type === "token") {
+        flushSync(() => setStreamingText(prev => prev + event.text));
+      } else if (event.type === "meta") {
+        setStreamingPersona({ persona: event.persona, personaLabel: event.personaLabel });
+      } else if (event.type === "done") {
+        donePayload = event as { type: "done"; nextQuestion: QuestionWithPersona | null; updatedQueue: unknown[]; sessionComplete: boolean };
+      } else if (event.type === "error") {
+        setStreamingText("");
+        setStreamingPersona(null);
+        setPendingAnswer("");
+        setError(event.message);
+        throw new Error(event.message);
+      }
+    }
+    setStreamingText("");
+    setStreamingPersona(null);
+    return donePayload;
+  }
+
   async function handleSubmit() {
     if (!answer.trim() || submitting || fetchingFeedback) return;
 
     if (interviewMode === "real") {
       setSubmitting(true);
       setError("");
+      const submittedAnswer = answer;
+      setPendingAnswer(submittedAnswer);
       try {
         const res = await fetch("/api/interview/answer", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sessionId, currentAnswer: answer }),
+          body: JSON.stringify({ sessionId, currentAnswer: submittedAnswer }),
         });
-        const data = await res.json();
-        if (!res.ok) { setError(data.message); return; }
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({ message: "오류 발생" }));
+          setError(data.message);
+          setPendingAnswer("");
+          return;
+        }
+        if (!res.body) { setError("스트림 응답이 없습니다."); setPendingAnswer(""); return; }
+
+        const doneEvent = await consumeAnswerStream(res.body);
+
         if (currentQuestion) {
           setHistory(prev => [...prev, {
             persona: currentQuestion.persona,
             personaLabel: currentQuestion.personaLabel,
             question: currentQuestion.question,
-            answer,
+            answer: submittedAnswer,
             type: currentQuestion.type ?? "main",
           }]);
         }
         setAnswer("");
-        setCurrentQuestion(data.nextQuestion);
-        setSessionComplete(data.sessionComplete);
+        setPendingAnswer("");
+        setCurrentQuestion(doneEvent?.nextQuestion ?? null);
+        setSessionComplete(doneEvent?.sessionComplete ?? false);
       } finally {
         setSubmitting(false);
       }
@@ -73,6 +118,7 @@ export default function InterviewSessionPage() {
       setError("");
       const currentAnswerText = answer;
       const prevAnswer = isRetried ? lastAnswer : undefined;
+      setPendingAnswer(currentAnswerText);
       try {
         const body: Record<string, unknown> = {
           question: currentQuestion?.question ?? "",
@@ -87,17 +133,22 @@ export default function InterviewSessionPage() {
           body: JSON.stringify(body),
         });
         const data = await res.json();
-        if (!res.ok) { setError(data.message); return; }
+        if (!res.ok) { setError(data.message); setPendingAnswer(""); return; }
 
         if (!isRetried) {
           setLastAnswer(currentAnswerText);
           setLastScore(data.score);
+        } else {
+          setLastAnswer(currentAnswerText);  // 재답변 시에도 lastAnswer 업데이트 (다음질문으로 전송할 답변)
+          setRetryInputVisible(false);
         }
         setAnswer("");
+        setPendingAnswer("");
         setPracticeAnswer(currentAnswerText);
         setPracticeFeedback(data);
       } catch {
         setError("피드백 생성에 실패했습니다.");
+        setPendingAnswer("");
       } finally {
         setFetchingFeedback(false);
       }
@@ -106,20 +157,29 @@ export default function InterviewSessionPage() {
 
   function handleRetry() {
     setIsRetried(true);
+    setRetryInputVisible(true);
   }
 
   async function handleNextQuestion() {
     if (submitting) return;
     setSubmitting(true);
     setError("");
+    setPracticeFeedback(null);
+    setRetryInputVisible(false);
+    setPendingAnswer(lastAnswer);
     try {
       const res = await fetch("/api/interview/answer", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId, currentAnswer: lastAnswer }),
       });
-      const data = await res.json();
-      if (!res.ok) { setError(data.message); return; }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ message: "오류 발생" }));
+        setError(data.message);
+        setPendingAnswer("");
+        return;
+      }
+      const doneEvent = res.body ? await consumeAnswerStream(res.body) : null;
       if (currentQuestion) {
         setHistory(prev => [...prev, {
           persona: currentQuestion!.persona,
@@ -129,13 +189,16 @@ export default function InterviewSessionPage() {
           type: currentQuestion!.type ?? "main",
         }]);
       }
-      setPracticeFeedback(null);
+      setPendingAnswer("");
       setIsRetried(false);
       setLastAnswer("");
       setLastScore(null);
       setPracticeAnswer("");
-      setCurrentQuestion(data.nextQuestion);
-      setSessionComplete(data.sessionComplete);
+      setCurrentQuestion(doneEvent?.nextQuestion ?? null);
+      setSessionComplete(doneEvent?.sessionComplete ?? false);
+    } catch {
+      setPendingAnswer("");
+      setError("다음 질문을 불러오지 못했습니다.");
     } finally {
       setSubmitting(false);
     }
@@ -186,10 +249,15 @@ export default function InterviewSessionPage() {
             isRetried={isRetried}
             practiceAnswer={practiceAnswer}
             isNextLoading={submitting}
+            streamingText={streamingText}
+            streamingPersona={streamingPersona}
+            pendingAnswer={pendingAnswer}
+            isFetchingFeedback={fetchingFeedback}
           />
+          <div ref={chatBottomRef} />
         </div>
 
-        {!sessionComplete && (!practiceFeedback || isRetried) && (
+        {!sessionComplete && (!practiceFeedback || retryInputVisible) && (
           <div className="glass-card rounded-2xl p-4 sticky bottom-4">
             <textarea
               data-testid="answer-input"

--- a/services/siw/src/app/api/interview/answer/__tests__/route.test.ts
+++ b/services/siw/src/app/api/interview/answer/__tests__/route.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// interviewService mock
+vi.mock('@/lib/interview/interview-service', () => ({
+  interviewService: {
+    answerStream: vi.fn(),
+  },
+}))
+
+// interviewRepository mock
+vi.mock('@/lib/interview/interview-repository', () => ({
+  interviewRepository: {
+    findById: vi.fn(),
+    saveEngineResult: vi.fn().mockResolvedValue(undefined),
+    updateAfterAnswer: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+// supabase/server mock
+vi.mock('@/lib/supabase/server', () => ({
+  createServerClient: vi.fn(() => ({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }) },
+  })),
+}))
+
+// next/headers mock
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({}),
+}))
+
+// @prisma/client mock
+vi.mock('@prisma/client', () => ({
+  Prisma: {
+    PrismaClientKnownRequestError: class extends Error {
+      code: string
+      constructor(msg: string, opts: { code: string }) {
+        super(msg)
+        this.code = opts.code
+      }
+    },
+    DbNull: null,
+  },
+}))
+
+import { interviewService } from '@/lib/interview/interview-service'
+import { interviewRepository } from '@/lib/interview/interview-repository'
+import { POST } from '../route'
+
+const mockAnswerStream = vi.mocked(interviewService.answerStream)
+const mockFindById = vi.mocked(interviewRepository.findById)
+const mockSaveEngineResult = vi.mocked(interviewRepository.saveEngineResult)
+const mockUpdateAfterAnswer = vi.mocked(interviewRepository.updateAfterAnswer)
+
+function makeSSEStream(events: object[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  const chunks = events.map(e => encoder.encode(`data: ${JSON.stringify(e)}\n\n`))
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+const mockSession = {
+  id: 'session-1',
+  userId: 'user-1',
+  resumeText: '테스트 이력서',
+  currentQuestion: '자기소개를 해주세요.',
+  currentPersona: 'hr',
+  currentQuestionType: 'main' as const,
+  questionsQueue: [],
+  history: [],
+  sessionComplete: false,
+  engineResultCache: null,
+  reportJson: null,
+}
+
+describe('POST /api/interview/answer (drain pattern)', () => {
+  beforeEach(() => {
+    mockAnswerStream.mockReset()
+    mockFindById.mockReset()
+    mockSaveEngineResult.mockReset()
+    mockUpdateAfterAnswer.mockReset()
+    mockFindById.mockResolvedValue(mockSession)
+    mockSaveEngineResult.mockResolvedValue(undefined)
+    mockUpdateAfterAnswer.mockResolvedValue(undefined)
+  })
+
+  it('SSE 스트림을 클라이언트에 파스스루하고 done 이벤트로 DB를 업데이트한다', async () => {
+    const donePayload = {
+      nextQuestion: { question: '다음 질문', persona: 'hr', personaLabel: 'HR 담당자', type: 'main' },
+      updatedQueue: [],
+      sessionComplete: false,
+    }
+    mockAnswerStream.mockResolvedValue(new Response(
+      makeSSEStream([
+        { type: 'token', text: '토큰' },
+        { type: 'done', ...donePayload },
+      ]),
+      { headers: { 'Content-Type': 'text/event-stream' } }
+    ))
+
+    const request = new Request('http://localhost/api/interview/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'session-1', currentAnswer: '답변입니다.' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream')
+
+    const text = await response.text()
+    expect(text).toContain('"type":"token"')
+    expect(text).toContain('"type":"done"')
+
+    // drain: saveEngineResult 호출 확인
+    expect(mockSaveEngineResult).toHaveBeenCalledWith('session-1', expect.objectContaining({
+      sessionComplete: false,
+    }))
+
+    // drain: updateAfterAnswer 호출 확인
+    expect(mockUpdateAfterAnswer).toHaveBeenCalledWith('session-1', expect.objectContaining({
+      engineResultCache: null,
+      sessionComplete: false,
+    }))
+  })
+
+  it('engineResultCache 존재 시 done 이벤트만 반환한다', async () => {
+    const cachedResult = {
+      nextQuestion: { question: '캐시 질문', persona: 'hr', personaLabel: 'HR 담당자', type: 'main' },
+      updatedQueue: [],
+      sessionComplete: false,
+    }
+    mockFindById.mockResolvedValue({
+      ...mockSession,
+      engineResultCache: cachedResult,
+    })
+    mockAnswerStream.mockResolvedValue(new Response(
+      makeSSEStream([{ type: 'done', ...cachedResult }]),
+      { headers: { 'Content-Type': 'text/event-stream' } }
+    ))
+
+    const request = new Request('http://localhost/api/interview/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'session-1', currentAnswer: '답변입니다.' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('"type":"done"')
+    expect(text).not.toContain('"type":"token"')
+  })
+
+  it('인증 없이 401을 반환한다', async () => {
+    const { createServerClient } = await import('@/lib/supabase/server')
+    vi.mocked(createServerClient).mockReturnValueOnce({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+    } as ReturnType<typeof createServerClient>)
+
+    const request = new Request('http://localhost/api/interview/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'session-1', currentAnswer: '답변' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(401)
+  })
+
+  it('다른 사용자 세션에 403을 반환한다', async () => {
+    mockFindById.mockResolvedValue({ ...mockSession, userId: 'other-user' })
+
+    const request = new Request('http://localhost/api/interview/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'session-1', currentAnswer: '답변' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(403)
+  })
+
+  it('공백만인 답변에 400을 반환한다', async () => {
+    const request = new Request('http://localhost/api/interview/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'session-1', currentAnswer: '   ' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+  })
+
+  it('token 이벤트 0개 스트림도 정상 처리된다 (done만)', async () => {
+    const donePayload = {
+      nextQuestion: null,
+      updatedQueue: [],
+      sessionComplete: true,
+    }
+    mockAnswerStream.mockResolvedValue(new Response(
+      makeSSEStream([{ type: 'done', ...donePayload }]),
+      { headers: { 'Content-Type': 'text/event-stream' } }
+    ))
+
+    const request = new Request('http://localhost/api/interview/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'session-1', currentAnswer: '마지막 답변' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('"sessionComplete":true')
+    expect(text).not.toContain('"type":"token"')
+  })
+})

--- a/services/siw/src/app/api/interview/answer/route.ts
+++ b/services/siw/src/app/api/interview/answer/route.ts
@@ -1,12 +1,22 @@
 import { ENGINE_ERROR_MESSAGES } from "@/lib/error-messages";
 import { interviewRepository } from "@/lib/interview/interview-repository";
 import { interviewService } from "@/lib/interview/interview-service";
+import { EngineAnswerResponseSchema } from "@/lib/interview/schemas";
+import { parseSSEStream } from "@/lib/sse-utils";
+import type { SSEEvent } from "@/lib/sse-utils";
 import { createServerClient } from "@/lib/supabase/server";
 import { Prisma } from "@prisma/client";
 import { cookies } from "next/headers";
+import type { PersonaType } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
+
+const PERSONA_LABELS: Record<string, string> = {
+  hr: "HR 담당자",
+  tech_lead: "기술 리드",
+  executive: "임원",
+};
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
@@ -26,12 +36,92 @@ export async function POST(request: Request) {
   const trimmedAnswer = currentAnswer.trim().slice(0, 5000);
 
   try {
-    // ownership 체크
+    // ownership 체크 + 세션 상태 조회 (drain에서 history 업데이트에 필요)
     const session = await interviewRepository.findById(sessionId);
     if (session.userId !== user.id) return Response.json({ message: "권한이 없습니다" }, { status: 403 });
 
-    const result = await interviewService.answer(sessionId, trimmedAnswer);
-    return Response.json(result);
+    const engineResponse = await interviewService.answerStream(sessionId, trimmedAnswer);
+
+    if (!engineResponse.body) {
+      return Response.json({ message: ENGINE_ERROR_MESSAGES.interviewAnswerFailed }, { status: 502 });
+    }
+
+    const encoder = new TextEncoder();
+    const [drainStream, clientStream] = engineResponse.body.tee();
+
+    // drain task: 클라이언트 disconnect 무관하게 done까지 완주
+    // engineResultCache 보호 및 DB 업데이트 보장
+    const drainPromise = (async () => {
+      try {
+        for await (const event of parseSSEStream(drainStream)) {
+          if (event.type === 'done') {
+            const doneEvent = event as Extract<SSEEvent, { type: 'done' }>;
+            try {
+              // EngineAnswerResponseSchema로 파싱하여 타입 안전성 확보
+              const engineResult = EngineAnswerResponseSchema.parse({
+                nextQuestion: doneEvent.nextQuestion,
+                updatedQueue: doneEvent.updatedQueue,
+                sessionComplete: doneEvent.sessionComplete,
+              });
+
+              // write-ahead cache 저장
+              await interviewRepository.saveEngineResult(sessionId, engineResult);
+
+              // history 업데이트 + cache null 처리
+              const updatedHistory = [
+                ...session.history,
+                {
+                  persona: session.currentPersona as PersonaType,
+                  personaLabel: PERSONA_LABELS[session.currentPersona] ?? session.currentPersona,
+                  question: session.currentQuestion,
+                  answer: trimmedAnswer,
+                  type: session.currentQuestionType,
+                },
+              ];
+
+              await interviewRepository.updateAfterAnswer(sessionId, {
+                history: updatedHistory,
+                questionsQueue: engineResult.updatedQueue,
+                currentQuestion: engineResult.nextQuestion?.question ?? "",
+                currentPersona: engineResult.nextQuestion?.persona ?? "",
+                currentQuestionType: engineResult.nextQuestion?.type ?? "main",
+                sessionComplete: engineResult.sessionComplete,
+                engineResultCache: null,
+              });
+            } catch (dbErr) {
+              console.error("[answer] drain DB 처리 실패:", dbErr);
+            }
+          }
+        }
+      } catch (err) {
+        // drain 실패는 무시 — 클라이언트에는 이미 스트림 전달됨
+        console.error("[answer] drain stream 처리 오류:", err);
+      }
+    })();
+
+    // 클라이언트 스트림 파스스루
+    const responseStream = new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const event of parseSSEStream(clientStream)) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          }
+        } catch {
+          // 클라이언트 disconnect — drain은 계속 진행
+        }
+        controller.close();
+        // 클라이언트 스트림 종료 후 drain 완료 대기 (disconnect 후에도 DB 업데이트 보장)
+        await drainPromise;
+      },
+    });
+
+    return new Response(responseStream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+    });
   } catch (e) {
     if (e instanceof Error && e.message === "session_complete")
       return Response.json({ message: "이미 완료된 면접 세션입니다." }, { status: 400 });

--- a/services/siw/src/components/InterviewChat.tsx
+++ b/services/siw/src/components/InterviewChat.tsx
@@ -27,9 +27,13 @@ interface Props {
   isRetried?: boolean;
   practiceAnswer?: string;
   isNextLoading?: boolean;
+  streamingText?: string;
+  streamingPersona?: { persona: string; personaLabel: string } | null;
+  pendingAnswer?: string;
+  isFetchingFeedback?: boolean;
 }
 
-export default function InterviewChat({ currentQuestion, history, sessionComplete, interviewMode, practiceFeedback, onRetryAnswer, onNextQuestion, isRetried, practiceAnswer, isNextLoading }: Props) {
+export default function InterviewChat({ currentQuestion, history, sessionComplete, interviewMode, practiceFeedback, onRetryAnswer, onNextQuestion, isRetried, practiceAnswer, isNextLoading, streamingText, streamingPersona, pendingAnswer, isFetchingFeedback }: Props) {
   return (
     <div className="space-y-6">
       {history.map((item, i) => {
@@ -44,7 +48,7 @@ export default function InterviewChat({ currentQuestion, history, sessionComplet
                 data-testid="persona-label"
                 className={`${style.nameColor} mb-2 text-sm`}
               >
-                {PERSONA_LABELS[item.persona] ?? item.persona}
+                {item.personaLabel || PERSONA_LABELS[item.persona] || item.persona}
               </p>
               <p className="text-sm text-[#1F2937] leading-relaxed">{item.question}</p>
             </div>
@@ -58,6 +62,7 @@ export default function InterviewChat({ currentQuestion, history, sessionComplet
         );
       })}
 
+      {/* 현재 질문 — 항상 표시 (스트리밍 중에도) */}
       {!sessionComplete && currentQuestion && (() => {
         const style = PERSONA_STYLE[currentQuestion.persona] ?? PERSONA_STYLE.hr;
         return (
@@ -69,9 +74,58 @@ export default function InterviewChat({ currentQuestion, history, sessionComplet
               data-testid="persona-label"
               className={`${style.nameColor} mb-2 text-sm`}
             >
-              {PERSONA_LABELS[currentQuestion.persona] ?? currentQuestion.persona}
+              {currentQuestion.personaLabel || PERSONA_LABELS[currentQuestion.persona] || currentQuestion.persona}
             </p>
             <p className="text-sm text-[#1F2937] leading-relaxed">{currentQuestion.question}</p>
+          </div>
+        );
+      })()}
+
+      {/* 사용자 답변 (제출 후 스트리밍 중 optimistic 표시) */}
+      {!sessionComplete && pendingAnswer && (
+        <div
+          data-testid="pending-answer"
+          className="ml-8 bg-white rounded-2xl p-4 border border-black/8"
+        >
+          <p className="text-sm text-[#4B5563] leading-relaxed">{pendingAnswer}</p>
+        </div>
+      )}
+
+      {/* 연습 모드 — 첫 제출 피드백 생성 중 스피너 (피드백 카드 없을 때) */}
+      {!sessionComplete && interviewMode === "practice" && isFetchingFeedback && !practiceFeedback && (
+        <div className="rounded-2xl p-4 border bg-white border-purple-200">
+          <div className="flex items-center gap-2">
+            <span className="w-4 h-4 border-2 border-purple-200 border-t-purple-500 rounded-full animate-spin" />
+            <p className="text-sm text-[#9CA3AF]">피드백 생성 중...</p>
+          </div>
+        </div>
+      )}
+
+      {/* 첫 토큰 대기 중 스피너 */}
+      {!sessionComplete && pendingAnswer && !streamingText && !isFetchingFeedback && (
+        <div className="rounded-2xl p-4 border bg-white border-purple-200">
+          <div className="flex items-center gap-2">
+            <span className="w-4 h-4 border-2 border-purple-200 border-t-purple-500 rounded-full animate-spin" />
+            <p className="text-sm text-[#9CA3AF]">질문 생성 중...</p>
+          </div>
+        </div>
+      )}
+
+      {/* 다음 질문 스트리밍 */}
+      {!sessionComplete && streamingText && (() => {
+        const persona = streamingPersona?.persona ?? "hr";
+        const style = PERSONA_STYLE[persona] ?? PERSONA_STYLE.hr;
+        const label = streamingPersona?.personaLabel ?? (PERSONA_LABELS[persona] ?? persona);
+        return (
+          <div
+            data-testid="streaming-text"
+            className={`rounded-2xl p-4 border ${style.bg} ${style.border}`}
+          >
+            <p className={`${style.nameColor} mb-2 text-sm`}>{label}</p>
+            <p className="text-sm text-[#1F2937] leading-relaxed">
+              {streamingText}
+              <span className="inline-block w-0.5 h-3.5 bg-purple-500 ml-0.5 animate-pulse" />
+            </p>
           </div>
         );
       })()}
@@ -83,7 +137,7 @@ export default function InterviewChat({ currentQuestion, history, sessionComplet
       )}
 
       {/* 연습 모드 — 제출한 답변 버블 */}
-      {interviewMode === "practice" && practiceFeedback && practiceAnswer && (
+      {!sessionComplete && interviewMode === "practice" && practiceFeedback && practiceAnswer && (
         <div className="ml-8 bg-white rounded-2xl p-4 border border-black/[0.08]">
           <p className="text-xs text-gray-400 mb-1 font-semibold">내 답변</p>
           <p className="text-sm text-[#4B5563] leading-relaxed whitespace-pre-wrap">{practiceAnswer}</p>
@@ -91,7 +145,7 @@ export default function InterviewChat({ currentQuestion, history, sessionComplet
       )}
 
       {/* 연습 모드 피드백 카드 */}
-      {interviewMode === "practice" && practiceFeedback && (
+      {!sessionComplete && interviewMode === "practice" && practiceFeedback && (
         <div className="glass-card rounded-2xl p-5 space-y-4 border border-violet-200">
           <div className="flex items-center justify-between">
             <p className="text-sm font-bold text-violet-700">AI 피드백</p>
@@ -188,6 +242,16 @@ export default function InterviewChat({ currentQuestion, history, sessionComplet
                 : "다음 질문으로"
               }
             </button>
+          </div>
+        </div>
+      )}
+
+      {/* 연습 모드 — 재답변 피드백 생성 중 스피너 (피드백 카드 아래) */}
+      {!sessionComplete && interviewMode === "practice" && isFetchingFeedback && practiceFeedback && (
+        <div className="rounded-2xl p-4 border bg-white border-purple-200">
+          <div className="flex items-center gap-2">
+            <span className="w-4 h-4 border-2 border-purple-200 border-t-purple-500 rounded-full animate-spin" />
+            <p className="text-sm text-[#9CA3AF]">피드백 생성 중...</p>
           </div>
         </div>
       )}

--- a/services/siw/src/lib/interview/__tests__/interview-service-stream.test.ts
+++ b/services/siw/src/lib/interview/__tests__/interview-service-stream.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// fetch mock
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+// interviewRepository mock
+vi.mock('@/lib/interview/interview-repository', () => ({
+  interviewRepository: {
+    findById: vi.fn(),
+    saveEngineResult: vi.fn().mockResolvedValue(undefined),
+    updateAfterAnswer: vi.fn().mockResolvedValue(undefined),
+    create: vi.fn(),
+  },
+}))
+
+// resumeRepository mock
+vi.mock('@/lib/resume-repository', () => ({
+  resumeRepository: {
+    findById: vi.fn(),
+  },
+}))
+
+// observability mock
+vi.mock('@/lib/observability/event-logger', () => ({
+  withEventLogging: vi.fn((event, sessionId, fn) => fn({ retry_count: 0 })),
+}))
+
+import { interviewRepository } from '@/lib/interview/interview-repository'
+import { interviewService } from '../interview-service'
+
+const mockFindById = vi.mocked(interviewRepository.findById)
+
+function makeSSEStream(events: object[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  const chunks = events.map(e => encoder.encode(`data: ${JSON.stringify(e)}\n\n`))
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+const mockSession = {
+  id: 'session-1',
+  userId: 'user-1',
+  resumeText: '테스트 이력서',
+  currentQuestion: '자기소개를 해주세요.',
+  currentPersona: 'hr',
+  currentQuestionType: 'main' as const,
+  questionsQueue: [],
+  history: [],
+  sessionComplete: false,
+  engineResultCache: null,
+  reportJson: null,
+}
+
+describe('interviewService.answerStream', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockFindById.mockReset()
+    mockFindById.mockResolvedValue(mockSession)
+  })
+
+  it('SSE 연결 성공 시 Response를 반환한다', async () => {
+    mockFetch.mockResolvedValue(new Response(
+      makeSSEStream([
+        { type: 'done', nextQuestion: null, updatedQueue: [], sessionComplete: true },
+      ]),
+      { status: 200 }
+    ))
+
+    const result = await interviewService.answerStream('session-1', '답변')
+    expect(result).toBeInstanceOf(Response)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('?stream=true 쿼리 파라미터로 엔진을 호출한다', async () => {
+    mockFetch.mockResolvedValue(new Response(makeSSEStream([]), { status: 200 }))
+
+    await interviewService.answerStream('session-1', '답변')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('?stream=true'),
+      expect.any(Object),
+    )
+  })
+
+  it('연결 실패 시 3회 재시도한다', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('네트워크 오류'))
+      .mockRejectedValueOnce(new Error('네트워크 오류'))
+      .mockResolvedValue(new Response(makeSSEStream([]), { status: 200 }))
+
+    const result = await interviewService.answerStream('session-1', '답변')
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(result).toBeInstanceOf(Response)
+  })
+
+  it('3회 모두 실패 시 에러를 던진다', async () => {
+    mockFetch.mockRejectedValue(new Error('네트워크 오류'))
+
+    await expect(interviewService.answerStream('session-1', '답변')).rejects.toThrow()
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('HTTP 비정상 응답 시 재시도한다', async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValue(new Response(makeSSEStream([]), { status: 200 }))
+
+    await interviewService.answerStream('session-1', '답변')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('engineResultCache 존재 시 캐시 데이터를 done 이벤트로 반환한다', async () => {
+    const cachedResult = {
+      nextQuestion: { question: '캐시 질문', persona: 'hr', personaLabel: 'HR 담당자', type: 'main' },
+      updatedQueue: [],
+      sessionComplete: false,
+    }
+    mockFindById.mockResolvedValue({ ...mockSession, engineResultCache: cachedResult })
+
+    const result = await interviewService.answerStream('session-1', '답변')
+
+    // fetch가 호출되지 않아야 함 (캐시 사용)
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    // 반환된 스트림에서 done 이벤트만 있어야 함
+    const text = await result.text()
+    expect(text).toContain('"type":"done"')
+    expect(text).not.toContain('"type":"token"')
+  })
+
+  it('session_complete 세션에 에러를 던진다', async () => {
+    mockFindById.mockResolvedValue({ ...mockSession, sessionComplete: true })
+
+    await expect(interviewService.answerStream('session-1', '답변')).rejects.toThrow('session_complete')
+  })
+})

--- a/services/siw/src/lib/interview/interview-service.ts
+++ b/services/siw/src/lib/interview/interview-service.ts
@@ -69,6 +69,73 @@ export const interviewService = {
     return { sessionId, firstQuestion: parsed.firstQuestion };
   },
 
+  /**
+   * SSE 스트리밍 answer: 엔진 SSE 스트림 Response를 반환.
+   * engineResultCache 존재 시: 스트리밍 없이 done 이벤트만 담은 가짜 스트림 반환.
+   * 재시도: SSE 연결 실패(HTTP 비정상/네트워크)만 재시도, 스트림 파싱 오류는 재시도 안 함.
+   */
+  async answerStream(sessionId: string, currentAnswer: string): Promise<Response> {
+    const session = await interviewRepository.findById(sessionId);
+    if (session.sessionComplete) throw new Error("session_complete");
+
+    // engineResultCache 존재 시: 캐시 데이터를 done 이벤트로 즉시 반환
+    if (session.engineResultCache) {
+      const engineResult = EngineAnswerResponseSchema.parse(session.engineResultCache);
+      const doneEvent = {
+        type: 'done',
+        nextQuestion: engineResult.nextQuestion,
+        updatedQueue: engineResult.updatedQueue,
+        sessionComplete: engineResult.sessionComplete,
+      };
+      const encoder = new TextEncoder();
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(doneEvent)}\n\n`));
+          controller.close();
+        },
+      });
+      return new Response(body, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+      });
+    }
+
+    // SSE 연결 실패만 재시도
+    const historyForEngine = session.history.map(({ type: _type, ...rest }) => rest);
+    const fetchOptions = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        resumeText: session.resumeText,
+        history: historyForEngine,
+        questionsQueue: session.questionsQueue,
+        currentQuestion: session.currentQuestion,
+        currentPersona: session.currentPersona,
+        currentAnswer,
+      }),
+      signal: AbortSignal.timeout(55000),
+    };
+
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const res = await fetch(`${ENGINE_BASE_URL}/api/interview/answer?stream=true`, fetchOptions);
+        if (!res.ok || !res.body) {
+          throw new Error(`stream init failed: ${res.status}`);
+        }
+        return res;
+      } catch (err) {
+        lastErr = err;
+        console.error(`[interviewService.answerStream] attempt ${attempt + 1} failed:`, err);
+        if (attempt < 2) await new Promise(r => setTimeout(r, 1000));
+      }
+    }
+    throw lastErr ?? new Error("engine_answer_stream_failed");
+  },
+
   async answer(sessionId: string, currentAnswer: string): Promise<InterviewAnswerResponse> {
     const session = await interviewRepository.findById(sessionId);
     if (session.sessionComplete) throw new Error("session_complete");

--- a/services/siw/src/lib/sse-utils.ts
+++ b/services/siw/src/lib/sse-utils.ts
@@ -1,0 +1,31 @@
+export type SSEEvent =
+  | { type: 'token'; text: string }
+  | { type: 'meta'; persona: string; personaLabel: string }
+  | { type: 'done'; nextQuestion: unknown; updatedQueue: unknown[]; sessionComplete: boolean }
+  | { type: 'error'; message: string }
+
+export function parseSSELine(line: string): SSEEvent | null {
+  if (!line.startsWith('data: ')) return null
+  try { return JSON.parse(line.slice(6)) as SSEEvent } catch { return null }
+}
+
+export async function* parseSSEStream(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSEEvent> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const parts = buffer.split('\n\n')
+      buffer = parts.pop() ?? ''
+      for (const part of parts) {
+        for (const line of part.split('\n')) {
+          const event = parseSSELine(line)
+          if (event) yield event
+        }
+      }
+    }
+  } finally { reader.releaseLock() }
+}

--- a/services/siw/tests/api/interview-answer-route.test.ts
+++ b/services/siw/tests/api/interview-answer-route.test.ts
@@ -1,19 +1,47 @@
 import { describe, it, expect, vi } from "vitest";
 import { Prisma } from "@prisma/client";
 
+function makeSSEBody(events: object[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const lines = events.map(e => `data: ${JSON.stringify(e)}\n\n`).join("");
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines));
+      controller.close();
+    },
+  });
+}
+
+const doneEvent = {
+  type: "done",
+  nextQuestion: { persona: "tech_lead", personaLabel: "기술 리드", question: "기술 질문", type: "main" },
+  updatedQueue: [],
+  sessionComplete: false,
+};
+
 vi.mock("@/lib/interview/interview-service", () => ({
   interviewService: {
-    answer: vi.fn().mockResolvedValue({
-      nextQuestion: { persona: "tech_lead", personaLabel: "기술 리드", question: "기술 질문" },
-      updatedQueue: [],
-      sessionComplete: false,
-    }),
+    answerStream: vi.fn().mockResolvedValue(
+      new Response(makeSSEBody([doneEvent]), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    ),
   },
 }));
 
 vi.mock("@/lib/interview/interview-repository", () => ({
   interviewRepository: {
-    findById: vi.fn().mockResolvedValue({ userId: "user-123" }),
+    findById: vi.fn().mockResolvedValue({
+      userId: "user-123",
+      history: [],
+      currentPersona: "hr",
+      currentPersonaLabel: "HR 담당자",
+      currentQuestion: "자기소개 해주세요",
+      currentQuestionType: "main",
+    }),
+    saveEngineResult: vi.fn().mockResolvedValue(undefined),
+    updateAfterAnswer: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -30,7 +58,7 @@ vi.mock("@/lib/supabase/server", () => ({
 }));
 
 describe("POST /api/interview/answer", () => {
-  it("200: nextQuestion 반환", async () => {
+  it("200: text/event-stream 응답 + done 이벤트에 sessionComplete 포함", async () => {
     const { POST } = await import("@/app/api/interview/answer/route");
     const req = new Request("http://localhost/api/interview/answer", {
       method: "POST",
@@ -39,8 +67,7 @@ describe("POST /api/interview/answer", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.sessionComplete).toBe(false);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
   });
 
   it("400: sessionId 없을 때", async () => {
@@ -56,7 +83,7 @@ describe("POST /api/interview/answer", () => {
 
   it("500: service throws 시", async () => {
     const { interviewService } = await import("@/lib/interview/interview-service");
-    (interviewService.answer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("error"));
+    (interviewService.answerStream as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("error"));
     const { POST } = await import("@/app/api/interview/answer/route");
     const req = new Request("http://localhost/api/interview/answer", {
       method: "POST",
@@ -73,7 +100,7 @@ describe("POST /api/interview/answer", () => {
       "No InterviewSession found",
       { code: "P2025", clientVersion: "5.0.0" }
     );
-    (interviewService.answer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(p2025Error);
+    (interviewService.answerStream as ReturnType<typeof vi.fn>).mockRejectedValueOnce(p2025Error);
     const { POST } = await import("@/app/api/interview/answer/route");
     const req = new Request("http://localhost/api/interview/answer", {
       method: "POST",
@@ -86,7 +113,7 @@ describe("POST /api/interview/answer", () => {
 
   it("404: session_not_found 에러", async () => {
     const { interviewService } = await import("@/lib/interview/interview-service");
-    (interviewService.answer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+    (interviewService.answerStream as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("session_not_found")
     );
     const { POST } = await import("@/app/api/interview/answer/route");
@@ -101,7 +128,7 @@ describe("POST /api/interview/answer", () => {
 
   it("400: session_complete (이미 완료된 세션)", async () => {
     const { interviewService } = await import("@/lib/interview/interview-service");
-    (interviewService.answer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+    (interviewService.answerStream as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("session_complete")
     );
     const { POST } = await import("@/app/api/interview/answer/route");

--- a/services/siw/tests/e2e/interview-streaming.spec.ts
+++ b/services/siw/tests/e2e/interview-streaming.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * SSE 스트리밍 e2e 테스트
+ * - Next.js: localhost:3000  (실제 서버)
+ * - Engine:  localhost:8000  (실제 서버)
+ *
+ * 전략:
+ *   1. 실제 엔진 호출 → text/event-stream 확인
+ *   2. /api/interview/answer 를 mock으로 인터셉트 → token 이벤트 주입
+ *      → MutationObserver로 streaming-text 버블의 순간 출현 감지
+ */
+
+async function startInterviewSession(page: import("@playwright/test").Page) {
+  await page.goto("/interview/new");
+  await page.waitForLoadState("networkidle", { timeout: 10_000 });
+
+  const resumeList = page.locator('.space-y-2 button').first();
+  await expect(resumeList).toBeVisible({ timeout: 8_000 });
+  await resumeList.click();
+
+  await page.getByTestId("mode-real").click();
+  await page.getByTestId("start-interview").click();
+  await expect(page).toHaveURL(/\/interview\/.+/, { timeout: 30_000 });
+  await expect(page.getByTestId("chat-message").first()).toBeVisible({ timeout: 30_000 });
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 테스트 1: 실제 엔진 — text/event-stream 응답 확인
+// ──────────────────────────────────────────────────────────────────────────────
+test("실제 엔진 응답이 text/event-stream인지 확인", async ({ page }) => {
+  await startInterviewSession(page);
+
+  const responsePromise = page.waitForResponse(
+    (res) => res.url().includes("/api/interview/answer"),
+    { timeout: 90_000 }
+  );
+
+  await page.getByTestId("answer-input").fill("테스트 답변입니다.");
+  await page.getByTestId("submit-answer").click();
+
+  const response = await responsePromise;
+  const contentType = response.headers()["content-type"] ?? "";
+  console.log("[e2e] Content-Type:", contentType);
+  expect(contentType).toContain("text/event-stream");
+
+  await expect(
+    page.getByTestId("chat-message").last().or(page.getByTestId("session-complete"))
+  ).toBeVisible({ timeout: 60_000 });
+}, { timeout: 180_000 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 테스트 2: mock SSE + MutationObserver → streaming-text 순간 출현 감지
+// ──────────────────────────────────────────────────────────────────────────────
+test("mock SSE — token 이벤트가 DOM에 렌더링된다 (MutationObserver 감지)", async ({ page }) => {
+  await startInterviewSession(page);
+
+  // mock SSE 응답 (token 10개 + done 1개)
+  await page.route("**/api/interview/answer", async (route) => {
+    const tokens = ["다음으로 ", "본인의 ", "가장 ", "큰 ", "강점을 ", "말씀해", "주세요.", " 구체적인 ", "사례와 ", "함께."];
+    const done = {
+      type: "done",
+      nextQuestion: { persona: "tech_lead", personaLabel: "기술 리드", question: "다음으로 본인의 가장 큰 강점을 말씀해주세요.", type: "main" },
+      updatedQueue: [],
+      sessionComplete: false,
+    };
+
+    let body = "";
+    for (const t of tokens) body += `data: ${JSON.stringify({ type: "token", text: t })}\n\n`;
+    body += `data: ${JSON.stringify(done)}\n\n`;
+
+    await route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+      body,
+    });
+  });
+
+  // MutationObserver 주입 — streaming-text 가 DOM에 추가되는 순간을 감지
+  await page.evaluate(() => {
+    (window as any).__streamingTextSeen = false;
+    (window as any).__streamingTextContent = "";
+    const obs = new MutationObserver(() => {
+      const el = document.querySelector('[data-testid="streaming-text"]');
+      if (el) {
+        (window as any).__streamingTextSeen = true;
+        (window as any).__streamingTextContent = el.textContent ?? "";
+      }
+    });
+    obs.observe(document.body, { childList: true, subtree: true, characterData: true });
+    (window as any).__streamingObserver = obs;
+  });
+
+  // 답변 제출
+  await page.getByTestId("answer-input").fill("제 강점은 빠른 학습 능력입니다.");
+  await page.getByTestId("submit-answer").click();
+
+  // 최종 상태 대기 (다음 질문 또는 세션 완료)
+  await expect(
+    page.getByTestId("chat-message").last().or(page.getByTestId("session-complete"))
+  ).toBeVisible({ timeout: 30_000 });
+
+  // observer 해제
+  await page.evaluate(() => (window as any).__streamingObserver?.disconnect());
+
+  // 플래그 확인
+  const sawStreaming: boolean = await page.evaluate(() => (window as any).__streamingTextSeen);
+  const streamingContent: string = await page.evaluate(() => (window as any).__streamingTextContent);
+
+  console.log("[e2e] sawStreaming:", sawStreaming);
+  console.log("[e2e] streamingContent:", streamingContent);
+
+  expect(
+    sawStreaming,
+    `streaming-text 버블이 DOM에 한 번도 나타나지 않음.
+     flushSync 동작을 확인하세요: page.tsx의 for await 루프 내 flushSync(() => setStreamingText(...))`
+  ).toBe(true);
+}, { timeout: 180_000 });

--- a/services/siw/tests/setup.ts
+++ b/services/siw/tests/setup.ts
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom";
+
+// JSDOM does not implement scrollIntoView — stub it globally (browser environment only)
+if (typeof window !== "undefined") {
+  window.HTMLElement.prototype.scrollIntoView = function () {};
+}

--- a/services/siw/tests/ui/interview-chat.test.tsx
+++ b/services/siw/tests/ui/interview-chat.test.tsx
@@ -29,6 +29,31 @@ describe("InterviewChat", () => {
     );
     expect(screen.getByTestId("session-complete")).toBeInTheDocument();
   });
+
+  it("streamingText prop 있을 때 streaming-text 버블 렌더링", () => {
+    render(
+      <InterviewChat
+        currentQuestion={null}
+        history={[]}
+        sessionComplete={false}
+        streamingText="스트리밍 중..."
+      />
+    );
+    expect(screen.getByTestId("streaming-text")).toBeInTheDocument();
+    expect(screen.getByTestId("streaming-text")).toHaveTextContent("스트리밍 중...");
+  });
+
+  it("streamingText 없을 때 streaming-text 버블 미표시", () => {
+    render(
+      <InterviewChat
+        currentQuestion={null}
+        history={[]}
+        sessionComplete={false}
+        streamingText=""
+      />
+    );
+    expect(screen.queryByTestId("streaming-text")).not.toBeInTheDocument();
+  });
 });
 
 const mockPracticeFeedback = {


### PR DESCRIPTION
## 이슈 배경

면접 답변 제출 후 다음 질문이 생성되는 3~10초 동안 사용자가 빈 화면만 보는 문제를 해결한다. `?stream=true` opt-in 파라미터로 하위 호환성을 유지하며, 엔진이 LLM 토큰을 생성하는 즉시 클라이언트에 스트리밍해 답변 제출 후 ~0.5초 만에 첫 글자가 출력된다. seung/kwan/lww는 별도 백로그(#234/#235/#236)로 순차 마이그레이션 예정.

## 완료 기준 (AC)

- [x] `engine/app/routers/interview.py` — `?stream=true` 쿼리 파라미터, 기본값 false(하위 호환 유지)
- [x] `engine/app/services/interview_service.py` — LLM `stream=True`, token·meta·done 이벤트 yield
- [x] **siw** `interview-service.ts` — 재시도 기준 스트림 연결 실패로 재설계
- [x] **siw** `answer/route.ts` — tee() 드레인 패턴, done 이벤트 DB 업데이트
- [x] **siw** 클라이언트 컴포넌트 — token 렌더링, done 세션 상태 업데이트
- [x] 테스트: engine pytest 12개 + siw vitest 222개 전체 통과
- [x] seung/kwan/lww — 별도 백로그 이슈 #234/#235/#236 생성 완료
- [x] 레거시 JSON 코드 제거 — 전 서비스 마이그레이션 완료 후 별도 처리

## 작업 내역

### Phase 1: SSE 스트리밍 기반 구현
- `engine/app/services/llm_client.py` — `AsyncOpenAI` lazy 싱글톤 + `call_llm_stream()` async generator
- `engine/app/services/interview_service.py` — `_sse_token/meta/done/error` 헬퍼 + `process_answer_stream()` Path A/B/C
- `engine/app/routers/interview.py` — `?stream=true` Query 파라미터 + `StreamingResponse` 분기
- `siw/src/lib/sse-utils.ts` — `parseSSELine`, `parseSSEStream` 유틸
- `siw/src/lib/interview/interview-service.ts` — `answerStream()` + `engineResultCache` 처리 + 재시도 재설계
- `siw/src/app/api/interview/answer/route.ts` — `tee()` 드레인 패턴 (disconnect 후에도 DB 업데이트 보장)

### Phase 2: 스트리밍 UX 개선 + 연습모드 대응
- `meta` SSE 이벤트 — 스트리밍 전 페르소나 정보 선발송
- Path B(꼬리질문) 단어 단위 스트리밍 + 0.07s 딜레이
- Path C JSON silent 수집 — `question` 텍스트만 스트리밍 (JSON 원문 노출 버그 수정)
- `pendingAnswer` — 답변 제출 즉시 내 버블 표시 (optimistic display)
- "질문 생성 중..." 스피너, "피드백 생성 중..." 스피너
- `retryInputVisible` 분리 — 연습모드 3번 제출 가능 버그 수정
- `consumeAnswerStream` 헬퍼 추출 — page.tsx SSE 파싱 루프 중복 제거

Closes #215