### PR TITLE
fix: getScoreColor·getBarStyle에 null score 전달 타입 에러 수정 (#309)

### DIFF
--- a/docs/work/done/000309-demo-getscore-null/00_issue.md
+++ b/docs/work/done/000309-demo-getscore-null/00_issue.md
@@ -1,0 +1,33 @@
+# fix: [siw] demo 페이지 getScoreColor null score 타입 에러로 빌드 실패
+
+## 목적
+demo 페이지 빌드 타입 에러를 수정한다.
+
+## 배경
+`item.score`가 `number | null` 타입인데 `getScoreColor(score: number)`에 직접 전달하여 TypeScript 빌드 실패 발생. PR #307 머지 후 Deploy siw to EC2 CI가 실패함.
+
+```
+./src/app/(landing)/demo/page.tsx:466:105
+Type error: Argument of type 'number | null' is not assignable to parameter of type 'number'.
+```
+
+## 완료 기준
+- [x] `item.score != null` 가드 추가로 TypeScript 빌드 통과
+- [ ] Deploy siw to EC2 CI 성공
+
+## 구현 플랜
+1. `services/siw/src/app/(landing)/demo/page.tsx:439`
+2. `getScoreColor(item.score)` → `item.score != null ? getScoreColor(item.score) : undefined`
+
+## 개발 체크리스트
+- [ ] 해당 디렉토리 .ai.md 최신화
+
+---
+
+## 작업 내역
+
+`services/siw/src/app/(landing)/demo/page.tsx` 2곳 수정:
+- `getScoreColor(item.score)` → `item.score != null ? getScoreColor(item.score) : undefined`
+- `getBarStyle(item.score)` → `item.score != null ? getBarStyle(item.score) : undefined`
+
+`AxisFeedback.score`가 `number | null`임에도 `number`만 받는 함수에 직접 전달해 빌드 타입 에러 발생. null 체크 가드를 추가해 해결. 로컬 `npm run build` 통과 확인.

--- a/docs/work/done/000309-demo-getscore-null/01_plan.md
+++ b/docs/work/done/000309-demo-getscore-null/01_plan.md
@@ -1,0 +1,17 @@
+# [#309] fix: [siw] demo 페이지 getScoreColor null score 타입 에러로 빌드 실패 — 구현 계획
+
+> 작성: 2026-03-27
+
+---
+
+## 완료 기준
+
+- [ ] `item.score != null` 가드 추가로 TypeScript 빌드 통과
+- [ ] Deploy siw to EC2 CI 성공
+
+---
+
+## 구현 계획
+
+`services/siw/src/app/(landing)/demo/page.tsx:466`
+- `getScoreColor(item.score)` → `item.score != null ? getScoreColor(item.score) : undefined`

--- a/services/siw/src/app/(landing)/demo/page.tsx
+++ b/services/siw/src/app/(landing)/demo/page.tsx
@@ -463,13 +463,13 @@ export default function DemoPage() {
                                 <span className="axis-row__name">{item.axisLabel}</span>
                               </div>
                               <div className="axis-row__scores">
-                                <span className="axis-row__current-score" style={{ color: getScoreColor(item.score) }}>
+                                <span className="axis-row__current-score" style={{ color: item.score != null ? getScoreColor(item.score) : undefined }}>
                                   {item.score}점
                                 </span>
                               </div>
                             </div>
                             <div className="axis-row__track">
-                              <div className="axis-row__bar-current" style={getBarStyle(item.score)} aria-hidden="true" />
+                              <div className="axis-row__bar-current" style={item.score != null ? getBarStyle(item.score) : undefined} aria-hidden="true" />
                             </div>
                             <p
                               className="axis-row__desc"


### PR DESCRIPTION
## 이슈 배경

PR #307 머지 후 `AxisFeedback.score`가 `number | null` 타입임에도 `number`만 받는 `getScoreColor`, `getBarStyle` 함수에 직접 전달해 TypeScript 빌드 실패. Deploy siw to EC2 CI가 차단됨.

## 완료 기준 (AC)

- [x] `item.score != null` 가드 추가로 TypeScript 빌드 통과
- [ ] Deploy siw to EC2 CI 성공 _(PR 머지 후 확인)_

## 작업 내역

`services/siw/src/app/(landing)/demo/page.tsx` 2곳 수정:
- `getScoreColor(item.score)` → `item.score != null ? getScoreColor(item.score) : undefined`
- `getBarStyle(item.score)` → `item.score != null ? getBarStyle(item.score) : undefined`

로컬 `npm run build` 통과 확인.

Closes #309