### PR TITLE
fix: [siw] analyze route maxDuration 60→150 (ALB 300s 기준)

### DIFF
--- a/services/siw/src/app/api/resumes/analyze/route.ts
+++ b/services/siw/src/app/api/resumes/analyze/route.ts
@@ -6,7 +6,7 @@ import { cookies } from "next/headers"
 import { getEngineBaseUrl } from "@/lib/rag/embedding-client"
 
 export const runtime = "nodejs"
-export const maxDuration = 60
+export const maxDuration = 150
 
 function requireEngineBaseUrl(): string {
   const url = getEngineBaseUrl();


### PR DESCRIPTION
## 변경 내용

`/api/resumes/analyze/route.ts`의 `maxDuration` 60 → 150으로 증가.

AbortSignal.timeout(120s)에 맞춰 Vercel 배포 시 일관성 확보.

| 설정 | 이전 | 이후 |
|------|------|------|
| AbortSignal | 55s → 120s (PR #286) | 120s |
| maxDuration | 60 | 150 |
| ALB idle timeout | 60s | 300s |