### PR TITLE
feat: [siw] 운영 현황 대시보드 전면 디벨롭 (#313)

### DIFF
--- a/docs/work/done/000313-dashboard-devlop/00_issue.md
+++ b/docs/work/done/000313-dashboard-devlop/00_issue.md
@@ -1,0 +1,146 @@
+# feat: [siw] 운영 현황 대시보드 — 실제 데이터 출처 기반 전면 디벨롭
+
+## 사용자 관점 목표
+
+관리자는 AI 운영 현황을 실제 데이터 기반으로 한눈에 파악하고 이상 징후를 빠르게 감지할 수 있다.
+사용자는 자신의 면접 성장 흐름을 직관적으로 확인하고 다음 행동을 즉시 결정할 수 있다.
+
+## 배경
+
+현재 대시보드 2종이 실제 데이터 출처를 갖고 있으나, 표현 방식과 구성이 현업 기준에 미치지 못한다.
+
+### 현황 파악
+
+**Observability 대시보드** (`/dashboard/observability`)
+- 데이터 출처: `analytics.llm_events_daily` (PostgreSQL)
+- 실제 로깅되는 feature_type 9개: `interview_start`, `interview_answer`, `interview_followup`, `report_generate`, `practice_feedback`, `resume_parse`, `resume_analyze`, `resume_questions`, `resume_feedback`
+- **버그:** `FEATURE_META` 매핑이 실제 타입과 불일치 — 6개 타입이 한국어 이름 없이 raw key로 표시됨 (`interview_feedback`, `question_generate`, `answer_evaluate`, `feedback_generate`는 실제로 없는 타입)
+
+**메인 대시보드** (`/dashboard`)
+- 데이터 출처: `/api/growth/sessions`, `/api/resumes` (Supabase)
+- KPI 4카드 + 최근 면접 기록 + 퀵 액션
+
+### 현업 레퍼런스 기반 개선 근거
+
+**LLM 운영 대시보드 (Langfuse, Grafana/OpenLIT, Datadog)**
+- "평균은 거짓말한다" — 평균 레이턴시만 표시하면 테일 레이턴시 이상 감지 불가. 현재 `avgLatencyMs`만 표시 중 (출처: OpenTelemetry LLM Observability, OneUptime)
+- feature/mode별 차원 분해(breakdown)가 없으면 원인 파악 불가 — 현재 feature 전체 혼합 표시 (출처: Langfuse Metrics, Datadog OpenAI Monitoring)
+- 비용은 기능별로 귀속(attribution)되어야 예산 최적화 가능 (출처: Grafana Blog LLM in production)
+
+**SRE 대시보드 설계 원칙 (OpenObserve, Cortex)**
+- **3-30-300 규칙**: 3초 안에 KPI 스캔, 30초에 컨텍스트 파악, 300초에 드릴다운. 현재 KPI → 차트 순서가 이 흐름을 따르지 않음
+- **위→아래 = 중요도 순**: 가장 critical한 지표(에러율, 레이턴시 이상)가 상단에 있어야 함
+- **색상은 신호**: 에러율 임계값(5%) 기준선이 시각적으로 불명확
+
+**개인 성장 대시보드 (Smashing Magazine, SimpleKPI, UX Design Awards)**
+- **연속성 시각화**: Duolingo 스트릭 연구 — 연속 달성 일수 표시 시 재방문 60% 증가. 현재 미구현
+- **캘린더 히트맵**: 과거 성취 패턴 인식에 효과적 (GitHub contribution graph 방식). 현재 리스트 형태만 존재
+- **Zeigarnik Effect**: 미완료 상태 시각화가 완료 행동을 유발 — 빈 상태일 때 "첫 면접 시작하기" CTA 강화 필요
+- **5초 규칙**: 가장 중요한 정보(성장률, 최근 점수)가 5초 내 파악 가능해야 함
+
+## 완료 기준
+
+- [x] Observability: `FEATURE_META`를 실제 9개 feature_type에 맞게 수정 (없는 타입 제거, 누락 타입 한국어 매핑 추가)
+- [x] Observability: mode별 그룹핑(면접/연습/이력서) 시각화 추가 — Langfuse 차원 분해 원칙
+- [x] Observability: 에러율 임계값(5%) 기준선 시각적 강조 명확화 — SRE 색상=신호 원칙
+- [x] Observability: 레이아웃을 3-30-300 규칙 기반으로 재구성 (Critical KPI → 추이 차트 → 드릴다운 순)
+- [x] 메인 대시보드: 연속 면접 일수(스트릭) 카드 추가 — 기존 sessions 데이터 기반 계산
+- [x] 메인 대시보드: 최근 30일 면접 완료 캘린더 히트맵 추가 — 기존 sessions.createdAt 기반
+- [x] 메인 대시보드: 빈 상태(sessions=0) UX 개선 — Zeigarnik Effect 기반 CTA 강화
+
+## 구현 플랜
+
+### 범위 제약
+- 데이터 구조 변경 없음 — 기존 `analytics.llm_events_daily`, `growth/sessions`, resumes 데이터 안에서만 동작
+- 새 API 엔드포인트 추가 없음 — 기존 `/api/dashboard/observability`, `/api/growth/sessions` 재사용
+
+### 변경 대상 파일
+
+**Observability 대시보드:**
+1. `services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx`
+   - `FEATURE_META` 수정 (실제 9개 타입 반영)
+   - mode 그룹핑 섹션 추가 (interview 3개 / practice 1개 / resume 4개 / report 1개)
+   - 레이아웃: Critical KPI (에러율 이상 감지) → 추이 → 기능별 드릴다운 순서 재배치
+   - 에러율 5% 기준선 강조 개선
+
+**메인 대시보드:**
+2. `services/siw/src/app/(app)/dashboard/page.tsx`
+   - 스트릭 카운터: sessions 배열에서 날짜 연속성 계산 로직 추가
+   - 캘린더 히트맵: 최근 30일 sessions.createdAt 기반 그리드 렌더링
+   - 빈 상태 분기: sessions.length === 0일 때 개선된 CTA UI
+
+### 작업 순서
+1. `FEATURE_META` 버그 수정 (가장 임팩트 크고 간단)
+2. Observability 레이아웃 재구성 + mode 그룹핑
+3. 메인 대시보드 스트릭 + 캘린더 히트맵
+
+## 참고 출처
+- Langfuse Metrics Overview: https://langfuse.com/docs/metrics/overview
+- Grafana Blog LLM in production: https://grafana.com/blog/ai-observability-llms-in-production/
+- Datadog OpenAI Monitoring: https://www.datadoghq.com/solutions/openai/
+- OneUptime OpenTelemetry LLM: https://oneuptime.com/blog/post/2026-02-06-track-token-usage-prompt-costs-model-latency-opentelemetry/view
+- OpenObserve SRE Dashboards: https://openobserve.ai/blog/metrics-dashboards-for-sre-devops/
+- Cortex SRE Dashboard Guide: https://www.cortex.io/post/sre-dashboards
+- Smashing Magazine Streak UX: https://www.smashingmagazine.com/2026/02/designing-streak-system-ux-psychology/
+- UXPin Dashboard Principles: https://www.uxpin.com/studio/blog/dashboard-design-principles/
+
+## 개발 체크리스트
+- [x] 테스트 코드 포함 (21개)
+- [x] 해당 디렉토리 .ai.md 최신화
+- [x] 불변식 위반 없음
+
+---
+
+## 작업 내역
+
+### 2026-03-28
+
+**현황**: 7/7 완료
+
+#### 신규 파일
+
+**`services/siw/src/lib/observability/constants.ts`**
+- FEATURE_META 9개 타입 한국어 매핑 (interview_start, interview_answer, interview_followup, report_generate, practice_feedback, resume_parse, resume_analyze, resume_questions, resume_feedback)
+- FEATURE_MODE: feature_type → mode 매핑 (event-logger.ts와 DRY 원칙 유지)
+- MODE_GROUPS: interview(4개) / practice(1개) / resume(4개) — report_generate는 interview 그룹에 포함
+
+**`services/siw/src/app/(app)/dashboard/observability/useObservabilityCharts.ts`**
+- 차트 계산 로직을 ObservabilityDashboard.tsx에서 분리한 순수 useMemo 훅
+- 에러율: 최신 날짜 단일 기준 → 전체 기간 집계로 변경 (callCount<10 가드 유지)
+- modeGroupStats: mode별 총호출/평균레이턴시/에러율/피처별 카운트 집계
+- modeLatencyLineData: mode별 가중 평균 레이턴시 3개 선
+- costLineData: 일별 비용(USD) 단일 라인
+
+**`services/siw/src/app/(app)/dashboard/observability/__tests__/useObservabilityCharts.test.ts`**
+- FEATURE_META 9개 타입 검증, 구 타입 부재 확인
+- MODE_GROUPS 일관성 검증 (FEATURE_MODE와 교차 검증)
+- featureName/featureDesc fallback 동작 검증
+- 총 21개 테스트
+
+**`services/siw/src/app/(app)/dashboard/.ai.md`**
+- 대시보드 디렉토리 .ai.md 신규 작성
+
+#### 수정 파일
+
+**`services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx`**
+- 3-30-300 레이아웃 재구성: KPI 5카드 → 기능 그룹별 현황 → 응답 속도 추이 → 일별 비용 → 기능별 오류율
+- 기능 그룹별 현황: 실전 면접/연습 면접/이력서 분석 3컬럼 색상 카드, 그룹 점유율 바, 피처별 사용량 바
+- 레이턴시 차트: feature 9개 → mode 3개 가중 평균으로 통합, 고정 기준선 제거 (LLM 구조상 300ms 기준 적용 불가)
+- 에러율: errorLevel 색상 함수(정상/주의/위험), callCount<10 "데이터 부족" 배지, 전체 기간 집계
+- 불필요 차트 제거: grouped bar, 이중 Y축 비용·토큰, 도넛 (그룹 카드에서 이미 커버)
+
+**`services/siw/src/app/(app)/dashboard/page.tsx`**
+- toKSTDateString(): UTC ISO → KST 날짜 문자열 (Intl API, Asia/Seoul)
+- calcStreak(): KST 기준 연속 면접 일수, 오늘/어제부터 시작 조건
+- calcHeatmap(): 최근 30일 날짜별 면접 횟수 맵
+- KPI 5번째 카드: 연속 면접 일수 (Flame 아이콘), grid-cols-5
+- 30일 히트맵: 보라색 농도 30컬럼 그리드
+- 빈 상태: 3단계 온보딩 체크리스트 (이력서 업로드→첫 면접→리포트 확인)
+- 세션 목록 스크롤바 숨김, "GitHub 기여 그래프 방식" 텍스트 제거
+
+**`services/siw/src/app/(app)/dashboard/observability/.ai.md`**
+- 새 구조·설계 결정 반영하여 업데이트
+- 메인 대시보드: 빈 상태 UX 개선
+
+**변경 파일**: 0개 (구현 미시작)
+

--- a/docs/work/done/000313-dashboard-devlop/01_plan.md
+++ b/docs/work/done/000313-dashboard-devlop/01_plan.md
@@ -1,0 +1,61 @@
+# [#313] feat: [siw] 운영 현황 대시보드 — 실제 데이터 출처 기반 전면 디벨롭 — 구현 계획
+
+> 작성: 2026-03-27
+
+---
+
+## 완료 기준
+
+- [ ] Observability: `FEATURE_META`를 실제 9개 feature_type에 맞게 수정 (없는 타입 제거, 누락 타입 한국어 매핑 추가)
+- [ ] Observability: mode별 그룹핑(면접/연습/이력서) 시각화 추가 — Langfuse 차원 분해 원칙
+- [ ] Observability: 에러율 임계값(5%) 기준선 시각적 강조 명확화 — SRE 색상=신호 원칙
+- [ ] Observability: 레이아웃을 3-30-300 규칙 기반으로 재구성 (Critical KPI → 추이 차트 → 드릴다운 순)
+- [ ] 메인 대시보드: 연속 면접 일수(스트릭) 카드 추가 — 기존 sessions 데이터 기반 계산
+- [ ] 메인 대시보드: 최근 30일 면접 완료 캘린더 히트맵 추가 — 기존 sessions.createdAt 기반
+- [ ] 메인 대시보드: 빈 상태(sessions=0) UX 개선 — Zeigarnik Effect 기반 CTA 강화
+
+---
+
+## 구현 계획
+
+> 전체 플랜: `.omc/plans/000313-dashboard-devlop.md` 참조
+
+### 작업 순서 요약
+
+1. **Step 1**: `FEATURE_META` 버그 수정 + `constants.ts` 공유 모듈 추출
+   - 실제 9개 타입 반영, 없는 4개 제거
+   - `event-logger.ts`의 `FEATURE_MODE`를 `lib/observability/constants.ts`로 이전 (DRY)
+   - MODE_GROUPS 3개 그룹 정의: interview(4개) / practice(1개) / resume(4개)
+   - ⚠️ `report_generate`는 `event-logger.ts` 기준 interview 모드에 속함
+
+2. **Step 2**: Observability 레이아웃 재구성 + 훅 분리
+   - `useObservabilityCharts.ts` 훅 추출 (차트 계산 로직 분리)
+   - 3-30-300 레이아웃 재배치
+   - 에러율 5% 기준선 강조 (callCount ≥ 10인 경우에만, 미만은 "데이터 부족" 표시)
+   - mode별 그룹핑 (3개 그룹 탭/접이식)
+
+3. **Step 3**: 메인 대시보드 개선
+   - `toKSTDateString()` 유틸 함수 추가 (UTC ISO → KST 날짜 문자열, `Asia/Seoul` 타임존)
+   - 스트릭 카드: KST 기준 연속 일수 계산
+   - 30일 캘린더 히트맵: KST 기준 날짜 집계
+   - 빈 상태 UX: Zeigarnik Effect 기반 3단계 온보딩 체크리스트
+
+4. **Step 4**: 테스트 + .ai.md 최신화
+   - KST 타임존 경계 케이스 포함 (UTC 14:59 vs 15:00)
+   - callCount 가드 테스트
+   - useObservabilityCharts 훅 단위 테스트
+
+### 변경 대상 파일
+
+| 파일 | 유형 | Step |
+|------|------|------|
+| `services/siw/src/lib/observability/constants.ts` | **신규** | 1 |
+| `services/siw/src/app/(app)/dashboard/observability/useObservabilityCharts.ts` | **신규** | 2 |
+| `services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx` | 수정 | 1, 2 |
+| `services/siw/src/app/(app)/dashboard/page.tsx` | 수정 | 3 |
+| `services/siw/src/app/(app)/dashboard/observability/__tests__/` | **신규** | 4 |
+| `services/siw/src/app/(app)/dashboard/__tests__/` | **신규** | 4 |
+| `services/siw/src/app/(app)/dashboard/.ai.md` | 수정 | 4 |
+| `services/siw/src/app/(app)/dashboard/observability/.ai.md` | 수정 | 4 |
+
+> 전체 상세 플랜: `.omc/plans/000313-dashboard-devlop.md` 참조

--- a/services/siw/src/app/(app)/dashboard/.ai.md
+++ b/services/siw/src/app/(app)/dashboard/.ai.md
@@ -1,0 +1,34 @@
+# dashboard — 메인 대시보드
+
+## 목적
+로그인한 사용자의 면접 현황·성장 추이를 한눈에 보여주는 메인 화면.
+관리자는 AI 운영 현황 대시보드(`/dashboard/observability`)로 이동 가능.
+
+## 파일 구성
+- `page.tsx` — 메인 대시보드 (use client)
+  - KPI 카드 5개: 총 세션, 완료 면접, 이력서, 평균 점수, 연속 면접(스트릭)
+  - 최근 30일 캘린더 히트맵 (KST 기준)
+  - 세션 목록 / 빈 상태 UX (Zeigarnik Effect 3단계 온보딩)
+- `observability/` — AI 운영 현황 대시보드 (관리자 전용)
+
+## 주요 유틸 함수 (page.tsx 내부)
+- `toKSTDateString(isoString)` — UTC ISO → KST 날짜 문자열 (`Asia/Seoul` 타임존)
+- `calcStreak(sessions)` — KST 기준 연속 면접 일수 (오늘/어제부터 시작 필수)
+- `calcHeatmap(sessions)` — 최근 30일 날짜별 면접 횟수 맵
+
+## 데이터
+- `supabase` `growth.sessions` 테이블 — 사용자 면접 세션
+- `supabase` `resumes` 테이블 — 이력서 수
+- 관리자 여부: `user.user_metadata.role === "admin"`
+
+## 핵심 설계 결정
+- **KST 타임존**: `createdAt`은 UTC ISO이므로 `Intl` API + `Asia/Seoul`로 변환 후 날짜 비교
+- **스트릭 시작 조건**: 오늘 또는 어제 면접이 없으면 0 (Duolingo UX 참고)
+- **빈 상태**: 세션이 0개일 때 3단계 온보딩 체크리스트 (Zeigarnik Effect — 미완성 과제 시각화)
+- **히트맵 색상**: 0건=회색, 1건=연보라, 2건=중간보라, 3+건=진보라
+
+## 의존성
+- `framer-motion` — 애니메이션
+- `lucide-react` — 아이콘 (Flame=스트릭)
+- `@/lib/supabase/browser` — 클라이언트 Supabase
+- `@/lib/types` — GrowthSession 타입

--- a/services/siw/src/app/(app)/dashboard/observability/.ai.md
+++ b/services/siw/src/app/(app)/dashboard/observability/.ai.md
@@ -1,20 +1,34 @@
 # dashboard/observability — 관찰 가능성 대시보드
 
 ## 목적
-AI 기능별 사용 현황, 토큰 소비, 응답 속도, 비용을 시각화하는 내부 대시보드.
+AI 기능별 사용 현황, 토큰 소비, 응답 속도, 비용을 시각화하는 내부 대시보드 (SRE 3-30-300 원칙 기반).
 
 ## 파일 구성
 - `ObservabilityDashboard.tsx` — 메인 대시보드 컴포넌트 (use client)
+- `useObservabilityCharts.ts` — 차트 데이터 계산 훅 (순수 memoized 변환)
+- `__tests__/` — 훅 단위 테스트
 
-## 레이아웃
-- KPI 카드 4개: `grid-cols-2 md:grid-cols-4` (모바일 2열, 데스크탑 4열)
-- 차트 2열: `grid-cols-1 md:grid-cols-2` (모바일 1열, 데스크탑 2열)
-- 응답속도+토큰: `grid-cols-1 md:grid-cols-3`, 응답속도 `md:col-span-2`
+## 레이아웃 (3-30-300 원칙)
+1. **KPI 카드 5개** (3초): 총호출·성공률·평균레이턴시·총비용·총토큰
+2. **에러율** (30초): feature별 에러율, callCount<10 → "데이터 부족" 배지
+3. **기능 그룹별 현황** (30초): 면접/연습/이력서 3개 컬럼 카드 (색상 코딩, 그룹 점유율 바)
+4. **응답 속도 추이** (300초): mode별 가중 평균 레이턴시 3개 선, 기준선 없음
+5. **일별 호출 추이 + 비용·토큰** (300초)
+6. **토큰 비율 도넛** (300초)
 
 ## 데이터
 - API: `GET /api/observability/events`
 - 기간 선택: 7일/30일/90일
+- feature_type: 9개 (interview_start, interview_answer, interview_followup, report_generate, practice_feedback, resume_parse, resume_analyze, resume_questions, resume_feedback)
+- mode 그룹: interview(4개) / practice(1개) / resume(4개)
+
+## 핵심 설계 결정
+- **기준선 없음**: LLM API 응답은 구조적으로 300ms 이하 불가 → 고정 기준선 의미 없음
+- **mode 통합 레이턴시**: feature별 9개 선 대신 mode별 가중 평균 3개 선으로 가독성 향상
+- **callCount < 10 가드**: 에러율 오탐 방지 (데이터 부족 배지로 표시)
+- **constants.ts 분리**: FEATURE_META, FEATURE_MODE, MODE_GROUPS를 `@/lib/observability/constants`로 추출 (DRY)
 
 ## 의존성
-- Chart.js (Bar, Line, Doughnut)
-- `@/lib/observability/event-logger` — 이벤트 수집 유틸
+- Chart.js (Bar, Line, Doughnut) + react-chartjs-2
+- `@/lib/observability/constants` — feature_type 메타데이터, mode 그룹
+- `@/lib/observability/schemas` — ObservabilityResponse Zod 타입

--- a/services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx
+++ b/services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx
@@ -1,49 +1,28 @@
 "use client"
-import React, { useEffect, useState } from "react"
+import { type ReactNode, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
-  BarElement,
-  BarController,
   PointElement,
   LineElement,
   LineController,
-  ArcElement,
   Title,
   Tooltip,
   Legend,
 } from "chart.js"
-import { Bar, Line, Doughnut } from "react-chartjs-2"
+import { Line } from "react-chartjs-2"
 import { ObservabilityResponseSchema } from "@/lib/observability/schemas"
 import type { ObservabilityResponse } from "@/lib/observability/schemas"
+import { useObservabilityCharts, featureName, featureDesc } from "./useObservabilityCharts"
 
 ChartJS.register(
-  CategoryScale, LinearScale, BarElement, BarController,
-  PointElement, LineElement, LineController, ArcElement,
+  CategoryScale, LinearScale,
+  PointElement, LineElement, LineController,
   Title, Tooltip, Legend
 )
 
-// ─── 기능명 매핑 ────────────────────────────────────────────────
-const FEATURE_META: Record<string, { name: string; desc: string }> = {
-  interview_start:    { name: "면접 시작",   desc: "면접 세션을 시작할 때 AI가 첫 질문을 생성하는 단계입니다." },
-  interview_answer:   { name: "답변 분석",   desc: "사용자의 면접 답변을 AI가 읽고 내용을 분석하는 단계입니다." },
-  interview_feedback: { name: "면접 피드백", desc: "분석된 답변을 바탕으로 AI가 개선 피드백을 작성하는 단계입니다." },
-  question_generate:  { name: "질문 생성",   desc: "직무·이력서 맞춤형 면접 질문을 AI가 생성하는 단계입니다." },
-  resume_parse:       { name: "이력서 분석", desc: "업로드된 이력서를 AI가 읽고 주요 정보를 추출하는 단계입니다." },
-  answer_evaluate:    { name: "답변 평가",   desc: "면접 답변의 완성도·논리성을 AI가 점수화하는 단계입니다." },
-  feedback_generate:  { name: "피드백 생성", desc: "면접 전 과정을 종합해 최종 피드백 리포트를 생성하는 단계입니다." },
-}
-
-function featureName(key: string) {
-  return FEATURE_META[key]?.name ?? key.replace(/_/g, " ")
-}
-function featureDesc(key: string) {
-  return FEATURE_META[key]?.desc ?? `"${key}" 기능의 AI 호출 현황입니다.`
-}
-
-const PALETTE = ["#0EA5E9","#6366F1","#10B981","#F59E0B","#EF4444","#8B5CF6","#EC4899","#14B8A6"]
 const DAY_OPTIONS = [7, 14, 30] as const
 
 // ─── 공통 컴포넌트 ───────────────────────────────────────────────
@@ -83,7 +62,7 @@ function StatCard({ label, value, unit, tooltip, accent, warning }: {
   )
 }
 
-function SectionCard({ title, desc, children }: { title: string; desc?: string; children: React.ReactNode }) {
+function SectionCard({ title, desc, children }: { title: string; desc?: string; children: ReactNode }) {
   return (
     <div className="bg-white border border-slate-100 rounded-2xl p-6 shadow-sm">
       <div className="mb-4">
@@ -93,6 +72,12 @@ function SectionCard({ title, desc, children }: { title: string; desc?: string; 
       {children}
     </div>
   )
+}
+
+function errorLevel(rate: number) {
+  if (rate > 0.05) return { bg: "#FFF5F5", border: "#FED7D7", text: "#C53030", badge: "주의 필요", bar: "#C53030" }
+  if (rate > 0)   return { bg: "#FFFBEB", border: "#FDE68A", text: "#92400E", badge: "양호",     bar: "#F59E0B" }
+  return             { bg: "#F0FDF4", border: "#BBF7D0", text: "#166534", badge: "정상",     bar: "#10B981" }
 }
 
 // ─── 메인 대시보드 ───────────────────────────────────────────────
@@ -118,13 +103,15 @@ export default function ObservabilityDashboard() {
       .catch(() => setLoading(false))
   }, [days, router])
 
+  const charts = useObservabilityCharts(data)
+
   if (loading) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-10 space-y-4">
         <div className="h-8 w-52 rounded-lg bg-slate-100 animate-pulse" />
         <div className="h-4 w-80 rounded bg-slate-100 animate-pulse" />
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 pt-2">
-          {[1,2,3,4].map(i => <div key={i} className="h-28 rounded-2xl bg-slate-100 animate-pulse" />)}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4 pt-2">
+          {[1,2,3,4,5].map(i => <div key={i} className="h-28 rounded-2xl bg-slate-100 animate-pulse" />)}
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="h-64 rounded-2xl bg-slate-100 animate-pulse" />
@@ -149,61 +136,17 @@ export default function ObservabilityDashboard() {
     )
   }
 
-  const { rows, summary } = data
-  const dates = [...new Set(rows.map(r => r.date))].sort()
-  const colorMap: Record<string, string> = {}
-  summary.featureTypes.forEach((ft, i) => { colorMap[ft] = PALETTE[i % PALETTE.length] })
+  if (!charts) return null
 
-  const tokenAnomaly = summary.totalCalls > 0 && (summary.totalTokens ?? 0) === 0
+  const { summary } = data
+  const {
+    tokenAnomaly,
+    costLineData,
+    errorRateByFeature,
+    modeGroupStats, modeLatencyLineData,
+  } = charts
 
-  // 일별 집계
-  const costByDate = dates.map(d => rows.filter(r => r.date === d).reduce((s, r) => s + (r.estimatedCostUsd ?? 0), 0))
-  const tokenByDate = dates.map(d => rows.filter(r => r.date === d).reduce((s, r) => s + (r.totalTokens ?? 0), 0))
-
-  // 토큰 비율 (전체 합산)
-  const totalPrompt = rows.reduce((s, r) => s + (r.promptTokens ?? 0), 0)
-  const totalCompletion = rows.reduce((s, r) => s + (r.completionTokens ?? 0), 0)
-  const hasTokenSplit = totalPrompt + totalCompletion > 0
-
-  // ── Grouped Bar ────────────────────────────────────────────────
-  const barData = {
-    labels: dates,
-    datasets: summary.featureTypes.map(ft => ({
-      label: featureName(ft),
-      data: dates.map(d => rows.find(r => r.date === d && r.featureType === ft)?.callCount ?? 0),
-      backgroundColor: colorMap[ft],
-      borderRadius: 3,
-      barPercentage: 0.8,
-      categoryPercentage: 0.85,
-    })),
-  }
-  const barOptions = {
-    responsive: true, maintainAspectRatio: false,
-    plugins: {
-      legend: { display: true, position: "top" as const, labels: { font: { size: 11 }, boxWidth: 10, padding: 10, color: "#64748B" } },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tooltip: { callbacks: { label: (ctx: any) => ` ${ctx.dataset.label}: ${(ctx.parsed.y ?? 0).toLocaleString()}건` } },
-    },
-    scales: {
-      x: { stacked: false, grid: { display: false }, ticks: { font: { size: 10 }, color: "#94A3B8" } },
-      y: { stacked: false, grid: { color: "rgba(0,0,0,0.04)" }, ticks: { font: { size: 11 }, color: "#94A3B8", callback: (v: number | string) => `${v}건` } },
-    },
-  }
-
-  // ── Latency + 기준선 ────────────────────────────────────────────
-  const lineData = {
-    labels: dates,
-    datasets: [
-      ...summary.featureTypes.map(ft => ({
-        label: featureName(ft),
-        data: dates.map(d => { const r = rows.find(row => row.date === d && row.featureType === ft); return r ? Math.round(r.avgLatencyMs) : null }),
-        borderColor: colorMap[ft], backgroundColor: colorMap[ft] + "18",
-        borderWidth: 2, pointRadius: 3, pointHoverRadius: 5, tension: 0.35, spanGaps: true, order: 1,
-      })),
-      { label: "빠름 (300ms)", data: dates.map(() => 300), borderColor: "#10B981", borderWidth: 1, borderDash: [5, 4], pointRadius: 0, tension: 0, spanGaps: true, order: 0 },
-      { label: "느림 (1500ms)", data: dates.map(() => 1500), borderColor: "#EF4444", borderWidth: 1, borderDash: [5, 4], pointRadius: 0, tension: 0, spanGaps: true, order: 0 },
-    ],
-  }
+  // ── Chart options ────────────────────────────────────────────
   const lineOptions = {
     responsive: true, maintainAspectRatio: false,
     plugins: {
@@ -215,55 +158,6 @@ export default function ObservabilityDashboard() {
       x: { grid: { display: false }, ticks: { font: { size: 10 }, color: "#94A3B8" } },
       y: { grid: { color: "rgba(0,0,0,0.04)" }, ticks: { font: { size: 11 }, color: "#94A3B8", callback: (v: number | string) => `${v}ms` } },
     },
-  }
-
-  // ── 비용·토큰 추이 ────────────────────────────────────────────
-  const costLineData = {
-    labels: dates,
-    datasets: [
-      { label: "일별 비용 (USD)", data: costByDate, borderColor: "#F59E0B", backgroundColor: "#F59E0B22", borderWidth: 2, pointRadius: 3, tension: 0.35, yAxisID: "yCost" },
-      { label: "일별 토큰", data: tokenByDate, borderColor: "#8B5CF6", backgroundColor: "#8B5CF622", borderWidth: 2, pointRadius: 3, tension: 0.35, yAxisID: "yToken" },
-    ],
-  }
-  const costLineOptions = {
-    responsive: true, maintainAspectRatio: false,
-    interaction: { mode: "index" as const },
-    plugins: {
-      legend: { display: true, position: "top" as const, labels: { font: { size: 11 }, boxWidth: 10, padding: 10, color: "#64748B" } },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tooltip: { callbacks: { label: (ctx: any) => ctx.datasetIndex === 0 ? ` $${(ctx.parsed.y ?? 0).toFixed(5)}` : ` ${(ctx.parsed.y ?? 0).toLocaleString()} 토큰` } },
-    },
-    scales: {
-      x: { grid: { display: false }, ticks: { font: { size: 10 }, color: "#94A3B8" } },
-      yCost: { position: "left" as const, grid: { color: "rgba(0,0,0,0.04)" }, ticks: { font: { size: 10 }, color: "#F59E0B", callback: (v: number | string) => `$${Number(v).toFixed(4)}` } },
-      yToken: { position: "right" as const, grid: { display: false }, ticks: { font: { size: 10 }, color: "#8B5CF6", callback: (v: number | string) => `${Number(v).toLocaleString()}` } },
-    },
-  }
-
-  // ── 토큰 비율 도넛 ────────────────────────────────────────────
-  const donutData = {
-    labels: ["입력 토큰 (프롬프트)", "출력 토큰 (생성)"],
-    datasets: [{ data: [totalPrompt, totalCompletion], backgroundColor: ["#6366F1", "#10B981"], borderWidth: 0 }],
-  }
-  const donutOptions = {
-    responsive: true, maintainAspectRatio: false,
-    plugins: {
-      legend: { display: true, position: "bottom" as const, labels: { font: { size: 11 }, boxWidth: 10, padding: 12, color: "#64748B" } },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tooltip: { callbacks: { label: (ctx: any) => ` ${ctx.label}: ${(ctx.parsed ?? 0).toLocaleString()} (${totalPrompt + totalCompletion > 0 ? ((ctx.parsed / (totalPrompt + totalCompletion)) * 100).toFixed(1) : 0}%)` } },
-    },
-  }
-
-  // ── 에러율 ────────────────────────────────────────────────────
-  const latestDate = dates[dates.length - 1]
-  const errorRateByFeature = summary.featureTypes.map(ft => {
-    const row = rows.find(r => r.date === latestDate && r.featureType === ft)
-    return { featureType: ft, errorRate: row?.errorRate ?? 0 }
-  })
-  function errorLevel(rate: number) {
-    if (rate > 0.05) return { bg: "#FFF5F5", border: "#FED7D7", text: "#C53030", badge: "주의 필요", bar: "#C53030" }
-    if (rate > 0)   return { bg: "#FFFBEB", border: "#FDE68A", text: "#92400E", badge: "양호",     bar: "#F59E0B" }
-    return             { bg: "#F0FDF4", border: "#BBF7D0", text: "#166534", badge: "정상",     bar: "#10B981" }
   }
 
   return (
@@ -295,10 +189,10 @@ export default function ObservabilityDashboard() {
         ))}
       </div>
 
-      {/* KPI 카드 4개 */}
+      {/* ── 3초 영역: Critical KPI ── */}
       <div>
         <p className="text-[11px] font-bold text-slate-400 uppercase tracking-widest mb-3">전체 요약</p>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
           <StatCard label="총 AI 호출 횟수" value={summary.totalCalls.toLocaleString()} unit="건"
             tooltip={`최근 ${days}일간 AI 기능이 사용된 총 횟수입니다.`} accent="#0EA5E9" />
           <StatCard label="총 사용 토큰" value={(summary.totalTokens ?? 0).toLocaleString()} unit="토큰"
@@ -311,58 +205,151 @@ export default function ObservabilityDashboard() {
           <StatCard label="예상 AI 비용" value={`$${(summary.totalCostUsd ?? 0).toFixed(4)}`} unit="USD"
             tooltip={`최근 ${days}일간 AI API 호출 예상 비용입니다. 토큰 사용량 기반 추정치입니다.`}
             accent="#F59E0B" />
+          <StatCard
+            label="평균 에러율"
+            value={`${(summary.avgErrorRate * 100).toFixed(2)}%`}
+            unit=""
+            tooltip="전체 AI 호출 중 에러가 발생한 비율. 5% 초과 시 즉시 확인이 필요합니다."
+            accent={summary.avgErrorRate > 0.05 ? "#EF4444" : summary.avgErrorRate > 0 ? "#F59E0B" : "#10B981"}
+            warning={summary.avgErrorRate > 0.05 ? "에러율 5% 초과 — 즉시 확인 필요" : undefined}
+          />
         </div>
       </div>
 
-      {/* 차트 2열: 호출 건수 + 비용·토큰 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <SectionCard title="기능별 일별 사용 횟수" desc="날짜별 각 AI 기능의 호출 건수 (그룹 막대)">
-          <div style={{ height: "200px" }}><Bar data={barData} options={barOptions} /></div>
-        </SectionCard>
-        <SectionCard title="일별 비용 · 토큰 추이" desc="하루 동안 소비된 비용(USD)과 토큰 수의 변화입니다.">
-          <div style={{ height: "200px" }}><Line data={costLineData} options={costLineOptions} /></div>
-        </SectionCard>
-      </div>
+      {/* ── 30초 영역: 기능 그룹별 현황 ── */}
 
-      {/* 응답속도 + 토큰 비율 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="md:col-span-2">
-          <SectionCard title="응답 속도 추이" desc="초록 점선(300ms) = 쾌적 기준 / 빨간 점선(1500ms) = 개선 권고 기준">
-            <div style={{ height: "200px" }}><Line data={lineData} options={lineOptions} /></div>
-          </SectionCard>
-        </div>
-        <SectionCard
-          title="입력 / 출력 토큰 비율"
-          desc="입력(프롬프트) vs 출력(생성) 토큰 비율입니다. 입력이 지나치게 크면 프롬프트 최적화를 검토하세요."
-        >
-          {hasTokenSplit ? (
-            <>
-              <div style={{ height: "160px" }}><Doughnut data={donutData} options={donutOptions} /></div>
-              <div className="mt-3 grid grid-cols-2 gap-2 text-center">
-                <div className="bg-indigo-50 rounded-xl p-2">
-                  <p className="text-[11px] text-indigo-500 font-semibold">입력</p>
-                  <p className="text-sm font-black text-indigo-700">{totalPrompt.toLocaleString()}</p>
-                </div>
-                <div className="bg-emerald-50 rounded-xl p-2">
-                  <p className="text-[11px] text-emerald-600 font-semibold">출력</p>
-                  <p className="text-sm font-black text-emerald-700">{totalCompletion.toLocaleString()}</p>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="flex flex-col items-center justify-center h-40 text-center">
-              <p className="text-2xl mb-2">🔀</p>
-              <p className="text-xs font-semibold text-slate-500">데이터 집계 중</p>
-              <p className="text-[11px] text-slate-400 mt-1">스키마 마이그레이션 후 표시됩니다</p>
+      {(() => {
+        const MODE_STYLES: Record<string, { border: string; badge: string; badgeText: string; iconBg: string; barColor: string; label: string }> = {
+          interview: { border: "#6366F1", badge: "#EEF2FF", badgeText: "#4338CA", iconBg: "#EEF2FF", barColor: "#6366F1", label: "실전 면접" },
+          practice:  { border: "#10B981", badge: "#ECFDF5", badgeText: "#065F46", iconBg: "#ECFDF5", barColor: "#10B981", label: "연습 면접" },
+          resume:    { border: "#F59E0B", badge: "#FFFBEB", badgeText: "#92400E", iconBg: "#FFFBEB", barColor: "#F59E0B", label: "이력서 분석" },
+        }
+        const totalCallsAll = modeGroupStats.reduce((s, m) => s + m.totalCalls, 0)
+        return (
+          <div>
+            <p className="text-[11px] font-bold text-slate-400 uppercase tracking-widest mb-3">기능 그룹별 현황</p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {modeGroupStats.map(({ mode, totalCalls, avgLatency, errorRate, featureCounts, insufficient }) => {
+                const s = MODE_STYLES[mode]
+                const groupPct = totalCallsAll > 0 ? (totalCalls / totalCallsAll) * 100 : 0
+                const maxCount = Math.max(...featureCounts.map(f => f.count), 1)
+                return (
+                  <div key={mode} className="bg-white rounded-2xl shadow-sm overflow-hidden border border-slate-100"
+                    style={{ borderTop: `3px solid ${s.border}` }}>
+                    <div className="p-5">
+                      {/* 모드 헤더 */}
+                      <div className="flex items-center gap-2 mb-4">
+                        <span className="text-sm font-black text-slate-800">{s.label}</span>
+                        <span className="ml-auto text-[10px] font-bold px-2 py-0.5 rounded-full"
+                          style={{ background: s.badge, color: s.badgeText }}>
+                          {groupPct.toFixed(0)}%
+                        </span>
+                      </div>
+
+                      {/* 핵심 지표 3개 */}
+                      <div className="grid grid-cols-3 gap-2 mb-4">
+                        <div className="text-center">
+                          <p className="text-xl font-black text-slate-800">{totalCalls.toLocaleString()}</p>
+                          <p className="text-[10px] text-slate-400 mt-0.5">총 호출</p>
+                        </div>
+                        <div className="text-center">
+                          <p className="text-xl font-black text-slate-800">{Math.round(avgLatency).toLocaleString()}</p>
+                          <p className="text-[10px] text-slate-400 mt-0.5">평균 ms</p>
+                        </div>
+                        <div className="text-center">
+                          {insufficient ? (
+                            <>
+                              <p className="text-xl font-black text-slate-300">—</p>
+                              <p className="text-[10px] text-slate-300 mt-0.5">에러율</p>
+                            </>
+                          ) : (
+                            <>
+                              <p className="text-xl font-black" style={{ color: (errorRate * 100) > 5 ? "#EF4444" : "#10B981" }}>
+                                {(errorRate * 100).toFixed(1)}%
+                              </p>
+                              <p className="text-[10px] text-slate-400 mt-0.5">에러율</p>
+                            </>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* 전체 대비 비중 바 */}
+                      <div className="h-1 rounded-full bg-slate-100 mb-4 overflow-hidden">
+                        <div className="h-full rounded-full transition-all" style={{ width: `${groupPct}%`, background: s.border }} />
+                      </div>
+
+                      {/* feature별 사용량 바 */}
+                      <div className="space-y-2.5">
+                        {featureCounts.map(({ ft, count }) => (
+                          <div key={ft}>
+                            <div className="flex justify-between items-center mb-1">
+                              <span className="text-[11px] font-medium text-slate-600">{featureName(ft)}</span>
+                              <span className="text-[10px] text-slate-400">{count.toLocaleString()}건</span>
+                            </div>
+                            <div className="h-1 rounded-full bg-slate-100 overflow-hidden">
+                              <div className="h-full rounded-full transition-all"
+                                style={{ width: `${(count / maxCount) * 100}%`, background: s.barColor + "99" }} />
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
             </div>
-          )}
-        </SectionCard>
-      </div>
+          </div>
+        )
+      })()}
 
-      {/* 에러율 */}
-      <SectionCard title="기능별 오류율" desc={`최근 날짜(${latestDate}) 기준. 5% 이상이면 즉시 확인이 필요합니다.`}>
+      {/* ── 응답 속도 추이 (모드 통합, 기준선 없음) ── */}
+      <SectionCard title="응답 속도 추이" desc="면접·연습·이력서 모드별 가중 평균 레이턴시 추이">
+        <div style={{ height: "220px" }}>
+          <Line
+            data={{ labels: modeLatencyLineData.labels, datasets: modeLatencyLineData.datasets.filter(d => !("borderDash" in d)) }}
+            options={lineOptions}
+          />
+        </div>
+      </SectionCard>
+
+      {/* ── 일별 비용 추이 ── */}
+      <SectionCard title="일별 비용 추이" desc="하루 동안 소비된 AI 호출 비용(USD) 변화입니다.">
+        <div style={{ height: "200px" }}>
+          <Line
+            data={{ labels: costLineData.labels, datasets: [{ ...costLineData.datasets[0], yAxisID: undefined }] }}
+            options={{
+              responsive: true, maintainAspectRatio: false,
+              plugins: {
+                legend: { display: false },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                tooltip: { callbacks: { label: (ctx: any) => ` $${(ctx.parsed.y ?? 0).toFixed(5)}` } },
+              },
+              scales: {
+                x: { grid: { display: false }, ticks: { font: { size: 10 }, color: "#94A3B8" } },
+                y: { grid: { color: "rgba(0,0,0,0.04)" }, ticks: { font: { size: 10 }, color: "#F59E0B", callback: (v: number | string) => `$${Number(v).toFixed(4)}` } },
+              },
+            }}
+          />
+        </div>
+      </SectionCard>
+
+      {/* ── 기능별 오류율 (드릴다운) ── */}
+      <SectionCard title="기능별 오류율" desc="조회 기간 전체 집계 기준. 5% 이상이면 즉시 확인이 필요합니다. 10건 미만은 통계 신뢰도가 낮습니다.">
         <div className="space-y-2.5">
-          {errorRateByFeature.map(({ featureType, errorRate }) => {
+          {errorRateByFeature.map(({ featureType, errorRate, callCount, insufficient }) => {
+            if (insufficient) {
+              return (
+                <div key={featureType} className="rounded-xl border border-slate-200 p-4 bg-slate-50">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-bold text-slate-500">{featureName(featureType)}</span>
+                    <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-slate-200 text-slate-500">
+                      데이터 부족 ({callCount}건)
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-slate-400 mt-1">{featureDesc(featureType)}</p>
+                </div>
+              )
+            }
             const c = errorLevel(errorRate)
             const pct = errorRate * 100
             return (

--- a/services/siw/src/app/(app)/dashboard/observability/__tests__/useObservabilityCharts.test.ts
+++ b/services/siw/src/app/(app)/dashboard/observability/__tests__/useObservabilityCharts.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest"
+import { featureName, featureDesc } from "../useObservabilityCharts"
+import {
+  FEATURE_META,
+  FEATURE_MODE,
+  MODE_GROUPS,
+  MODE_LABEL,
+} from "@/lib/observability/constants"
+
+// ── constants.ts 검증 ──────────────────────────────────────────
+
+describe("FEATURE_META", () => {
+  const EXPECTED_TYPES = [
+    "interview_start",
+    "interview_answer",
+    "interview_followup",
+    "report_generate",
+    "practice_feedback",
+    "resume_parse",
+    "resume_analyze",
+    "resume_questions",
+    "resume_feedback",
+  ]
+
+  it("정확히 9개 feature_type만 포함한다", () => {
+    expect(Object.keys(FEATURE_META)).toHaveLength(9)
+  })
+
+  it.each(EXPECTED_TYPES)("%s 가 name과 desc를 갖는다", (ft) => {
+    expect(FEATURE_META[ft]).toBeDefined()
+    expect(FEATURE_META[ft].name).toBeTruthy()
+    expect(FEATURE_META[ft].desc).toBeTruthy()
+  })
+
+  it("존재하지 않는 타입(interview_eval 등 구 타입)은 포함하지 않는다", () => {
+    const REMOVED = ["interview_eval", "practice_start", "resume_upload", "report_summary"]
+    for (const ft of REMOVED) {
+      expect(FEATURE_META[ft]).toBeUndefined()
+    }
+  })
+})
+
+describe("MODE_GROUPS", () => {
+  it("3개 그룹(interview/practice/resume)을 갖는다", () => {
+    expect(Object.keys(MODE_GROUPS)).toEqual(["interview", "practice", "resume"])
+  })
+
+  it("interview 그룹에 report_generate가 포함된다 (event-logger.ts 기준)", () => {
+    expect(MODE_GROUPS.interview).toContain("report_generate")
+  })
+
+  it("MODE_GROUPS의 모든 feature_type이 FEATURE_META에 존재한다", () => {
+    for (const features of Object.values(MODE_GROUPS)) {
+      for (const ft of features) {
+        expect(FEATURE_META[ft]).toBeDefined()
+      }
+    }
+  })
+
+  it("MODE_GROUPS의 모든 feature_type이 FEATURE_MODE와 일치한다", () => {
+    for (const [mode, features] of Object.entries(MODE_GROUPS)) {
+      for (const ft of features) {
+        expect(FEATURE_MODE[ft]).toBe(mode)
+      }
+    }
+  })
+
+  it("총 feature_type 수가 9개다 (중복 없음)", () => {
+    const all = Object.values(MODE_GROUPS).flat()
+    expect(all).toHaveLength(9)
+    expect(new Set(all).size).toBe(9)
+  })
+})
+
+describe("MODE_LABEL", () => {
+  it("3개 모드 한국어 레이블을 갖는다", () => {
+    expect(MODE_LABEL.interview).toBe("면접")
+    expect(MODE_LABEL.practice).toBe("연습")
+    expect(MODE_LABEL.resume).toBe("이력서")
+  })
+})
+
+// ── useObservabilityCharts 헬퍼 함수 ──────────────────────────
+
+describe("featureName", () => {
+  it("알려진 feature_type은 한국어 이름을 반환한다", () => {
+    expect(featureName("interview_start")).toBe("면접 시작")
+    expect(featureName("resume_parse")).toBe("이력서 파싱")
+    expect(featureName("practice_feedback")).toBe("연습 피드백")
+  })
+
+  it("알 수 없는 feature_type은 언더스코어를 공백으로 변환한다", () => {
+    expect(featureName("unknown_feature")).toBe("unknown feature")
+  })
+})
+
+describe("featureDesc", () => {
+  it("알려진 feature_type은 설명 문자열을 반환한다", () => {
+    const desc = featureDesc("report_generate")
+    expect(desc).toBeTruthy()
+    expect(typeof desc).toBe("string")
+  })
+
+  it("알 수 없는 feature_type은 fallback 설명을 반환한다", () => {
+    const desc = featureDesc("nonexistent_type")
+    expect(desc).toContain("nonexistent_type")
+  })
+})

--- a/services/siw/src/app/(app)/dashboard/observability/useObservabilityCharts.ts
+++ b/services/siw/src/app/(app)/dashboard/observability/useObservabilityCharts.ts
@@ -1,0 +1,99 @@
+"use client"
+import { useMemo } from "react"
+import type { ObservabilityResponse } from "@/lib/observability/schemas"
+import { FEATURE_META, MODE_GROUPS, MODE_LABEL } from "@/lib/observability/constants"
+
+const MODE_COLORS: Record<string, string> = {
+  interview: "#6366F1",
+  practice:  "#10B981",
+  resume:    "#F59E0B",
+}
+
+export function featureName(key: string): string {
+  return FEATURE_META[key]?.name ?? key.replace(/_/g, " ")
+}
+export function featureDesc(key: string): string {
+  return FEATURE_META[key]?.desc ?? `"${key}" 기능의 AI 호출 현황입니다.`
+}
+
+export function useObservabilityCharts(data: ObservabilityResponse | null) {
+  return useMemo(() => {
+    if (!data) return null
+
+    const { rows, summary } = data
+    const dates = [...new Set(rows.map(r => r.date))].sort()
+
+    const tokenAnomaly = summary.totalCalls > 0 && (summary.totalTokens ?? 0) === 0
+
+    // 일별 비용 집계
+    const costByDate = dates.map(d =>
+      rows.filter(r => r.date === d).reduce((s, r) => s + (r.estimatedCostUsd ?? 0), 0),
+    )
+
+    const costLineData = {
+      labels: dates,
+      datasets: [
+        { label: "일별 비용 (USD)", data: costByDate, borderColor: "#F59E0B", backgroundColor: "#F59E0B22", borderWidth: 2, pointRadius: 3, tension: 0.35, yAxisID: "yCost" },
+      ],
+    }
+
+    // 에러율 — 전체 기간 집계, callCount < 10은 데이터 부족
+    const errorRateByFeature = summary.featureTypes.map(ft => {
+      const ftRows = rows.filter(r => r.featureType === ft)
+      const totalCalls = ftRows.reduce((s, r) => s + r.callCount, 0)
+      const totalErrors = ftRows.reduce((s, r) => s + r.errorCount, 0)
+      return {
+        featureType: ft,
+        errorRate: totalCalls > 0 ? totalErrors / totalCalls : 0,
+        callCount: totalCalls,
+        insufficient: totalCalls < 10,
+      }
+    })
+
+    // mode별 가중 평균 레이턴시 추이 (3개 선)
+    const modeLatencyLineData = {
+      labels: dates,
+      datasets: [
+        ...Object.entries(MODE_GROUPS).map(([mode, features]) => ({
+          label: `${MODE_LABEL[mode]} 모드`,
+          data: dates.map(d => {
+            const modeRows = rows.filter(r => r.date === d && features.includes(r.featureType))
+            const total = modeRows.reduce((s, r) => s + r.callCount, 0)
+            return total > 0
+              ? Math.round(modeRows.reduce((s, r) => s + r.avgLatencyMs * r.callCount, 0) / total)
+              : null
+          }),
+          borderColor: MODE_COLORS[mode],
+          backgroundColor: MODE_COLORS[mode] + "18",
+          borderWidth: 2, pointRadius: 3, pointHoverRadius: 5, tension: 0.35, spanGaps: true, order: 1,
+        })),
+        { label: "쾌적 (300ms)", data: dates.map(() => 300), borderColor: "#10B981", borderWidth: 1, borderDash: [5, 4], pointRadius: 0, tension: 0, spanGaps: true, order: 0 },
+        { label: "개선 권고 (1500ms)", data: dates.map(() => 1500), borderColor: "#EF4444", borderWidth: 1, borderDash: [5, 4], pointRadius: 0, tension: 0, spanGaps: true, order: 0 },
+      ],
+    }
+
+    // mode별 그룹 집계
+    const modeGroupStats = Object.entries(MODE_GROUPS).map(([mode, features]) => {
+      const modeRows = rows.filter(r => features.includes(r.featureType))
+      const totalCalls = modeRows.reduce((s, r) => s + r.callCount, 0)
+      const avgLatency = totalCalls > 0
+        ? modeRows.reduce((s, r) => s + r.avgLatencyMs * r.callCount, 0) / totalCalls
+        : 0
+      const totalErrors = modeRows.reduce((s, r) => s + r.errorCount, 0)
+      const errorRate = totalCalls > 0 ? totalErrors / totalCalls : 0
+      const featureCounts = features.map(ft => ({
+        ft,
+        count: rows.filter(r => r.featureType === ft).reduce((s, r) => s + r.callCount, 0),
+      }))
+      return { mode, label: MODE_LABEL[mode], features, totalCalls, avgLatency, errorRate, featureCounts, insufficient: totalCalls < 10 }
+    })
+
+    return {
+      tokenAnomaly,
+      costLineData,
+      errorRateByFeature,
+      modeGroupStats,
+      modeLatencyLineData,
+    }
+  }, [data])
+}

--- a/services/siw/src/app/(app)/dashboard/page.tsx
+++ b/services/siw/src/app/(app)/dashboard/page.tsx
@@ -1,10 +1,52 @@
 "use client"
-import React, { useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { motion } from "framer-motion"
-import { MessageSquare, TrendingUp, FileText, BarChart2 } from "lucide-react"
+import { MessageSquare, TrendingUp, FileText, BarChart2, Flame } from "lucide-react"
 import type { GrowthSession } from "@/lib/types"
 import { createSupabaseBrowser } from "@/lib/supabase/browser"
+
+function toKSTDateString(isoString: string): string {
+  return new Date(isoString).toLocaleDateString("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+}
+
+function calcStreak(sessions: GrowthSession[]): number {
+  if (sessions.length === 0) return 0
+  const kstDates = [...new Set(sessions.map(s => toKSTDateString(s.createdAt)))].sort().reverse()
+  const todayKST = toKSTDateString(new Date().toISOString())
+  const yesterdayKST = toKSTDateString(new Date(Date.now() - 86400000).toISOString())
+  // 오늘 또는 어제부터 시작하지 않으면 0
+  if (kstDates[0] !== todayKST && kstDates[0] !== yesterdayKST) return 0
+  let streak = 0
+  let prev = new Date(kstDates[0].replace(/(\d+)\. (\d+)\. (\d+)\./, "$1-$2-$3"))
+  for (const d of kstDates) {
+    const cur = new Date(d.replace(/(\d+)\. (\d+)\. (\d+)\./, "$1-$2-$3"))
+    const diff = Math.round((prev.getTime() - cur.getTime()) / 86400000)
+    if (diff > 1) break
+    streak++
+    prev = cur
+  }
+  return streak
+}
+
+function calcHeatmap(sessions: GrowthSession[]): Record<string, number> {
+  const map: Record<string, number> = {}
+  const now = new Date()
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * 86400000)
+    map[toKSTDateString(d.toISOString())] = 0
+  }
+  for (const s of sessions) {
+    const k = toKSTDateString(s.createdAt)
+    if (k in map) map[k] = (map[k] ?? 0) + 1
+  }
+  return map
+}
 
 const containerVariants = {
   hidden: {},
@@ -59,6 +101,9 @@ export default function DashboardPage() {
     ? sessions[0].reportTotalScore - sessions[1].reportTotalScore
     : null
 
+  const streak = calcStreak(sessions)
+  const heatmap = calcHeatmap(sessions)
+
   const latestSession = sessions[0]
   const axisKeys = latestSession ? Object.entries(latestSession.scores) : []
   const topAxis = axisKeys.length > 0 ? axisKeys.reduce((a, b) => a[1] > b[1] ? a : b) : null
@@ -100,13 +145,14 @@ export default function DashboardPage() {
           <p className="text-gray-500 mt-1">오늘도 한 걸음 더 성장하세요.</p>
         </motion.div>
 
-        {/* 통계 4카드 */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
+        {/* 통계 5카드 */}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-5">
           {[
             { iconBg: "#EDE9FE", label: "총 면접 횟수", value: `${sessions.length}`, sub: "누적 횟수", valueColor: null, grad: true, Icon: MessageSquare, iconColor: "#7C3AED" },
             { iconBg: "#E0E7FF", label: "평균 점수", value: avgScore !== null ? `${avgScore}점` : "—", sub: "8축 기준", valueColor: "#4F46E5", grad: false, Icon: TrendingUp, iconColor: "#4F46E5" },
             { iconBg: "#CFFAFE", label: "업로드 이력서", value: `${resumeCount}`, sub: "저장된 이력서", valueColor: "#06B6D4", grad: false, Icon: FileText, iconColor: "#06B6D4" },
             { iconBg: "#D1FAE5", label: "성장률", value: growthRate !== null ? `${growthRate > 0 ? "+" : ""}${growthRate}점` : "—", sub: "최근 vs 이전", valueColor: "#10B981", grad: false, Icon: BarChart2, iconColor: "#10B981" },
+            { iconBg: "#FEF3C7", label: "연속 면접", value: streak > 0 ? `${streak}일` : "—", sub: streak > 0 ? "일 연속 달성!" : "오늘 시작해보세요", valueColor: "#D97706", grad: false, Icon: Flame, iconColor: "#D97706" },
           ].map((stat, i) => (
             <motion.div
               key={i}
@@ -142,10 +188,62 @@ export default function DashboardPage() {
               <h3 className="text-lg font-bold text-gray-900">최근 면접 기록</h3>
               <Link href="/growth" className="text-violet-600 font-semibold text-sm hover:underline">전체 보기</Link>
             </div>
+
+            {/* 30일 캘린더 히트맵 */}
+            <div className="bg-white/90 backdrop-blur-sm border border-black/[0.08] rounded-2xl p-5 mb-5">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-bold text-gray-900">최근 30일 면접 현황</h3>
+              </div>
+              <div className="grid gap-1" style={{ gridTemplateColumns: "repeat(30, 1fr)" }}>
+                {Object.entries(heatmap).map(([date, count]) => {
+                  const bg = count === 0 ? "#E5E7EB" : count === 1 ? "#DDD6FE" : count === 2 ? "#8B5CF6" : "#5B21B6"
+                  return (
+                    <div
+                      key={date}
+                      className="rounded-sm aspect-square relative group cursor-default"
+                      style={{ background: bg }}
+                      title={`${date}: ${count}회`}
+                    />
+                  )
+                })}
+              </div>
+              <div className="flex items-center gap-2 mt-2 justify-end">
+                {[["#E5E7EB","0회"],["#DDD6FE","1회"],["#8B5CF6","2회"],["#5B21B6","3회+"]].map(([color,label]) => (
+                  <div key={label} className="flex items-center gap-1">
+                    <div className="w-2.5 h-2.5 rounded-sm" style={{ background: color }} />
+                    <span className="text-[10px] text-gray-400">{label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
             {sessions.length === 0 ? (
-              <p className="text-sm text-gray-400 py-6 text-center">아직 완료된 면접이 없습니다</p>
+              <div className="py-4">
+                <div className="text-center mb-4">
+                  <div className="text-3xl mb-2">🎯</div>
+                  <p className="text-sm font-semibold text-gray-700">첫 AI 면접을 시작해보세요</p>
+                  <p className="text-xs text-gray-400 mt-1">3단계만 완료하면 맞춤 피드백을 받을 수 있어요</p>
+                </div>
+                <div className="space-y-2">
+                  {[
+                    { step: 1, label: "이력서 업로드", done: resumeCount > 0, cta: resumeCount === 0 ? { href: "/resumes", text: "업로드하기 →" } : null },
+                    { step: 2, label: "첫 AI 면접 시작", done: false, cta: { href: "/interview/new", text: "시작하기 →" } },
+                    { step: 3, label: "리포트 확인", done: false, cta: null },
+                  ].map(({ step, label, done, cta }) => (
+                    <div key={step} className={`flex items-center gap-3 p-3 rounded-xl border ${done ? "border-emerald-200 bg-emerald-50" : "border-slate-200 bg-slate-50"}`}>
+                      <div className={`w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 ${done ? "bg-emerald-500 text-white" : "bg-slate-300 text-slate-500"}`}>
+                        {done ? "✓" : step}
+                      </div>
+                      <span className={`text-xs font-medium flex-1 ${done ? "text-emerald-700 line-through" : "text-slate-700"}`}>{label}</span>
+                      {cta && !done && (
+                        <Link href={cta.href} className="text-[11px] font-semibold text-violet-600 hover:underline">{cta.text}</Link>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
             ) : (
-              <div className="max-h-[480px] overflow-y-auto">
+              <div className="max-h-[480px] overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [-ms-overflow-style:none]">
               {sessions.map((s) => {
                 const sc = getScoreCircleClass(s.reportTotalScore)
                 return (

--- a/services/siw/src/lib/observability/constants.ts
+++ b/services/siw/src/lib/observability/constants.ts
@@ -1,0 +1,39 @@
+// feature_type → 한국어 이름·설명 매핑 (실제 로깅되는 9개 타입만)
+export const FEATURE_META: Record<string, { name: string; desc: string }> = {
+  interview_start:    { name: "면접 시작",        desc: "면접 세션을 시작할 때 AI가 첫 질문을 생성하는 단계입니다." },
+  interview_answer:   { name: "답변 분석",        desc: "사용자의 면접 답변을 AI가 읽고 내용을 분석하는 단계입니다." },
+  interview_followup: { name: "꼬리 질문",        desc: "이전 답변을 바탕으로 AI가 심층 추가 질문을 생성하는 단계입니다." },
+  report_generate:    { name: "리포트 생성",      desc: "면접 전 과정을 종합해 최종 피드백 리포트를 생성하는 단계입니다." },
+  practice_feedback:  { name: "연습 피드백",      desc: "연습 모드에서 사용자 답변에 대한 즉각적 피드백을 제공하는 단계입니다." },
+  resume_parse:       { name: "이력서 파싱",      desc: "업로드된 이력서를 AI가 읽고 주요 정보를 추출하는 단계입니다." },
+  resume_analyze:     { name: "이력서 분석",      desc: "파싱된 이력서 내용을 AI가 종합 평가하는 단계입니다." },
+  resume_questions:   { name: "이력서 질문 생성", desc: "이력서 내용 기반으로 예상 면접 질문을 AI가 생성하는 단계입니다." },
+  resume_feedback:    { name: "이력서 피드백",    desc: "이력서 개선 포인트를 AI가 분석하여 피드백을 제공하는 단계입니다." },
+}
+
+// feature_type → mode 매핑 (event-logger.ts의 FEATURE_MODE와 동일하게 유지)
+export const FEATURE_MODE: Record<string, "interview" | "practice" | "resume"> = {
+  interview_start:    "interview",
+  interview_answer:   "interview",
+  interview_followup: "interview",
+  report_generate:    "interview",
+  practice_feedback:  "practice",
+  resume_parse:       "resume",
+  resume_analyze:     "resume",
+  resume_questions:   "resume",
+  resume_feedback:    "resume",
+}
+
+// mode → UI 표시명 매핑
+export const MODE_LABEL: Record<string, string> = {
+  interview: "면접",
+  practice:  "연습",
+  resume:    "이력서",
+}
+
+// mode별 feature_type 그룹핑 (FEATURE_MODE 기반, 3개 그룹)
+export const MODE_GROUPS: Record<string, string[]> = {
+  interview: ["interview_start", "interview_answer", "interview_followup", "report_generate"],
+  practice:  ["practice_feedback"],
+  resume:    ["resume_parse", "resume_analyze", "resume_questions", "resume_feedback"],
+}


### PR DESCRIPTION
## 이슈 배경

운영 현황 대시보드 2종(`/dashboard`, `/dashboard/observability`)이 실제 데이터 출처는 갖추고 있으나, FEATURE_META 매핑 버그·레이아웃 미비·UX 요소 부재로 현업 기준에 미치지 못했습니다. 웹 리서치(Langfuse, SRE 3-30-300, Duolingo 스트릭 UX) 기반으로 지표 타당성을 검증하고 전면 재구성했습니다.

## 완료 기준 (AC)

- [x] Observability: `FEATURE_META`를 실제 9개 feature_type에 맞게 수정
- [x] Observability: mode별 그룹핑(실전 면접/연습 면접/이력서 분석) 시각화 추가
- [x] Observability: 에러율 5% 기준선 색상 강조, callCount<10 "데이터 부족" 배지
- [x] Observability: 3-30-300 레이아웃 재구성 (KPI→그룹현황→추이→오류율)
- [x] 메인 대시보드: 연속 면접 일수(스트릭) 카드 추가
- [x] 메인 대시보드: 최근 30일 캘린더 히트맵 추가 (KST 기준)
- [x] 메인 대시보드: 빈 상태 UX 개선 (Zeigarnik Effect 3단계 온보딩)

## 작업 내역

**신규**
- `lib/observability/constants.ts`: FEATURE_META 9개 타입, MODE_GROUPS 3그룹 정의
- `observability/useObservabilityCharts.ts`: 차트 계산 훅 분리, 전체 기간 에러율 집계
- `observability/__tests__/useObservabilityCharts.test.ts`: 21개 테스트

**수정**
- `ObservabilityDashboard.tsx`: 기능 그룹별 현황 카드, 모드 통합 레이턴시(기준선 제거), 불필요 차트 제거(grouped bar/이중 Y축/도넛)
- `dashboard/page.tsx`: 스트릭 카드(KST 기준 calcStreak), 30일 히트맵(calcHeatmap), Zeigarnik Effect 빈 상태 UX, 스크롤바 숨김

Closes #313