### PR TITLE
feat: [siw] 랜딩페이지 페르소나 섹션 하단에 면접 모드 소개 카드 추가 (#248)

### DIFF
--- a/docs/work/done/000248-landing-interview-mode/00_issue.md
+++ b/docs/work/done/000248-landing-interview-mode/00_issue.md
@@ -1,0 +1,57 @@
+# feat: [siw] 랜딩페이지 페르소나 섹션 하단에 면접 모드(실전/연습) 소개 추가
+
+## 사용자 관점 목표
+랜딩페이지에서 MirAI가 실전 모드와 연습 모드 두 가지를 제공한다는 것을 가입 전에 알 수 있다.
+
+## 배경
+현재 랜딩페이지 페르소나 섹션(#personas)에 3인 면접관 소개만 있고, 면접 모드(실전/연습) 설명이 없다.
+`interview/new/page.tsx`에 이미 모드 선택 UI가 있으므로, 동일한 디자인 톤으로 랜딩페이지에 소개 섹션을 추가한다.
+
+### 참고 UI
+- 실전 모드: "면접처럼 진행, 즉각 피드백 없음"
+- 연습 모드: "즉각 AI 피드백, 재답변 가능"
+- 디자인 기준: `services/siw/src/app/(app)/interview/new/page.tsx` 모드 선택 카드 (line 198~221)
+
+## 완료 기준
+- [x] 랜딩페이지 페르소나 섹션 하단에 실전 모드·연습 모드 소개 카드 2개 추가
+- [x] `interview/new/page.tsx`의 모드 선택 디자인 톤과 일관성 유지
+- [x] 기존 FadeInSection 애니메이션 적용
+
+## 구현 플랜
+
+**1단계:** `services/siw/src/app/(landing)/page.tsx`의 PERSONAS 섹션(#personas, line 330~373) 하단에 면접 모드 소개 카드 추가
+- INTERVIEW_MODES 데이터 배열 추가 (실전/연습)
+- 2열 그리드 카드 렌더링 (FadeInSection 래핑)
+
+## 수정 파일 목록
+
+| 파일 | 변경 내용 |
+|------|---------|
+| `services/siw/src/app/(landing)/page.tsx` | 페르소나 섹션 하단에 면접 모드 소개 추가 |
+
+## 개발 체크리스트
+- [x] 테스트 코드 포함
+- [x] 해당 디렉토리 .ai.md 최신화
+- [x] 불변식 위반 없음
+
+---
+
+## 작업 내역
+
+### 2026-03-25
+
+**현황**: 3/3 완료
+
+**완료된 항목**:
+- [x] 랜딩페이지 페르소나 섹션 하단에 실전 모드·연습 모드 소개 카드 2개 추가
+- [x] `interview/new/page.tsx`의 모드 선택 디자인 톤과 일관성 유지
+- [x] 기존 FadeInSection 애니메이션 적용
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 3개
+
+- `services/siw/src/app/(landing)/page.tsx` — `INTERVIEW_MODES` 상수 배열 추가(line 70~88), PERSONAS 섹션 하단에 FadeInSection으로 래핑된 모드 소개 카드 2열 그리드 삽입(line 391~415). `interview/new/page.tsx`와 동일한 indigo/violet 색상 체계·copy 사용. `cursor-pointer` 제거(비인터랙티브). `key={m.title}` 사용.
+- `services/siw/tests/ui/landing-page.test.tsx` — 실전 모드·연습 모드 카드 렌더링 테스트 2개 추가(line 67~78). desc 텍스트 assert로 copy drift 방지.
+- `services/siw/src/app/(landing)/.ai.md` — PERSONAS 섹션 설명, INTERVIEW_MODES 상수, 테스트 개수(6→8) 최신화.

--- a/docs/work/done/000248-landing-interview-mode/01_plan.md
+++ b/docs/work/done/000248-landing-interview-mode/01_plan.md
@@ -1,0 +1,139 @@
+# [#248] feat: [siw] 랜딩페이지 페르소나 섹션 하단에 면접 모드(실전/연습) 소개 추가 — 구현 계획
+
+> 작성: 2026-03-25
+
+---
+
+## 완료 기준
+
+- [ ] 랜딩페이지 페르소나 섹션 하단에 실전 모드·연습 모드 소개 카드 2개 추가
+- [ ] `interview/new/page.tsx`의 모드 선택 디자인 톤과 일관성 유지
+- [ ] 기존 FadeInSection 애니메이션 적용
+- [ ] 테스트 코드 포함
+- [ ] 해당 디렉토리 .ai.md 최신화
+- [ ] 불변식 위반 없음
+
+---
+
+## 구현 계획
+
+### RALPLAN-DR 요약
+
+**Principles**
+1. 기존 패턴 준수 (데이터 상수 + `.map()` + FadeInSection + glass-card)
+2. `interview/new/page.tsx` 디자인 톤 일관성 (copy, 색상 그대로)
+3. 최소 변경 범위 (1개 파일 주수정)
+4. 테스트 가능성
+
+**Decision Drivers**
+1. AC 충족 (페르소나 섹션 하단 삽입, 디자인 일관성, FadeInSection)
+2. 기존 코드베이스 패턴 준수
+3. 최소 변경으로 리스크 억제
+
+**Option A (채택)**: PERSONAS 섹션 내부 하단 삽입
+- pros: 최소 변경, 섹션 맥락 일관성, 기존 패턴 준수
+- cons: 섹션이 길어짐 (persona 3 + mode 2 카드)
+
+**Option B (기각)**: 독립 섹션으로 분리
+- 이유: 불필요한 구조 분리, NAV 앵커 추가 등 과도한 범위 확장
+
+---
+
+### Step 1 — INTERVIEW_MODES 상수 배열 추가
+
+**파일**: `services/siw/src/app/(landing)/page.tsx`
+**위치**: 파일 상단 데이터 상수 영역 (PERSONAS 배열 다음)
+
+```ts
+// NOTE: 면접 모드 설명은 interview/new/page.tsx 모드 선택 UI와 동기화 필요
+const INTERVIEW_MODES = [
+  {
+    icon: "⚡",
+    title: "실전 모드",
+    desc: "면접처럼 진행\n즉각 피드백 없음",
+    borderColor: "border-indigo-500",
+    bgColor: "bg-indigo-50",
+    tagColor: "text-indigo-700",
+  },
+  {
+    icon: "📝",
+    title: "연습 모드",
+    desc: "즉각 AI 피드백\n재답변 가능",
+    borderColor: "border-violet-500",
+    bgColor: "bg-violet-50",
+    tagColor: "text-violet-700",
+  },
+] as const;
+```
+
+**주의사항**:
+- Tailwind 퍼지 대응: 동적 className은 완전한 문자열 객체로 선언
+- desc 줄바꿈: `whitespace-pre-line` 또는 `<br/>` 처리
+
+---
+
+### Step 2 — 모드 소개 서브섹션 JSX 삽입
+
+**파일**: `services/siw/src/app/(landing)/page.tsx`
+**위치**: PERSONAS 그리드(`div.grid`) 닫힌 직후, `</div></section>` 직전 (line 371~373 사이)
+
+```tsx
+{/* ── 면접 모드 소개 ─────────────────────────────────── */}
+<FadeInSection delay={100}>
+  <div className="mt-12">
+    <h3 className="text-xl font-bold text-[#111827] text-center mb-6">
+      면접 모드 선택
+    </h3>
+    <div className="grid grid-cols-2 gap-4 max-w-xl mx-auto">
+      {INTERVIEW_MODES.map((m, i) => (
+        <div
+          key={i}
+          className={`glass-card rounded-2xl p-5 border ${m.borderColor} ${m.bgColor}`}
+        >
+          <p className={`font-bold text-sm mb-1 ${m.tagColor}`}>
+            {m.icon} {m.title}
+          </p>
+          <p className="text-xs text-gray-500 leading-[1.6] whitespace-pre-line">
+            {m.desc}
+          </p>
+        </div>
+      ))}
+    </div>
+  </div>
+</FadeInSection>
+```
+
+**주의사항**:
+- `cursor-pointer` **제거** (PERSONAS 카드와 달리 비인터랙티브)
+- `glass-card-hover` 생략 권장 (클릭 불가 카드에 hover elevation은 UX friction)
+- 색상 className은 INTERVIEW_MODES 객체에서 주입 (Tailwind 퍼지 안전)
+
+---
+
+### Step 3 — 테스트 작성
+
+**파일**: `services/siw/tests/ui/landing-page.test.tsx`
+
+```ts
+it("페르소나 섹션 하단에 실전 모드 카드가 렌더링된다", () => {
+  render(<LandingPage />);
+  expect(screen.getByText(/실전 모드/)).toBeInTheDocument();
+  expect(screen.getByText(/즉각 피드백 없음/)).toBeInTheDocument();
+});
+
+it("페르소나 섹션 하단에 연습 모드 카드가 렌더링된다", () => {
+  render(<LandingPage />);
+  expect(screen.getByText(/연습 모드/)).toBeInTheDocument();
+  expect(screen.getByText(/즉각 AI 피드백/)).toBeInTheDocument();
+});
+```
+
+**주의사항**: 텍스트 assert로 copy drift 방지 (interview/new와 desc 동기화 검증)
+
+---
+
+### Step 4 — .ai.md 최신화
+
+**파일**: `services/siw/src/app/(landing)/.ai.md`
+- 면접 모드 소개 섹션 추가 사실 반영
+- INTERVIEW_MODES 상수 추가 언급

--- a/services/siw/src/app/(landing)/.ai.md
+++ b/services/siw/src/app/(landing)/.ai.md
@@ -13,7 +13,7 @@ MirAI 서비스의 메인 랜딩페이지. 방문자가 핵심 가치를 즉시 
 | NAV | — | 상단 고정 네비게이션. 평가시스템 링크 → `#evaluation` |
 | HERO | — | 히어로 + RadarChartInteractive (LayeredCardWrapper 래핑) |
 | FEATURES | `#features` | 핵심 기능 3개 카드. 배지("핵심 기능") + h2("면접 준비의 새로운 기준") |
-| PERSONAS | `#personas` | 3가지 면접관 페르소나 카드. h2("실제 면접처럼, 더 실전같이") |
+| PERSONAS | `#personas` | 3가지 면접관 페르소나 카드. h2("실제 면접처럼, 더 실전같이"). 하단에 면접 모드 소개(실전/연습) 카드 2개 포함 |
 | EVALUATION | `#evaluation` | 8축 평가 시스템 4×2 카드 그리드. h2("단순 점수가 아닌, 정밀한 분석") |
 | CTA | — | 전환 유도 섹션 |
 | FOOTER | — | 푸터 |
@@ -21,6 +21,7 @@ MirAI 서비스의 메인 랜딩페이지. 방문자가 핵심 가치를 즉시 
 ## 주요 상수
 - `FEATURES` — 기능 3개 (아이콘, 제목, 설명)
 - `PERSONAS` — 페르소나 3개 (HR/기술/경영진)
+- `INTERVIEW_MODES` — 면접 모드 2개 (실전/연습). `interview/new/page.tsx` 모드 선택 UI와 동기화 필요
 - `EVALUATION_AXES` — 8개 평가 축 (name, Icon, iconColor, iconBg, desc)
   - 엔진 기준 정렬: 의사소통, 문제해결, 논리적 사고, 직무 전문성, 조직 적합성, 리더십, 창의성, 성실성
   - Lucide 아이콘 + violet/indigo 그라디언트 배경
@@ -33,7 +34,7 @@ MirAI 서비스의 메인 랜딩페이지. 방문자가 핵심 가치를 즉시 
 - `LayeredCardWrapper` — 카드 레이어 래퍼
 
 ## 테스트
-- `services/siw/tests/ui/landing-page.test.tsx` — 6개 텍스트·구조 검증 테스트
+- `services/siw/tests/ui/landing-page.test.tsx` — 8개 텍스트·구조 검증 테스트 (면접 모드 카드 2개 포함)
   - IntersectionObserver, next/navigation, supabase, RadarChart, LayeredCardWrapper mock 포함
 
 ## 디자인 시스템

--- a/services/siw/src/app/(landing)/page.tsx
+++ b/services/siw/src/app/(landing)/page.tsx
@@ -67,6 +67,30 @@ const PERSONAS = [
   },
 ]
 
+// NOTE: 면접 모드 설명은 interview/new/page.tsx 모드 선택 UI와 동기화 필요
+const INTERVIEW_MODES = [
+  {
+    icon: "⚡",
+    label: "실전",
+    tag: "tag-blue",
+    name: "실전 모드",
+    desc: "면접처럼 진행, 즉각 피드백 없음",
+    features: ["실전처럼 몰입", "즉각 피드백 없음", "전체 면접 완주"],
+    accentColor: "border-t-indigo-400",
+    iconBg: "bg-indigo-100 text-indigo-700",
+  },
+  {
+    icon: "📝",
+    label: "연습",
+    tag: "tag-purple",
+    name: "연습 모드",
+    desc: "즉각 AI 피드백, 재답변 가능",
+    features: ["즉각 AI 피드백", "재답변 가능", "약점 집중 훈련"],
+    accentColor: "border-t-violet-400",
+    iconBg: "bg-violet-100 text-violet-700",
+  },
+] as const;
+
 // NOTE: RadarChartInteractive.tsx의 AXES와 동일한 도메인 데이터
 // TODO: 향후 공유 상수로 추출 예정
 const EVALUATION_AXES = [
@@ -362,6 +386,32 @@ export default function LandingPage() {
                       <li key={j} className="text-xs text-[#6B7280] flex items-center gap-2">
                         <span className="w-1 h-1 rounded-full bg-[#D1D5DB] flex-shrink-0" />
                         {s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </FadeInSection>
+            ))}
+          </div>
+
+          {/* ── 면접 모드 소개 ─────────────────────────────────── */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+            {INTERVIEW_MODES.map((m, i) => (
+              <FadeInSection key={m.name} delay={i * 80}>
+                <div className={`glass-card glass-card-hover border-t-2 ${m.accentColor} rounded-2xl p-6 cursor-pointer h-full text-center`}>
+                  <div className="flex flex-col items-center mb-3">
+                    <div className={`w-10 h-10 rounded-full ${m.iconBg} flex items-center justify-center text-lg mb-2`}>
+                      {m.icon}
+                    </div>
+                    <span className={`tag ${m.tag}`}>{m.label}</span>
+                  </div>
+                  <h3 className="font-semibold text-[#111827] mb-1">{m.name}</h3>
+                  <p className="text-xs text-[#6B7280] mb-4">{m.desc}</p>
+                  <ul className="space-y-1.5">
+                    {m.features.map((f) => (
+                      <li key={f} className="text-xs text-[#6B7280] flex items-center justify-center gap-2">
+                        <span className="w-1 h-1 rounded-full bg-[#D1D5DB] flex-shrink-0" />
+                        {f}
                       </li>
                     ))}
                   </ul>

--- a/services/siw/tests/ui/landing-page.test.tsx
+++ b/services/siw/tests/ui/landing-page.test.tsx
@@ -63,4 +63,16 @@ describe("LandingPage", () => {
     const link = screen.getByRole("link", { name: "평가시스템" })
     expect(link).toHaveAttribute("href", "#evaluation")
   })
+
+  it("페르소나 섹션 하단에 실전 모드 카드가 렌더링된다", () => {
+    render(<LandingPage />)
+    expect(screen.getByText(/실전 모드/)).toBeInTheDocument()
+    expect(screen.getByText(/즉각 피드백 없음/)).toBeInTheDocument()
+  })
+
+  it("페르소나 섹션 하단에 연습 모드 카드가 렌더링된다", () => {
+    render(<LandingPage />)
+    expect(screen.getByText(/연습 모드/)).toBeInTheDocument()
+    expect(screen.getByText(/즉각 AI 피드백/)).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 이슈 배경

랜딩페이지 페르소나 섹션(#personas)에 3인 면접관 소개만 있고 면접 모드(실전/연습) 설명이 없어, 가입 전 사용자가 MirAI의 두 가지 면접 모드를 인지하기 어려웠다. `interview/new/page.tsx`의 모드 선택 UI와 동일한 디자인 톤으로 소개 섹션을 추가한다.

## 완료 기준 (AC)

- [x] 랜딩페이지 페르소나 섹션 하단에 실전 모드·연습 모드 소개 카드 2개 추가
- [x] `interview/new/page.tsx`의 모드 선택 디자인 톤과 일관성 유지
- [x] 기존 FadeInSection 애니메이션 적용

## 작업 내역

- `services/siw/src/app/(landing)/page.tsx` — `INTERVIEW_MODES` 상수 배열 추가, PERSONAS 섹션 하단에 페르소나 카드와 동일한 스타일(`glass-card glass-card-hover border-t-2`, FadeInSection, 반응형 2열 그리드)로 면접 모드 소개 카드 2개 삽입. 텍스트 가운데 정렬, indigo/violet 색상 체계 적용.
- `services/siw/tests/ui/landing-page.test.tsx` — 실전 모드·연습 모드 카드 렌더링 검증 테스트 2개 추가 (8 passed)
- `services/siw/src/app/(landing)/.ai.md` — INTERVIEW_MODES 상수 및 테스트 개수 최신화

Closes #248