### PR TITLE
fix: observability 대시보드 로그 확인 링크 S3 prefix 오류 수정 (#323)

### DIFF
--- a/docs/work/done/000323-siw-observability-s3/00_issue.md
+++ b/docs/work/done/000323-siw-observability-s3/00_issue.md
@@ -1,0 +1,48 @@
+# fix: [siw] observability 대시보드 로그 확인 링크 S3 prefix 오류 수정
+
+## 목적
+
+observability 대시보드의 "로그 확인 →" 버튼이 올바른 S3 경로로 이동하도록 수정한다.
+
+## 배경
+
+`ObservabilityDashboard.tsx`의 로그 확인 링크가 \`prefix=logs/\${featureType}/\` (예: \`logs/interview-start/\`)를 사용하고 있으나, 실제 \`event-logger.ts\`는 \`llm-events/YYYY/MM/DD/\` 경로에 로그를 저장한다. 결과적으로 링크를 클릭하면 존재하지 않는 S3 prefix로 이동하게 된다.
+
+- 실제 저장 경로: \`llm-events/YYYY/MM/DD/\` (\`S3_LOG_PREFIX\` 기본값)
+- 링크 prefix: \`logs/\${featureType}/\` ← 잘못됨
+
+## 완료 기준
+
+- [x] \`ObservabilityDashboard.tsx\` 로그 확인 링크 href의 prefix를 \`llm-events/\`로 수정
+- [x] 수정 후 링크가 S3 콘솔의 \`mirai-llm-logs-siw\` 버킷 → \`llm-events/\` prefix로 올바르게 이동
+
+## 구현 플랜
+
+1. \`services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx:374\`
+   - \`prefix=logs/\${featureType}/\` → \`prefix=llm-events/\`
+
+## 개발 체크리스트
+
+- [x] 해당 디렉토리 .ai.md 최신화
+
+---
+
+## 작업 내역
+
+### 2026-03-30
+
+**현황**: 2/2 완료
+
+**완료된 항목**:
+- `ObservabilityDashboard.tsx` 로그 확인 링크 href의 prefix를 `llm-events/`로 수정
+- 수정 후 링크가 S3 콘솔의 `mirai-llm-logs-siw` 버킷 → `llm-events/` prefix로 올바르게 이동
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 2개
+
+**구현 내용**:
+- `ObservabilityDashboard.tsx:374` — `prefix=logs/${featureType}/` → `prefix=llm-events/` 수정. S3 URL을 모듈 레벨 상수 `S3_LLM_EVENTS_URL`로 추출해 `.map()` 내 중복 생성 제거.
+- `.ai.md` — S3 로그 링크 prefix 설계 결정 사항 추가.
+

--- a/docs/work/done/000323-siw-observability-s3/01_plan.md
+++ b/docs/work/done/000323-siw-observability-s3/01_plan.md
@@ -1,0 +1,16 @@
+# [#323] fix: [siw] observability 대시보드 로그 확인 링크 S3 prefix 오류 수정 — 구현 계획
+
+> 작성: 2026-03-30
+
+---
+
+## 완료 기준
+
+- [ ] `ObservabilityDashboard.tsx` 로그 확인 링크 href의 prefix를 `llm-events/`로 수정
+- [ ] 수정 후 링크가 S3 콘솔의 `mirai-llm-logs-siw` 버킷 → `llm-events/` prefix로 올바르게 이동
+
+---
+
+## 구현 계획
+
+(작성 예정)

--- a/services/siw/src/app/(app)/dashboard/observability/.ai.md
+++ b/services/siw/src/app/(app)/dashboard/observability/.ai.md
@@ -27,6 +27,7 @@ AI 기능별 사용 현황, 토큰 소비, 응답 속도, 비용을 시각화하
 - **mode 통합 레이턴시**: feature별 9개 선 대신 mode별 가중 평균 3개 선으로 가독성 향상
 - **callCount < 10 가드**: 에러율 오탐 방지 (데이터 부족 배지로 표시)
 - **constants.ts 분리**: FEATURE_META, FEATURE_MODE, MODE_GROUPS를 `@/lib/observability/constants`로 추출 (DRY)
+- **S3 로그 링크 prefix**: `llm-events/` 고정 사용 (`event-logger.ts`의 실제 저장 경로와 일치), featureType별 prefix는 사용하지 않음
 
 ## 의존성
 - Chart.js (Bar, Line, Doughnut) + react-chartjs-2

--- a/services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx
+++ b/services/siw/src/app/(app)/dashboard/observability/ObservabilityDashboard.tsx
@@ -17,6 +17,8 @@ import { ObservabilityResponseSchema } from "@/lib/observability/schemas"
 import type { ObservabilityResponse } from "@/lib/observability/schemas"
 import { useObservabilityCharts, featureName, featureDesc } from "./useObservabilityCharts"
 
+const S3_LLM_EVENTS_URL = "https://s3.console.aws.amazon.com/s3/buckets/mirai-llm-logs-siw?prefix=llm-events/"
+
 ChartJS.register(
   CategoryScale, LinearScale,
   PointElement, LineElement, LineController,
@@ -371,7 +373,7 @@ export default function ObservabilityDashboard() {
                       <p className="text-[10px] mt-0.5" style={{ color: c.text + "88" }}>오류 비율</p>
                     </div>
                     <a
-                      href={`https://s3.console.aws.amazon.com/s3/buckets/mirai-llm-logs-siw?prefix=logs/${featureType}/`}
+                      href={S3_LLM_EVENTS_URL}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-[11px] font-semibold px-3 py-1.5 rounded-lg border transition-colors whitespace-nowrap"


### PR DESCRIPTION
## 이슈 배경

`ObservabilityDashboard.tsx`의 "로그 확인 →" 버튼 링크가 `prefix=logs/${featureType}/`를 사용하고 있었으나, 실제 `event-logger.ts`는 `llm-events/YYYY/MM/DD/` 경로에 로그를 저장한다. 링크 클릭 시 존재하지 않는 S3 prefix로 이동하는 버그를 수정한다.

## 완료 기준 (AC)

- [x] `ObservabilityDashboard.tsx` 로그 확인 링크 href의 prefix를 `llm-events/`로 수정
- [x] 수정 후 링크가 S3 콘솔의 `mirai-llm-logs-siw` 버킷 → `llm-events/` prefix로 올바르게 이동

## 작업 내역

- `ObservabilityDashboard.tsx` — `prefix=logs/${featureType}/` → `prefix=llm-events/` 수정. S3 URL을 모듈 레벨 상수 `S3_LLM_EVENTS_URL`로 추출해 `.map()` 내 중복 생성 제거.
- `.ai.md` — S3 로그 링크 prefix 설계 결정 사항 추가.

Closes #323