### PR TITLE
feat: [siw] 면접 시작 UX 개선 — 이력서 없을 때 업로드 유도 + 로고 아이콘 정리 (#311)

### DIFF
--- a/docs/work/done/000311-siw-interview-ux/00_issue.md
+++ b/docs/work/done/000311-siw-interview-ux/00_issue.md
@@ -1,0 +1,66 @@
+# feat: [siw] 면접 시작 UX 개선 — 이력서 없을 때 업로드 유도 + 로고 아이콘 정리
+
+## 사용자 관점 목표
+이력서 없는 사용자가 면접 시작 페이지에서 막히지 않고 자연스럽게 업로드로 유도되며, 사이드바 로고가 깔끔하게 정리된다.
+
+## 배경
+1. `/interview/new` 페이지에서 이력서가 없을 때 \"이력서를 먼저 업로드해주세요.\" 텍스트만 표시되고 다음 동선이 없어 사용자가 막힘
+2. 사이드바/헤더에 별 모양 아이콘(`rounded-[10px]` + star SVG, indigo-violet 그라디언트 배경)이 있는데 디자인상 불필요함. 옆의 MirAI 텍스트에 색상(그라디언트)을 넣어 아이콘 없이도 브랜드가 살도록 정리
+
+## 완료 기준
+- [x] `/interview/new` — 이력서 목록이 비어 있을 때 \"이력서 업로드하러 가기\" 버튼이 함께 표시되고, 클릭 시 `/resumes`로 이동한다
+- [x] 별 아이콘(`w-9 h-9 rounded-[10px]` star SVG) 이 제거된다
+- [x] MirAI 텍스트에 그라디언트 색상(`linear-gradient(135deg, #7C3AED, #4F46E5)`)이 적용되어 브랜드 식별이 유지된다
+
+## 구현 플랜
+1. `services/siw/src/app/(app)/interview/new/page.tsx` L181 — `resumes.length === 0` 분기에 `<button onClick={() => router.push('/resumes')}>` 추가
+2. 별 아이콘 위치 탐색: `rounded-\[10px\]` + star path로 grep → 해당 컴포넌트에서 아이콘 div 제거, MirAI `<span>` 에 그라디언트 스타일 적용 (Sidebar.tsx는 이미 적용됨 — 다른 컴포넌트 확인 필요)
+
+## 개발 체크리스트
+- [ ] 테스트 코드 포함
+- [ ] 해당 디렉토리 .ai.md 최신화
+- [ ] 불변식 위반 없음
+
+---
+
+## 작업 내역
+
+### 2026-03-27
+
+**현황**: 3/3 완료
+
+**완료된 항목**:
+- `/interview/new` — 이력서 없을 때 "이력서 업로드하러 가기" 버튼 추가
+- 별 아이콘(`w-9 h-9 rounded-[10px]` star SVG) 제거 (login, signup 페이지)
+- MirAI 텍스트에 그라디언트 색상 적용 (login, signup 페이지)
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 7개
+
+---
+
+#### 변경 파일 상세
+
+**`services/siw/src/app/(app)/interview/new/page.tsx`**
+- `resumes.length === 0` 분기에 단순 텍스트 대신 빈 상태 UI 추가
+- FileText 아이콘 + 설명 텍스트 + "이력서 업로드하러 가기" 버튼 구성
+- 버튼 클릭 시 `router.push('/resumes')` 연결
+- 버튼 디자인: 그라디언트 배경, ArrowRight 아이콘, hover 시 화살표 이동, active 눌림 피드백
+
+**`services/siw/src/app/(auth)/login/page.tsx`**
+- `w-9 h-9 rounded-[10px]` 별 아이콘 div 및 star SVG 제거
+- MirAI `<span>`에 기존 `.gradient-text` CSS 클래스 적용 (인라인 스타일 대신)
+
+**`services/siw/src/app/(auth)/signup/page.tsx`**
+- login과 동일 — 모바일용 로고 영역의 별 아이콘 제거, `.gradient-text` 적용
+
+**`services/siw/src/app/(app)/interview/new/__tests__/page.test.tsx`** (신규)
+- 빈 이력서 상태에서 버튼 렌더링 및 `/resumes` 이동 검증 (5개 테스트)
+
+**`services/siw/src/app/(auth)/__tests__/logo-branding.test.tsx`** (신규)
+- login/signup 별 아이콘 제거 및 `.gradient-text` 클래스 적용 검증 (7개 테스트)
+
+**`.ai.md` 2개**: interview/new, (auth) 디렉토리 최신화
+

--- a/docs/work/done/000311-siw-interview-ux/01_plan.md
+++ b/docs/work/done/000311-siw-interview-ux/01_plan.md
@@ -1,0 +1,80 @@
+# [#311] feat: [siw] 면접 시작 UX 개선 — 이력서 없을 때 업로드 유도 + 로고 아이콘 정리 — 구현 계획
+
+> 작성: 2026-03-27
+
+---
+
+## 완료 기준
+
+- [ ] `/interview/new` — 이력서 목록이 비어 있을 때 "이력서 업로드하러 가기" 버튼이 함께 표시되고, 클릭 시 `/resumes`로 이동한다
+- [ ] 별 아이콘(`w-9 h-9 rounded-[10px]` star SVG) 이 제거된다
+- [ ] MirAI 텍스트에 그라디언트 색상(`linear-gradient(135deg, #7C3AED, #4F46E5)`)이 적용되어 브랜드 식별이 유지된다
+
+---
+
+## 구현 계획
+
+### Step 1 — `/interview/new`: 이력서 없을 때 버튼 추가
+
+**파일**: `services/siw/src/app/(app)/interview/new/page.tsx`
+
+- L181-182: `resumes.length === 0` 분기의 `<p>이력서를 먼저 업로드해주세요.</p>` 를 아래로 교체
+
+```tsx
+) : resumes.length === 0 ? (
+  <div className="flex flex-col items-center gap-3 py-2">
+    <p className="text-sm text-gray-400">이력서를 먼저 업로드해주세요.</p>
+    <button
+      onClick={() => router.push('/resumes')}
+      className="text-sm font-semibold text-violet-600 hover:underline"
+    >
+      이력서 업로드하러 가기 →
+    </button>
+  </div>
+```
+
+- `router`는 파일 상단에 이미 `useRouter()` 사용 중인지 확인 후, 없으면 import 추가
+
+---
+
+### Step 2 — `login/page.tsx`: 별 아이콘 제거 + MirAI 그라디언트
+
+**파일**: `services/siw/src/app/(auth)/login/page.tsx`
+
+- L68-73: `<div className="w-9 h-9 rounded-[10px] ...">` + 내부 star SVG 전체 제거
+- L74: `<span className="text-lg font-extrabold text-gray-800">MirAI</span>` →
+
+```tsx
+<span className="text-lg font-extrabold"
+  style={{ background: "linear-gradient(135deg, #7C3AED, #4F46E5)", WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent" }}>
+  MirAI
+</span>
+```
+
+---
+
+### Step 3 — `signup/page.tsx`: 별 아이콘 제거 + MirAI 그라디언트
+
+**파일**: `services/siw/src/app/(auth)/signup/page.tsx`
+
+- L144-149: `<div className="w-9 h-9 rounded-[10px] ...">` + 내부 star SVG 전체 제거 (모바일용 로고)
+- L150: `<span className="text-lg font-extrabold text-gray-800">MirAI</span>` → 동일한 그라디언트 적용
+- 데스크탑용 사이드 로고 영역도 동일 패턴으로 별 아이콘 존재 여부 확인 후 처리
+
+---
+
+### Step 4 — 테스트 코드 작성
+
+**파일**: `services/siw/src/__tests__/interview-new-empty-resume.test.tsx` (신규)
+
+- `resumes.length === 0` 상태에서 "이력서 업로드하러 가기" 버튼이 렌더링되는지 확인
+- 버튼 클릭 시 `router.push('/resumes')` 호출되는지 확인
+- `resumes.length > 0` 상태에서 버튼이 없는지 확인
+
+---
+
+### 주의사항
+
+- `interview/new/page.tsx`의 `useRouter` 사용 여부 먼저 확인 (없으면 `import { useRouter } from 'next/navigation'` 추가)
+- signup 페이지에 데스크탑용 별 아이콘이 별도로 존재할 수 있음 → Grep으로 추가 확인
+- Sidebar.tsx는 이미 그라디언트 적용 완료 → 건드리지 않음

--- a/services/siw/src/app/(app)/interview/new/.ai.md
+++ b/services/siw/src/app/(app)/interview/new/.ai.md
@@ -7,10 +7,11 @@
 - `page.tsx` — 단일 페이지 (use client). Suspense + useSearchParams 사용
 
 ## 주요 흐름
-1. 페르소나 카드 3개 선택 (`hr | tech_lead | executive`)
-2. 면접 모드 선택 (`real | practice`) — `InterviewMode` 타입
-3. `/api/interview/new` POST → `sessionId` 응답 → `sessionStorage`에 첫 질문 + 모드 저장
-4. `/interview/[sessionId]`로 라우팅
+1. 이력서 선택 — `/api/resumes` GET으로 목록 로드; 이력서 없으면 "이력서 업로드하러 가기" 버튼 표시 → `/resumes` 이동 (#311)
+2. 페르소나 카드 3개 선택 (`hr | tech_lead | executive`)
+3. 면접 모드 선택 (`real | practice`) — `InterviewMode` 타입
+4. `/api/interview/start` POST → `sessionId` 응답 → `sessionStorage`에 첫 질문 + 모드 저장
+5. `/interview/[sessionId]`로 라우팅
 
 ## 반응형
 - 페르소나 3열 grid: `grid-cols-1 sm:grid-cols-3` (#261)

--- a/services/siw/src/app/(app)/interview/new/__tests__/page.test.tsx
+++ b/services/siw/src/app/(app)/interview/new/__tests__/page.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Suspense } from 'react'
+import InterviewNewPage from '../page'
+
+const mockPush = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  },
+}))
+
+vi.mock('lucide-react', () => ({
+  Users: () => <svg data-testid="icon-users" />,
+  Code2: () => <svg data-testid="icon-code2" />,
+  Briefcase: () => <svg data-testid="icon-briefcase" />,
+  FileText: () => <svg data-testid="icon-file-text" />,
+  ArrowRight: () => <svg data-testid="icon-arrow-right" />,
+}))
+
+beforeEach(() => {
+  mockPush.mockClear()
+})
+
+describe('InterviewNewPage — 이력서 없을 때', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([]),
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('"아직 이력서가 없어요" 텍스트가 표시된다', async () => {
+    render(<Suspense><InterviewNewPage /></Suspense>)
+    await waitFor(() => {
+      expect(screen.getByText('아직 이력서가 없어요')).toBeDefined()
+    })
+  })
+
+  it('"이력서 업로드하러 가기" 버튼이 표시된다', async () => {
+    render(<Suspense><InterviewNewPage /></Suspense>)
+    await waitFor(() => {
+      expect(screen.getByText(/이력서 업로드하러 가기/)).toBeDefined()
+    })
+  })
+
+  it('버튼 클릭 시 /resumes 로 이동한다', async () => {
+    render(<Suspense><InterviewNewPage /></Suspense>)
+    const button = await screen.findByText(/이력서 업로드하러 가기/)
+    await userEvent.click(button)
+    expect(mockPush).toHaveBeenCalledWith('/resumes')
+  })
+})
+
+describe('InterviewNewPage — 이력서 있을 때', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([{ id: 'r1', fileName: '내이력서.pdf' }]),
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('"이력서 업로드하러 가기" 버튼이 표시되지 않는다', async () => {
+    render(<Suspense><InterviewNewPage /></Suspense>)
+    await waitFor(() => {
+      expect(screen.queryByText(/이력서 업로드하러 가기/)).toBeNull()
+    })
+  })
+
+  it('이력서 파일명이 표시된다', async () => {
+    render(<Suspense><InterviewNewPage /></Suspense>)
+    await waitFor(() => {
+      expect(screen.getByText('내이력서.pdf')).toBeDefined()
+    })
+  })
+})

--- a/services/siw/src/app/(app)/interview/new/page.tsx
+++ b/services/siw/src/app/(app)/interview/new/page.tsx
@@ -2,7 +2,7 @@
 import React, { Suspense, useState, useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { motion } from "framer-motion"
-import { Users, Code2, Briefcase } from "lucide-react"
+import { Users, Code2, Briefcase, FileText, ArrowRight } from "lucide-react"
 import type { InterviewMode } from "@/lib/types"
 
 const containerVariants = {
@@ -179,7 +179,23 @@ function InterviewNewPageContent() {
           {selectedResume ? (
             <p className="text-sm text-gray-700 leading-[1.6]">{selectedResume.fileName}</p>
           ) : resumes.length === 0 ? (
-            <p className="text-sm text-gray-400">이력서를 먼저 업로드해주세요.</p>
+            <div className="flex flex-col items-center gap-4 py-5 px-2">
+              <div className="w-11 h-11 rounded-2xl flex items-center justify-center bg-violet-50 border border-violet-100/80">
+                <FileText className="w-5 h-5 text-violet-400" />
+              </div>
+              <div className="text-center space-y-1">
+                <p className="text-sm font-medium text-gray-700">아직 이력서가 없어요</p>
+                <p className="text-xs text-gray-400 leading-relaxed">이력서를 업로드하면 면접을 시작할 수 있어요</p>
+              </div>
+              <button
+                onClick={() => router.push('/resumes')}
+                className="group inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold text-white transition-all duration-200 ease-out active:scale-[0.97]"
+                style={{ background: "linear-gradient(135deg, #7C3AED, #4F46E5)", boxShadow: "0 2px 8px rgba(124,58,237,0.25)" }}
+              >
+                이력서 업로드하러 가기
+                <ArrowRight className="w-3.5 h-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
+              </button>
+            </div>
           ) : (
             <div className="space-y-2">
               {resumes.map(r => (

--- a/services/siw/src/app/(auth)/.ai.md
+++ b/services/siw/src/app/(auth)/.ai.md
@@ -14,6 +14,7 @@
 - `terms/page.tsx` — 이용약관 페이지
 - `privacy/page.tsx` — 개인정보처리방침 페이지
 - `__tests__/layout.test.tsx` — 레이아웃 컴포넌트 테스트
+- `__tests__/logo-branding.test.tsx` — login/signup 페이지 로고 브랜딩 테스트 (#311)
 
 ## 레이아웃
 - 좌상단 MirAI 로고: `gradient-text` 클래스, 클릭 시 랜딩페이지(`/`)로 이동

--- a/services/siw/src/app/(auth)/__tests__/logo-branding.test.tsx
+++ b/services/siw/src/app/(auth)/__tests__/logo-branding.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Suspense } from 'react'
+import LoginPage from '../login/page'
+import SignupPage from '../signup/page'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock('@/lib/supabase/browser', () => ({
+  createSupabaseBrowser: () => ({
+    auth: { signInWithPassword: vi.fn(), signUp: vi.fn() },
+  }),
+}))
+
+vi.mock('@/lib/auth/schemas', () => ({
+  loginSchema: { safeParse: () => ({ success: true, data: {} }) },
+  signupSchema: { safeParse: () => ({ success: true, data: {} }) },
+}))
+
+describe('Login 페이지 — 로고 브랜딩', () => {
+  it('별 아이콘 SVG가 없다', () => {
+    const { container } = render(<Suspense><LoginPage /></Suspense>)
+    const starPaths = container.querySelectorAll('path[d*="L15.09 8.26"]')
+    expect(starPaths.length).toBe(0)
+  })
+
+  it('MirAI 텍스트가 렌더링된다', () => {
+    render(<Suspense><LoginPage /></Suspense>)
+    expect(screen.getByText('MirAI')).toBeDefined()
+  })
+
+  it('MirAI 텍스트에 gradient-text 클래스가 적용된다', () => {
+    render(<Suspense><LoginPage /></Suspense>)
+    const miraiEl = screen.getByText('MirAI')
+    expect(miraiEl.className).toContain('gradient-text')
+  })
+
+  it('w-9 h-9 rounded-[10px] 아이콘 컨테이너가 없다', () => {
+    const { container } = render(<Suspense><LoginPage /></Suspense>)
+    expect(container.querySelector('.w-9.h-9')).toBeNull()
+  })
+})
+
+describe('Signup 페이지 — 로고 브랜딩', () => {
+  it('MirAI 텍스트가 렌더링된다', () => {
+    render(<SignupPage />)
+    expect(screen.getByText('MirAI')).toBeDefined()
+  })
+
+  it('MirAI 텍스트에 gradient-text 클래스가 적용된다', () => {
+    render(<SignupPage />)
+    const miraiEl = screen.getByText('MirAI')
+    expect(miraiEl.className).toContain('gradient-text')
+  })
+
+  it('w-9 h-9 rounded-[10px] 아이콘 컨테이너가 없다', () => {
+    const { container } = render(<SignupPage />)
+    expect(container.querySelector('.w-9.h-9')).toBeNull()
+  })
+})

--- a/services/siw/src/app/(auth)/login/page.tsx
+++ b/services/siw/src/app/(auth)/login/page.tsx
@@ -65,13 +65,7 @@ function LoginPageContent() {
         {/* 로고 */}
         <div className="text-center mb-6">
           <Link href="/" className="inline-flex items-center gap-2 mb-4">
-            <div className="w-9 h-9 rounded-[10px] flex items-center justify-center"
-              style={{ background: "linear-gradient(135deg, #4F46E5, #7C3AED)" }}>
-              <svg className="w-[18px] h-[18px] text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
-              </svg>
-            </div>
-            <span className="text-lg font-extrabold text-gray-800">MirAI</span>
+            <span className="text-lg font-extrabold gradient-text">MirAI</span>
           </Link>
           <h1 className="text-2xl font-extrabold text-gray-900">다시 오신 걸 환영합니다</h1>
           <p className="text-sm text-gray-400 mt-1">면접 연습을 이어서 진행하세요</p>

--- a/services/siw/src/app/(auth)/signup/page.tsx
+++ b/services/siw/src/app/(auth)/signup/page.tsx
@@ -141,13 +141,7 @@ export default function SignupPage() {
           {/* 모바일용 로고 */}
           <div className="lg:hidden text-center mb-6">
             <Link href="/" className="inline-flex items-center gap-2">
-              <div className="w-9 h-9 rounded-[10px] flex items-center justify-center"
-                style={{ background: "linear-gradient(135deg, #4F46E5, #7C3AED)" }}>
-                <svg className="w-[18px] h-[18px] text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
-                </svg>
-              </div>
-              <span className="text-lg font-extrabold text-gray-800">MirAI</span>
+              <span className="text-lg font-extrabold gradient-text">MirAI</span>
             </Link>
           </div>
 


### PR DESCRIPTION
## 이슈 배경

`/interview/new` 페이지에서 이력서가 없을 때 텍스트만 표시되어 사용자가 다음 동선을 찾지 못하는 문제가 있었습니다. 또한 사이드바/로그인/회원가입 페이지의 별 모양 아이콘이 디자인상 불필요하여, MirAI 텍스트에 그라디언트를 적용해 브랜드를 유지하면서 아이콘을 제거합니다.

## 완료 기준 (AC)

- [x] `/interview/new` — 이력서 목록이 비어 있을 때 "이력서 업로드하러 가기" 버튼이 함께 표시되고, 클릭 시 `/resumes`로 이동한다
- [x] 별 아이콘(`w-9 h-9 rounded-[10px]` star SVG) 이 제거된다
- [x] MirAI 텍스트에 그라디언트 색상(`linear-gradient(135deg, #7C3AED, #4F46E5)`)이 적용되어 브랜드 식별이 유지된다

## 작업 내역

**`interview/new/page.tsx`**
- `resumes.length === 0` 분기에 빈 상태 UI 추가: FileText 아이콘 + 설명 텍스트 + "이력서 업로드하러 가기" 버튼
- 버튼: 그라디언트 배경, ArrowRight 아이콘(hover 시 이동), `active:scale-[0.97]` 눌림 피드백

**`login/page.tsx`, `signup/page.tsx`**
- `w-9 h-9 rounded-[10px]` 별 아이콘 div 및 star SVG 제거
- MirAI `<span>`에 기존 `.gradient-text` CSS 클래스 적용 (인라인 스타일 제거)

**테스트 추가**
- `interview/new/__tests__/page.test.tsx`: 빈 이력서 상태 버튼 렌더링 + `/resumes` 이동 검증 (5개)
- `(auth)/__tests__/logo-branding.test.tsx`: login/signup 별 아이콘 제거 + gradient-text 클래스 검증 (7개)

Closes #311