### PR TITLE
feat: 합격 자소서 seed 데이터 적재 및 RAG 파이프라인 검증 (#294)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ temp/
 *.pkl
 *.parquet
 
+# RAG seed 데이터 (5MB 초과, DB에 적재됨 — 재생성: engine/scripts/extract_pdf_resumes.py)
+data/accepted_resumes.json
+
 # 테스트 fixtures는 무시
 **/tests/fixtures/**
 

--- a/data/.ai.md
+++ b/data/.ai.md
@@ -1,0 +1,51 @@
+# data/
+
+## 목적
+
+RAG 파이프라인 초기 적재용 정형 데이터 보관 디렉토리.
+`engine/scripts/build_resume_index.py`의 입력 파일이 위치한다.
+
+## 구조
+
+```
+data/
+└── accepted_resumes.json   # 합격 자소서 seed 데이터 (job_role, content, source)
+```
+
+## 파일 형식
+
+```json
+[
+  {
+    "job_role": "연구개발",
+    "content": "자기소개서 본문...",
+    "source": "회사명"
+  }
+]
+```
+
+- `job_role`: PDF 파일명 `{id}_{company}_{job_role}.pdf` 에서 자동 추출
+- `content`: pypdf로 추출한 PDF 본문 텍스트
+- `source`: 회사명 (PDF 파일명 2번째 파트)
+
+## 생성 방법
+
+```bash
+python engine/scripts/extract_pdf_resumes.py \
+  --input-dir "경로/to/pdfs" \
+  --output data/accepted_resumes.json
+```
+
+## 현황 (2026-03-27, #294)
+
+- 총 999개 레코드 (1000개 PDF 중 1개 content 누락으로 제외)
+- 공용 Supabase `accepted_resume_embeddings` 테이블에 적재 완료 (#198)
+- 재적재 시 `ON CONFLICT DO NOTHING` 으로 멱등 실행 가능
+
+## 주의사항
+
+- 개인 식별 정보(이름·연락처) 포함 금지
+- `accepted_resumes.json`은 7.20MB로 5MB 초과 → `.gitignore` 처리됨 (레포에 없음)
+  - 재생성 필요 시: `engine/scripts/extract_pdf_resumes.py` 실행
+  - DB 재적재 필요 시: `engine/scripts/build_resume_index.py` 실행
+- `*.pdf`, `*.csv` 등 원본 파일은 커밋 금지 (`.gitignore` 적용)

--- a/docs/work/done/000294-seed-data/00_issue.md
+++ b/docs/work/done/000294-seed-data/00_issue.md
@@ -1,0 +1,65 @@
+# feat: [seung][DE] 합격 자소서 seed 데이터 수집 및 초기 적재
+
+## 목적
+
+`accepted_resume_embeddings` 테이블에 초기 데이터를 적재하여 RAG 기능을 실제로 활성화한다.
+
+## 배경
+
+유저 기여 방식은 초기 데이터가 없는 cold start 문제와 데이터 부족 문제로 현실적이지 않다. 대신 링커리어 등 공개 합격 자소서 게시판에서 데이터를 직접 수집하여 `build_resume_index.py`로 초기 적재한다.
+
+#293 (임베딩 파이프라인 자동화)의 선행 조건.
+
+## 완료 기준
+
+- [x] 공개 합격 자소서 데이터 수집 (직군별 최소 5건 이상)
+- [x] `data/accepted_resumes.json` 형식으로 정리 (`job_role`, `content`, `source` 필드)
+- [x] `build_resume_index.py --dry-run` 으로 데이터 유효성 검증
+- [x] `build_resume_index.py` 실행으로 `accepted_resume_embeddings` 테이블 초기 적재 완료
+- [x] `ENABLE_RAG=true` 환경에서 서류 진단 시 RAG 컨텍스트 실제 반영 확인
+
+## 구현 플랜
+
+### Step 1 — 데이터 수집
+링커리어 등 공개 합격 자소서 게시판에서 직군별 자소서 수집 후 JSON 형식으로 정리
+
+### Step 2 — 유효성 검증
+```bash
+python engine/scripts/build_resume_index.py \
+  --input data/accepted_resumes.json \
+  --dry-run
+```
+
+### Step 3 — 초기 적재
+```bash
+python engine/scripts/build_resume_index.py \
+  --input data/accepted_resumes.json
+```
+
+## 개발 체크리스트
+- [x] 해당 디렉토리 `.ai.md` 최신화 (`data/.ai.md` 신규 작성)
+- [x] 불변식 위반 없음 (임베딩 호출은 engine `/api/embed` 경유 확인)
+
+## 작업 내역
+
+### 2026-03-27
+
+**현황**: 5/5 AC 완료
+
+**실제 신규 작업**:
+- `extract_pdf_resumes.py`로 PDF 1000개 → `data/accepted_resumes.json` 변환 (999개 유효)
+- `data/.ai.md` 신규 작성
+
+**기확인 사항 (#198에서 기완료)**:
+- DB 적재: 공용 Supabase `accepted_resume_embeddings`에 999개 (#198에서 완료됨)
+- `build_resume_index.py --dry-run` 검증 및 RAG 파이프라인 E2E 동작 확인 (사후 검증)
+
+> 이슈 #294는 #198 완료 시점에 대부분 해결된 상태였음.
+> 이번에 실제로 추가된 산출물은 `data/accepted_resumes.json`, `data/.ai.md` 뿐.
+
+**변경 파일**:
+- `data/.ai.md` (신규)
+- `.gitignore` — `data/accepted_resumes.json` 추가 (7.20MB 초과, DB 적재 완료로 레포 불필요)
+
+> `data/accepted_resumes.json`은 생성됐으나 5MB 초과로 gitignore 처리. 재생성 시 `extract_pdf_resumes.py` 사용.
+

--- a/docs/work/done/000294-seed-data/01_plan.md
+++ b/docs/work/done/000294-seed-data/01_plan.md
@@ -1,0 +1,110 @@
+# [#294] feat: [seung][DE] 합격 자소서 seed 데이터 수집 및 초기 적재 — 구현 계획
+
+> 작성: 2026-03-27
+
+---
+
+## 완료 기준
+
+- [x] 공개 합격 자소서 데이터 수집 (직군별 최소 5건 이상)
+- [x] `data/accepted_resumes.json` 형식으로 정리 (`job_role`, `content`, `source` 필드)
+- [x] `build_resume_index.py --dry-run` 으로 데이터 유효성 검증
+- [x] `build_resume_index.py` 실행으로 `accepted_resume_embeddings` 테이블 초기 적재 완료
+- [x] `ENABLE_RAG=true` 환경에서 서류 진단 시 RAG 컨텍스트 실제 반영 확인
+
+---
+
+## 구현 계획
+
+### 사전 파악 사항
+
+- 파이프라인 스크립트 **3개 모두 이미 완성됨** — 새 코드 작성 불필요
+  - `engine/scripts/extract_pdf_resumes.py` — PDF → JSON 변환 (파일명에서 job_role 자동 추출)
+  - `engine/scripts/build_resume_index.py` — JSON → 엔진 임베딩 → Supabase upsert
+- PDF 파일명 패턴: `{id}_{company}_{job_role}.pdf` (예: `23969_서울우유협동조합_연구개발.pdf`)
+  - `job_role` = 파일명 3번째 파트, `source` = 2번째 파트(회사명) 자동 추출
+- `data/` 디렉토리 미존재 — 스크립트가 자동 생성 (`mkdir parents=True`)
+- `.gitignore`는 `.json` 미제외 → `data/accepted_resumes.json` 커밋 가능
+- RAG 활성화 조건: `ENABLE_RAG=true` + `RAG_DATABASE_URL` (공용 Supabase) + `ENGINE_BASE_URL`
+
+---
+
+### Step 1 — PDF → JSON 변환
+
+PDF 약 1000개를 `data/accepted_resumes.json`으로 변환한다.
+
+```bash
+python engine/scripts/extract_pdf_resumes.py \
+  --input-dir "D:/path/to/pdfs" \
+  --output data/accepted_resumes.json
+```
+
+**확인 사항:**
+- `완료: N개 레코드 → data/accepted_resumes.json` 출력
+- `건너뜀: M개 (텍스트 100자 미만)` — 이미지 PDF 등 추출 실패 건은 자동 제외됨
+- 출력 JSON의 `job_role` 필드가 파일명에서 올바르게 추출됐는지 샘플 확인
+
+---
+
+### Step 2 — dry-run 유효성 검증
+
+```bash
+python engine/scripts/build_resume_index.py \
+  --input data/accepted_resumes.json \
+  --dry-run
+```
+
+**확인 사항:**
+- `[로드] 총 N개 레코드` 출력 확인
+- `[dry-run] 검증 완료` 출력 확인
+- `[경고]` 항목(job_role·content 누락) 없음
+
+---
+
+### Step 3 — DB 초기 적재
+
+**사전 조건:**
+- 엔진 로컬 구동(`docker run`) 또는 EC2 엔진 접근 가능
+- `RAG_DATABASE_URL` 환경변수 설정 (공용 Supabase — 팀 공유 `.env` 참조, 개인 DB 아님)
+
+```bash
+export ENGINE_BASE_URL=http://localhost:8000   # 또는 EC2 엔진 URL
+export RAG_DATABASE_URL=postgresql://...       # 공용 Supabase
+
+python engine/scripts/build_resume_index.py \
+  --input data/accepted_resumes.json
+```
+
+**확인 사항:**
+- `완료: 총 N개 레코드 삽입` 출력
+- 재실행 시 `ON CONFLICT DO NOTHING`으로 0개 삽입 (멱등성)
+
+---
+
+### Step 4 — RAG 컨텍스트 반영 확인
+
+**서비스:** `services/seung` (서류 진단 경로)
+**RAG 코드:** `services/seung/src/lib/rag/`, `src/app/api/resume/feedback/route.ts`
+
+```bash
+# services/seung .env 설정
+ENABLE_RAG=true
+RAG_DATABASE_URL=...  # Step 3와 동일
+ENGINE_BASE_URL=...
+```
+
+서비스 로컬 실행 후 서류 진단 요청 → 엔진 `/api/resume/feedback` 응답의 `resume_context` 배열에 유사 자소서 포함 여부 확인.
+
+---
+
+### Step 5 — `.ai.md` 최신화
+
+- `data/.ai.md` 작성 (목적·구조·역할)
+
+---
+
+## 주의사항
+
+- `RAG_DATABASE_URL`은 개인 `DATABASE_URL`이 아닌 **공용 Supabase** 사용
+- `data/accepted_resumes.json`은 7.20MB로 5MB 초과 → `.gitignore` 처리 (레포 미포함)
+- 임베딩 호출은 엔진 `/api/embed` 경유 (불변식 #2) — `build_resume_index.py` 이미 준수


### PR DESCRIPTION
## 이슈 배경

`accepted_resume_embeddings` 테이블 초기 데이터 적재를 통해 서류 진단 RAG 기능을 활성화한다. DB 적재는 #198에서 기완료된 상태였으며, 이번 이슈에서는 `data/.ai.md` 작성 및 RAG 파이프라인 E2E 동작 확인을 수행했다. #293 (임베딩 자동화) 선행 조건 충족.

## 완료 기준 (AC)

- [x] 공개 합격 자소서 데이터 수집 (직군별 최소 5건 이상)
- [x] `data/accepted_resumes.json` 형식으로 정리 (`job_role`, `content`, `source` 필드)
- [x] `build_resume_index.py --dry-run` 으로 데이터 유효성 검증
- [x] `build_resume_index.py` 실행으로 `accepted_resume_embeddings` 테이블 초기 적재 완료
- [x] `ENABLE_RAG=true` 환경에서 서류 진단 시 RAG 컨텍스트 실제 반영 확인

## 작업 내역

**실제 신규 작업**:
- `extract_pdf_resumes.py`로 PDF 1000개 → `data/accepted_resumes.json` 변환 (999개 유효)
- `data/.ai.md` 신규 작성
- `.gitignore`에 `data/accepted_resumes.json` 추가 (7.20MB 초과, DB 적재 완료로 레포 불필요)

**기확인 사항 (#198에서 기완료)**:
- DB 적재: 공용 Supabase `accepted_resume_embeddings`에 999개
- RAG 파이프라인 E2E 검증: 임베딩 1024차원 정상, TOP 5 유사 자소서 검색 동작 (similarity 최고 0.54)

Closes #294