### PR TITLE
feat: [Fint] 리포트 카드 SNS 공유 — OG 이미지 + 카카오톡 공유 버튼 (#184)

### DIFF
--- a/docs/work/done/000184-lww-sns-share/00_issue.md
+++ b/docs/work/done/000184-lww-sns-share/00_issue.md
@@ -1,0 +1,79 @@
+# feat: [lww] Phase 1 — 리포트 카드 SNS 공유 (OG 이미지 + 카카오톡 공유)
+
+## 사용자 관점 목표
+면접 결과를 친구에게 자랑하거나 카카오톡으로 공유할 때, 점수·직군이 담긴 예쁜 카드 이미지가 미리보기로 뜨며 lww 바이럴이 자연스럽게 퍼진다.
+
+## 배경
+프로포절 AARRR Referral 핵심 — "결과 리포트 카드 SNS 공유 → 바이럴 루프". 현재 리포트 URL을 공유해도 기본 OG 태그만 뜨고 점수 정보가 없어 공유 유인이 없다.
+
+## 완료 기준
+- [x] 리포트 URL 공유 시 카카오톡·SNS 미리보기에 점수·직군이 포함된 OG 카드 이미지 표시
+- [x] 리포트 화면에 카카오톡 공유 버튼 + 링크 복사 버튼 추가
+- [x] 공유 링크로 비로그인 유저도 리포트 조회 가능 (읽기 전용, RLS 설정)
+- [x] OG 카드에 Fint 브랜딩 (Teal #0D9488) 적용
+
+## 구현 플랜
+1. `/api/og/report` 라우트 — `@vercel/og` (Edge Runtime)로 리포트 카드 이미지 동적 생성. 쿼리파람: `sessionId` → DB에서 점수·직군 조회 → 카드 렌더링
+2. `/report/[sessionId]` 페이지 — `generateMetadata`로 OG 메타태그 추가 (`og:image` → `/api/og/report?sessionId=...`, `og:title` = "내 면접 점수는 {totalScore}점!")
+3. 공유 버튼 UI — 카카오톡 JavaScript SDK 연동 (커스텀 피드 공유) + 클립보드 링크 복사
+4. Supabase RLS — `reports` 테이블 읽기 정책: 본인 또는 `is_public=true`인 경우 허용
+
+## 참고
+- `@vercel/og` Edge Runtime — Vercel 무료 플랜 지원
+- 카카오톡 공유 SDK: kakao.Share.sendDefault (JavaScript SDK v2)
+- 현재 리포트 화면: `services/lww/src/app/(interview)/report/[sessionId]/page.tsx`
+
+## 개발 체크리스트
+- [x] 테스트 코드 포함
+- [x] `services/fint/.ai.md` 최신화
+- [x] 불변식 위반 없음
+
+---
+
+## 작업 내역
+
+### 2026-03-25
+
+**현황**: 0/4 완료
+
+**완료된 항목**:
+- (없음)
+
+**미완료 항목**:
+- 리포트 URL 공유 시 카카오톡·SNS 미리보기에 점수·직군이 포함된 OG 카드 이미지 표시
+- 리포트 화면에 카카오톡 공유 버튼 + 링크 복사 버튼 추가
+- 공유 링크로 비로그인 유저도 리포트 조회 가능 (읽기 전용, RLS 설정)
+- OG 카드에 Fint 브랜딩 (Teal #0D9488) 적용
+
+**변경 파일**: 0개 (구현 계획 작성 완료 — Ralplan 5-pass 합의, 구현 미시작)
+
+### 2026-03-28
+
+**현황**: 4/4 완료
+
+**완료된 항목**:
+- [x] 리포트 URL 공유 시 카카오톡·SNS 미리보기에 점수·직군이 포함된 OG 카드 이미지 표시
+- [x] 리포트 화면에 카카오톡 공유 버튼 + 링크 복사 버튼 추가
+- [x] 공유 링크로 비로그인 유저도 리포트 조회 가능 (읽기 전용, RLS 설정)
+- [x] OG 카드에 Fint 브랜딩 (Teal #0D9488) 적용
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 8개 (api/og/report/route.tsx, ShareButtons.tsx, ReportContent.tsx, report/page.tsx, supabase migration, .ai.md, types/, tests/)
+
+### 2026-04-05
+
+**현황**: 4/4 완료
+
+**완료된 항목**:
+- [x] 리포트 URL 공유 시 카카오톡·SNS 미리보기에 점수·직군이 포함된 OG 카드 이미지 표시
+- [x] 리포트 화면에 카카오톡 공유 버튼 + 링크 복사 버튼 추가
+- [x] 공유 링크로 비로그인 유저도 리포트 조회 가능 (읽기 전용, RLS 설정)
+- [x] OG 카드에 Fint 브랜딩 (Teal #0D9488) 적용
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 14개 (수정 6개 + 신규 8개, 미커밋 상태)
+

--- a/docs/work/done/000184-lww-sns-share/01_plan.md
+++ b/docs/work/done/000184-lww-sns-share/01_plan.md
@@ -1,0 +1,376 @@
+# [#184] feat: [Fint] Phase 1 — 리포트 카드 SNS 공유 (OG 이미지 + 카카오톡 공유) — 구현 계획
+
+> 작성: 2026-03-25
+> Ralplan 합의 (Planner → Architect×2 → Critic×2 → APPROVE)
+
+---
+
+## 완료 기준
+
+- [ ] 리포트 URL 공유 시 카카오톡·SNS 미리보기에 점수·직군이 포함된 OG 카드 이미지 표시
+- [ ] 리포트 화면에 카카오톡 공유 버튼 + 링크 복사 버튼 추가
+- [ ] 공유 링크로 비로그인 유저도 리포트 조회 가능 (읽기 전용, RLS 설정)
+- [ ] OG 카드에 Fint 브랜딩 (Teal #0D9488) 적용
+
+---
+
+## ADR (Architecture Decision Record)
+
+### Decision
+리포트 페이지를 Server Component wrapper + Client Component(`ReportContent.tsx`)로 분리하고, `is_public=true` RLS + Edge OG 이미지 라우트로 SNS 공유를 구현한다.
+
+### Drivers
+1. 현재 `"use client"` + sessionStorage 구조는 `generateMetadata`(OG 메타태그)를 지원하지 않음
+2. 공유 링크로 접근한 비로그인 사용자는 sessionStorage가 없으므로 DB 직접 조회 필요
+3. Phase 1 마감 2026-03-27, 최소 침습적 변경 필요
+
+### Alternatives Considered
+| 대안 | 기각 이유 |
+|------|----------|
+| Option B: 별도 `/share/[sessionId]` 페이지 | URL 이원화(공유 URL ≠ 원본 URL), UI 코드 중복 |
+| `is_public DEFAULT true` | 기존 모든 리포트 소급 공개 — 프라이버시 침해 |
+| OG route에서 `createClient()` (anon) | Edge Runtime에서 `cookies()` 의존 불안정 |
+| Kakao SDK를 root layout에 로드 | 모든 페이지에 불필요한 ~40KB 추가 |
+
+### Why Chosen
+- **Option A**: 동일 URL 유지로 바이럴 링크 일관성 보장, `isOwner` prop으로 소유자/뷰어 UI 분기
+- **`DEFAULT false`**: 신규 리포트만 공유 허용, 기존 데이터 안전
+- **`createServiceClient()` + 명시적 필터**: Edge 호환성 + is_public 접근 제어 보장
+- **Kakao SDK `(interview)` 레이아웃 스코프**: report 페이지에서만 필요한 SDK를 해당 그룹에만 로드
+
+### Consequences
+- 긍정: 기존 URL로 SNS 공유 카드 표시, 비로그인 공유 뷰어 지원, 바이럴 루프 완성
+- 부정: `is_public=false` 구 리포트는 공유 불가 (sessionStorage fallback만 동작), 소유자가 sessionStorage 소거 후 재방문 시 서버 fetch로 표시(허용됨)
+- 알려진 비대칭: 구 리포트 공유 원하면 별도 백필 마이그레이션 필요
+
+### Follow-ups
+- Kakao 개발자 앱 등록 및 도메인 화이트리스트 설정 (구현 전 선행)
+- 구 리포트 백필(`UPDATE reports SET is_public=true WHERE status='completed'`) — 선택적, 별도 이슈
+- `/api/og/` rate limiting 강화 — 별도 이슈
+
+---
+
+## 구현 계획
+
+### Step 0: 사전 준비 — `@vercel/og` 의존성 추가
+
+**작업**:
+```bash
+cd services/fint && npm install @vercel/og
+```
+
+**검증**: `services/fint/package.json`에 `"@vercel/og"` 항목 확인
+
+---
+
+### Step 1: Supabase DB 마이그레이션
+
+**파일 (신규)**: `services/fint/supabase/migrations/20260325000000_add_reports_is_public.sql`
+
+```sql
+-- RLS 활성화 (아직 활성화되지 않은 경우)
+ALTER TABLE reports ENABLE ROW LEVEL SECURITY;
+
+-- reports 테이블에 is_public 컬럼 추가
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
+
+-- RLS: anon 사용자가 is_public=true 리포트 조회 허용
+CREATE POLICY "public reports are viewable by everyone"
+  ON reports
+  FOR SELECT
+  TO anon
+  USING (is_public = true);
+```
+
+**RLS 활성화 확인**: 마이그레이션 전 Supabase 대시보드 → Authentication → Policies → reports 테이블에서 RLS 활성화 여부 확인 필수. 이미 활성화된 경우 `ENABLE ROW LEVEL SECURITY` 라인은 no-op (안전).
+
+**주의**: `services/fint/`에 `supabase/migrations/` 디렉토리 없음. Supabase 대시보드 SQL 에디터에서 직접 실행하거나, 디렉토리 신규 생성 후 `supabase db push`.
+
+**검증**:
+- Supabase 대시보드에서 `reports` 테이블에 `is_public` 컬럼 존재 확인
+- anon key로 `is_public=false` 리포트 SELECT 시 빈 배열 반환 확인
+
+---
+
+### Step 2: `end` route — `is_public: true` 명시적 설정
+
+**파일**: `services/fint/src/app/api/interview/end/route.ts`
+
+기존 `supabase.from("reports").insert({...})` 에 `is_public: true` 추가:
+```typescript
+.insert({
+  session_id: sessionId,
+  anonymous_id: anonymousId,
+  user_id: userId,
+  status: "completed",
+  total_score: report.totalScore,
+  axis_scores: report.axisScores,
+  axis_feedbacks: report.axisFeedbacks,
+  summary: report.summary,
+  is_public: true,  // ← 추가
+})
+```
+
+**검증**: 면접 완료 후 DB에서 `is_public = true` 확인
+
+---
+
+### Step 3: `/api/og/report` Edge Route — OG 이미지 동적 생성
+
+**파일 (신규)**: `services/fint/src/app/api/og/report/route.tsx`
+
+**스펙**:
+- `export const runtime = "edge"`
+- **Supabase 클라이언트**: `createServiceClient()` (service role, cookie-less, Edge 호환) + 명시적 `.eq('is_public', true)` 필터
+- **Edge env 확인**: Vercel 대시보드에서 `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_URL`이 Edge Runtime에 노출되어 있는지 확인 필요
+- 쿼리파람: `?sessionId=<UUID>`
+- UUID 형식 검증 (Zod) → 실패 시 fallback 이미지 반환 (400 아님, SNS 크롤러 에러 방지)
+- Supabase 조회: `reports` (total_score, summary, is_public) + `interview_sessions` (job_category) by session_id
+- `is_public = false` 또는 데이터 없으면 → 기본 fallback 카드 반환
+- `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800` 헤더 설정
+
+**OG 카드 디자인** (1200×630):
+- 배경: 흰색
+- 상단: "Fint" 브랜드 텍스트 (Teal #0D9488)
+- 중앙: "내 면접 점수는 {N}점!" (점수 크게)
+- 점수 색상: 80+ → #0D9488, 60-79 → #F59E0B, <60 → #EF4444
+- 하단: 직군명, 요약 앞 50자
+- OG 이미지는 JSX inline style 사용 (Tailwind 무관)
+
+**검증**:
+- `curl "http://localhost:3000/api/og/report?sessionId=<valid-uuid>"` → PNG 반환
+- 잘못된 sessionId → fallback 이미지 (200 OK)
+- `Cache-Control` 헤더 포함 확인
+
+---
+
+### Step 4: 리포트 페이지 Server/Client 분리
+
+#### 4-A: `ReportContent.tsx` Client Component 분리
+
+**파일 (신규)**: `services/fint/src/components/report/ReportContent.tsx`
+
+기존 `page.tsx`의 UI 로직 전체를 이 파일로 이동.
+
+```typescript
+"use client";
+
+interface ReportContentProps {
+  sessionId: string;
+  initialReport: ReportResponse | null;  // 서버에서 pre-fetch한 데이터
+  isOwner: boolean;                       // 서버에서 판별한 소유자 여부
+}
+```
+
+데이터 우선순위:
+1. `initialReport` prop 있으면 사용
+2. 없으면 `sessionStorage.getItem(`report_${sessionId}`)` fallback
+
+`isOwner`에 따른 UI 분기:
+- `isOwner = true`: 기존 UI 그대로 (exit dialog, SaveAccountCTA, 기존 하단 CTA)
+- `isOwner = false` (공유 뷰어): exit dialog 없음, "나도 면접 연습하기" CTA
+
+#### 4-B: `page.tsx` → Server Component 전환
+
+**파일**: `services/fint/src/app/(interview)/report/[sessionId]/page.tsx`
+
+- **Supabase 클라이언트**: `createClient()` (anon key, RLS 적용) — `createServiceClient()` 아님
+  - RLS가 적용되므로 `is_public=true`인 리포트만 조회됨 (코드 레벨 필터 불필요하지만 명시 권장)
+  - `is_public=false` 구 리포트는 서버 fetch 실패 → `initialReport=null` → Client에서 sessionStorage fallback
+- `"use client"` 제거 → async Server Component
+- `generateMetadata` 추가 (`generateMetadata`도 같은 클라이언트 사용)
+- `fint_anon_id` 쿠키 (`getAnonId()` from `@/lib/anon-cookie`) vs `report.anonymous_id` 비교로 `isOwner` 판별
+- `<ReportContent sessionId={...} initialReport={...} isOwner={...} />` 렌더링
+
+**DB row → ReportResponse 타입 매핑** (page.tsx 내 변환 필수):
+```typescript
+// DB 컬럼 (snake_case) → 클라이언트 타입 (camelCase)
+const initialReport: ReportResponse | null = reportRow ? {
+  totalScore: reportRow.total_score,       // total_score → totalScore
+  summary: reportRow.summary,              // summary → summary (동일)
+  axisFeedbacks: reportRow.axis_feedbacks, // axis_feedbacks → axisFeedbacks
+  growthCurve: null,                       // DB에 없음, 항상 null
+  // axis_scores는 클라이언트 타입에 없으므로 무시
+} : null;
+```
+
+**알려진 비대칭 동작**: `is_public=false` 구 리포트 소유자는 서버 fetch 실패 → sessionStorage fallback으로 정상 표시. 새 리포트(`is_public=true`)는 서버 fetch 성공 → sessionStorage 없어도 다른 기기에서 공유 링크로 접근 가능. 이는 의도된 동작.
+
+**엣지 케이스**:
+- `is_public=false` (구 리포트): `initialReport=null`, Client에서 sessionStorage fallback
+- 소유자가 sessionStorage 소거 후 재방문: DB fetch → 정상 표시
+- `end` route DB insert 실패: sessionStorage fallback (기존 동작 유지)
+
+**검증**:
+- 면접 직후 리포트: 정상 표시
+- 다른 기기에서 공유 링크 접근: 점수·직군 표시, 공유 뷰어 UI
+- `curl -I` 로 OG 메타태그 확인 (`og:image`, `og:title`)
+
+---
+
+### Step 5: 공유 버튼 UI
+
+**파일 (신규)**: `services/fint/src/components/report/ShareButtons.tsx`
+
+```typescript
+"use client";
+
+interface ShareButtonsProps {
+  sessionId: string;
+  totalScore: number;
+  summary?: string;
+}
+```
+
+- **카카오톡 공유 버튼**: `window.Kakao?.Share?.sendDefault({...})` 호출
+  - Kakao SDK 없으면 버튼 비활성화 또는 숨김 (graceful degradation)
+- **링크 복사 버튼**: `navigator.clipboard.writeText(window.location.href)` + 토스트 "링크가 복사되었어요!"
+
+카카오 payload:
+```typescript
+{
+  objectType: "feed",
+  content: {
+    title: `내 면접 점수는 ${totalScore}점!`,
+    description: "AI 모의면접 결과를 확인해보세요",
+    imageUrl: `${origin}/api/og/report?sessionId=${sessionId}`,
+    link: {
+      mobileWebUrl: `${origin}/report/${sessionId}`,
+      webUrl: `${origin}/report/${sessionId}`,
+    },
+  },
+  buttons: [{ title: "결과 보기", link: { ... } }],
+}
+```
+
+`ReportContent.tsx`의 하단 CTA 영역에 `<ShareButtons>` 추가.
+
+**검증**: 공유 버튼 클릭 → 카카오 공유 시트 열림 / 클립보드에 URL 복사
+
+---
+
+### Step 6: Kakao SDK 초기화
+
+**파일**: `services/fint/src/app/(interview)/layout.tsx` (수정)
+
+`next/script`로 Kakao JS SDK lazy-load (report 페이지에서만 필요하므로 `(interview)` 그룹 레이아웃에 스코프):
+
+```tsx
+import Script from "next/script";
+
+// (interview) layout에 추가
+<Script
+  src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js"
+  integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4"
+  crossOrigin="anonymous"
+  strategy="lazyOnload"
+  onLoad={() => {
+    if (window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+    }
+  }}
+/>
+```
+
+**환경 변수 (신규)**:
+- `NEXT_PUBLIC_KAKAO_JS_KEY` — Kakao 개발자 콘솔 JavaScript 키
+- Vercel 환경 변수에 추가 필요
+
+**Kakao 개발자 콘솔 설정**:
+- 앱 생성 → JavaScript 키 발급
+- 플랫폼 → 웹 → 도메인 등록 (개발: `http://localhost:3000`, 프로덕션: 실제 도메인)
+
+**검증**: 브라우저 콘솔에서 `window.Kakao.isInitialized() === true`
+
+---
+
+### Step 7: TypeScript 타입 선언
+
+**파일 (신규)**: `services/fint/src/types/kakao.d.ts`
+
+```typescript
+interface Window {
+  Kakao?: {
+    init: (appKey: string) => void;
+    isInitialized: () => boolean;
+    Share?: {
+      sendDefault: (options: unknown) => void;
+    };
+  };
+}
+```
+
+---
+
+### Step 8: 테스트 작성
+
+1. **`services/fint/tests/api/og-report.test.ts`** (신규)
+   - 유효한 sessionId, is_public=true → ImageResponse 반환
+   - is_public=false → fallback 이미지 반환
+   - 잘못된 UUID → fallback 이미지 반환 (200 OK)
+   - Cache-Control 헤더 포함
+
+2. **`services/fint/src/components/report/__tests__/ShareButtons.test.tsx`** (신규)
+   - 카카오 공유 버튼 클릭 → `window.Kakao.Share.sendDefault` 호출
+   - 링크 복사 버튼 클릭 → `navigator.clipboard.writeText` 호출
+   - Kakao SDK 없는 경우 graceful degradation
+
+3. **`services/fint/src/components/report/__tests__/ReportContent.test.tsx`** (신규)
+   - `initialReport` prop 전달 시 정상 렌더링
+   - `isOwner=false` 시 exit dialog 없음, 공유 뷰어 CTA 표시
+   - `isOwner=true` 시 기존 UI 표시
+   - `initialReport=null` + sessionStorage 있으면 fallback 정상 동작
+
+---
+
+### Step 9: `.ai.md` 업데이트
+
+**파일**: `services/fint/.ai.md`
+
+Phase 1 SNS 공유 구현 내용 추가:
+- 신규 파일 목록
+- `is_public` 컬럼 및 RLS 정책
+- Kakao SDK 초기화 방식
+- 환경 변수 목록 (`NEXT_PUBLIC_KAKAO_JS_KEY`)
+
+---
+
+## 파일 변경 요약
+
+| 작업 | 파일 |
+|------|------|
+| 신규 | `services/fint/supabase/migrations/20260325000000_add_reports_is_public.sql` |
+| 수정 | `services/fint/src/app/api/interview/end/route.ts` |
+| 신규 | `services/fint/src/app/api/og/report/route.tsx` |
+| 전환 | `services/fint/src/app/(interview)/report/[sessionId]/page.tsx` |
+| 신규 | `services/fint/src/components/report/ReportContent.tsx` |
+| 신규 | `services/fint/src/components/report/ShareButtons.tsx` |
+| 수정 | `services/fint/src/app/(interview)/layout.tsx` |
+| 신규 | `services/fint/src/types/kakao.d.ts` |
+| 신규 | `services/fint/tests/api/og-report.test.ts` |
+| 신규 | `services/fint/src/components/report/__tests__/ShareButtons.test.tsx` |
+| 신규 | `services/fint/src/components/report/__tests__/ReportContent.test.tsx` |
+| 수정 | `services/fint/.ai.md` |
+
+---
+
+## 리스크 및 미해결 사항
+
+| 리스크 | 완화 방법 |
+|--------|----------|
+| Kakao 개발자 앱 등록 미완료 | 버튼 UI는 앱 키 없이 구현. 키 발급 후 env 설정으로 활성화 |
+| `end` route DB insert 실패 (non-fatal) | sessionStorage fallback 유지. 공유 기능만 제한 |
+| `/api/og/` rate limit 미적용 | UUID 형식 검증 + Edge Cache로 반복 조회 차단 |
+| interview_sessions.job_category 형식 | 쉼표 구분 문자열 → 그대로 OG 카드에 표시 |
+
+---
+
+## 검증 체크리스트
+
+- [ ] `npm run build` — 0 errors
+- [ ] `npm test` — 신규 테스트 포함 모두 PASS
+- [ ] 카카오톡에서 리포트 URL 공유 시 점수·직군 포함된 OG 카드 표시
+- [ ] 리포트 화면에 공유 버튼 표시 및 동작 확인
+- [ ] 다른 기기(비로그인)에서 공유 링크 접근 → 리포트 내용 표시
+- [ ] OG 카드에 Teal #0D9488 브랜딩 적용 확인
+- [ ] `services/fint/.ai.md` 최신화 완료

--- a/services/fint/.ai.md
+++ b/services/fint/.ai.md
@@ -82,6 +82,31 @@ CREDIT_PERSONA_CREATOR_SHARE = 3   // 현직자 배분 (CREDIT_PERSONA_INTERVIEW
 /api/resume/questions  POST: PDF → 예상 질문
 ```
 
+### Phase 1 — SNS 공유 (이슈 #184, 2026-03-25)
+
+**OG 이미지 공유**: `@vercel/og` Edge Runtime으로 동적 OG 카드 생성
+- `/api/og/report?sessionId=<UUID>` → 1200×630 OG 이미지 반환
+- `reports.is_public=true` 리포트만 공개 (Cache-Control: s-maxage=86400)
+
+**카카오톡 공유**: Kakao JS SDK v2.7.2 (`(interview)` layout에 lazyOnload 스코프)
+- `kakao.Share.sendDefault` 커스텀 피드 공유
+- `NEXT_PUBLIC_KAKAO_JS_KEY` 환경 변수 필요 (Kakao 개발자 콘솔에서 발급)
+
+**공유 링크 비로그인 접근**: RLS `is_public=true` + Server Component DB fetch
+- `/report/[sessionId]` → Server Component → `ReportContent` Client Component
+- `isOwner` prop으로 소유자(원본 CTA)/뷰어(공유 CTA) UI 분기
+
+**신규 파일**:
+- `src/app/api/og/report/route.tsx` — OG 이미지 Edge Route
+- `src/components/report/ReportContent.tsx` — 리포트 UI Client Component
+- `src/components/report/ShareButtons.tsx` — 카카오/클립보드 공유 버튼
+- `src/types/kakao.d.ts` — Kakao SDK Window 타입 선언
+- `supabase/migrations/20260325000000_add_reports_is_public.sql` — DB 마이그레이션
+
+**DB 변경**: `reports` 테이블에 `is_public BOOLEAN DEFAULT false` 컬럼 추가
+- RLS 정책: anon role이 `is_public=true` 리포트 SELECT 허용
+- 신규 리포트는 `end` route에서 `is_public: true`로 insert
+
 ### 디렉토리 구조
 ```
 fint/

--- a/services/fint/package-lock.json
+++ b/services/fint/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/supabase-js": "^2.99.3",
         "@tailwindcss/postcss": "^4.2.1",
         "@testing-library/dom": "^10.4.1",
+        "@vercel/og": "^0.11.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -1578,6 +1579,15 @@
         }
       }
     },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1934,6 +1944,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.99.3",
@@ -2490,6 +2516,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vercel/og": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.11.1.tgz",
+      "integrity": "sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.25.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2682,6 +2724,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2751,6 +2802,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2827,6 +2887,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2858,6 +2924,47 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -3001,6 +3108,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -3132,6 +3248,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3151,6 +3273,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -3302,6 +3430,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -3715,6 +3855,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -3921,6 +4071,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -4030,6 +4196,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
@@ -4165,6 +4337,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/satori": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.25.0.tgz",
+      "integrity": "sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4282,6 +4476,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4362,6 +4562,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4478,6 +4684,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4781,6 +4997,12 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/services/fint/package.json
+++ b/services/fint/package.json
@@ -15,6 +15,7 @@
     "@supabase/supabase-js": "^2.99.3",
     "@tailwindcss/postcss": "^4.2.1",
     "@testing-library/dom": "^10.4.1",
+    "@vercel/og": "^0.11.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",

--- a/services/fint/src/app/(interview)/layout.tsx
+++ b/services/fint/src/app/(interview)/layout.tsx
@@ -1,5 +1,6 @@
 import { MobileShell } from "@/components/layout/MobileShell";
 import { ToastProvider } from "@/components/ui/toast";
+import Script from "next/script";
 
 export default function InterviewLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -7,6 +8,17 @@ export default function InterviewLayout({ children }: { children: React.ReactNod
       <MobileShell>
         {children}
       </MobileShell>
+      <Script
+        src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js"
+        integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4"
+        crossOrigin="anonymous"
+        strategy="lazyOnload"
+        onLoad={() => {
+          if (window.Kakao && !window.Kakao.isInitialized()) {
+            window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY ?? "");
+          }
+        }}
+      />
     </ToastProvider>
   );
 }

--- a/services/fint/src/app/(interview)/report/[sessionId]/page.tsx
+++ b/services/fint/src/app/(interview)/report/[sessionId]/page.tsx
@@ -1,173 +1,79 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { LoadingPhaseText } from "@/components/report/LoadingPhaseText";
-import { ScoreBar } from "@/components/report/ScoreBar";
-import { CategoryScoreGrid } from "@/components/report/CategoryScoreGrid";
-import { FeedbackSection } from "@/components/report/FeedbackSection";
-import { OrbPreviewCard } from "@/components/report/OrbPreviewCard";
-import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-import { TopBar } from "@/components/layout/TopBar";
+import { createClient } from "@/lib/supabase/server";
+import { getAnonId } from "@/lib/anon-cookie";
+import { ReportContent } from "@/components/report/ReportContent";
 import type { ReportResponse } from "@/lib/types";
-import { SaveAccountCTA } from "@/components/interview/SaveAccountCTA";
+import type { Metadata } from "next";
 
-export default function ReportPage() {
-  const params = useParams<{ sessionId: string }>();
-  const sessionId = params.sessionId;
-  const router = useRouter();
+interface Props {
+  params: Promise<{ sessionId: string }>;
+}
 
-  const [report, setReport] = useState<ReportResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [showExitDialog, setShowExitDialog] = useState(false);
-  const [exitTarget, setExitTarget] = useState<"history" | "home">("home");
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { sessionId } = await params;
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("reports")
+    .select("total_score, summary")
+    .eq("session_id", sessionId)
+    .eq("is_public", true)
+    .single();
 
-  useEffect(() => {
-    // sessionStorage에서 리포트 데이터 읽기
-    const stored = sessionStorage.getItem(`report_${sessionId}`);
-    if (stored) {
-      try {
-        setReport(JSON.parse(stored));
-        setLoading(false);
-      } catch {}
-    }
-  }, [sessionId]);
-
-  const handleNavigate = (target: "history" | "home") => {
-    setExitTarget(target);
-    setShowExitDialog(true);
-  };
-
-  const handleConfirmExit = () => {
-    try { sessionStorage.removeItem(`report_${sessionId}`); } catch {}
-    router.push(exitTarget === "history" ? "/interview" : "/");
-  };
-
-  if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[100dvh] gap-6 px-6">
-        <div className="relative flex items-center justify-center">
-          <span className="absolute inline-flex h-16 w-16 animate-ping rounded-full bg-[#0D9488] opacity-20" />
-          <span className="absolute inline-flex h-12 w-12 animate-ping rounded-full bg-[#0D9488] opacity-30 animation-delay-150" />
-          <div className="relative z-10">
-            <LoadingPhaseText />
-          </div>
-        </div>
-        <p className="text-xs text-center text-[--color-muted-foreground]">
-          평균 12-18초 소요돼요. 잠깐만 기다려주세요!
-        </p>
-      </div>
-    );
+  if (!data) {
+    return { title: "면접 결과 리포트 | Fint" };
   }
 
-  if (!report) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[100dvh] gap-4 px-6 text-center">
-        <p className="text-base font-semibold">리포트를 불러올 수 없어요</p>
-        <Button onClick={() => router.push("/")}>다시 연습하기</Button>
-      </div>
-    );
+  const title = `내 면접 점수는 ${data.total_score}점! | Fint`;
+  const description = data.summary?.slice(0, 100) ?? "AI 모의면접 결과를 확인해보세요";
+  const ogImage = `/api/og/report?sessionId=${sessionId}`;
+
+  return {
+    title,
+    openGraph: {
+      title,
+      description,
+      images: [ogImage],
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}
+
+export default async function ReportPage({ params }: Props) {
+  const { sessionId } = await params;
+  const supabase = await createClient();
+
+  const { data: reportRow } = await supabase
+    .from("reports")
+    .select("total_score, summary, axis_feedbacks, anonymous_id")
+    .eq("session_id", sessionId)
+    .eq("is_public", true)
+    .single();
+
+  let isOwner = false;
+  if (reportRow) {
+    const anonId = await getAnonId();
+    isOwner = !!anonId && anonId === reportRow.anonymous_id;
   }
 
-  const scoreColor =
-    report.totalScore >= 80 ? "text-[#0D9488]" :
-    report.totalScore >= 60 ? "text-yellow-600" :
-    "text-amber-500";
+  const initialReport: ReportResponse | null = reportRow
+    ? {
+        totalScore: reportRow.total_score,
+        summary: reportRow.summary,
+        axisFeedbacks: reportRow.axis_feedbacks ?? [],
+        growthCurve: null,
+      }
+    : null;
 
   return (
-    <div className="flex flex-col min-h-[100dvh] bg-[--color-background]">
-      <TopBar title="면접 결과 리포트 📊" />
-
-      <main className="flex-1 px-5 py-6 space-y-6 pb-24">
-        {/* 종합 점수 */}
-        <div className="bg-gradient-to-br from-white to-gray-50 rounded-2xl border border-[--color-border] p-5 flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-[--color-muted-foreground]">종합 점수</p>
-            <span className="text-xs text-[--color-muted-foreground] bg-gray-100 rounded-full px-2 py-0.5">
-              {new Date().toLocaleDateString("ko-KR", { month: "long", day: "numeric" })}
-            </span>
-          </div>
-          <div className="flex items-end gap-2">
-            <span className={`text-6xl font-black tabular-nums ${scoreColor}`}>{report.totalScore}</span>
-            <span className="text-lg text-[--color-muted-foreground] mb-1">/ 100</span>
-          </div>
-          <ScoreBar score={report.totalScore} size="lg" />
-          {report.totalScore < 60 && (
-            <p className="text-xs text-amber-600 bg-amber-50 rounded-xl px-3 py-2 text-center">
-              💪 처음엔 누구나 어려워요. 지금부터 함께 올라가봐요!
-            </p>
-          )}
-          {report.summary && (
-            <p className="text-sm text-[--color-muted-foreground] leading-relaxed border-t border-[--color-border] pt-3 border-l-4 border-l-[#0D9488] pl-3">
-              {report.summary}
-            </p>
-          )}
-        </div>
-
-        {/* 카테고리 점수 */}
-        {report.axisFeedbacks && report.axisFeedbacks.length > 0 && (
-          <div className="space-y-3">
-            <h2 className="text-sm font-bold text-gray-700 uppercase tracking-wider">카테고리별 점수</h2>
-            <CategoryScoreGrid axisFeedback={report.axisFeedbacks} />
-          </div>
-        )}
-
-        {/* 피드백 */}
-        {report.axisFeedbacks && report.axisFeedbacks.length > 0 && (
-          <div className="space-y-3">
-            <h2 className="text-sm font-bold text-gray-700 uppercase tracking-wider">상세 피드백</h2>
-            <FeedbackSection axisFeedback={report.axisFeedbacks} />
-          </div>
-        )}
-
-        {/* 합격 예언 오브 */}
-        <div className="space-y-3">
-          <h2 className="text-sm font-bold text-gray-700 uppercase tracking-wider">합격 예언 오브</h2>
-          <OrbPreviewCard />
-        </div>
-      </main>
-
-      {/* 비로그인 로그인/가입 유도 CTA */}
-      <SaveAccountCTA sessionId={sessionId} />
-
-      {/* 하단 CTA */}
-      <div
-        className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] bg-[--color-surface] border-t border-[--color-border] px-4 py-3 flex gap-2"
-        style={{ paddingBottom: `calc(0.75rem + env(safe-area-inset-bottom))` }}
-      >
-        <Button
-          className="flex-1 bg-[#0D9488] hover:bg-[#0b7a70] text-white font-semibold"
-          onClick={() => router.push("/interview")}
-        >
-          면접 기록 보기
-        </Button>
-        <Button
-          variant="outline"
-          className="flex-1"
-          onClick={() => router.push("/onboarding")}
-        >
-          다시 연습하기
-        </Button>
-      </div>
-
-      {/* 이탈 확인 다이얼로그 */}
-      <Dialog open={showExitDialog} onOpenChange={setShowExitDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>결과 화면을 나갈까요?</DialogTitle>
-            <DialogDescription>
-              이 결과는 아직 저장되지 않아요. 계속할까요?
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setShowExitDialog(false)}>
-              취소
-            </Button>
-            <Button onClick={handleConfirmExit}>나가기</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    <ReportContent
+      sessionId={sessionId}
+      initialReport={initialReport}
+      isOwner={isOwner}
+    />
   );
 }

--- a/services/fint/src/app/api/interview/end/route.ts
+++ b/services/fint/src/app/api/interview/end/route.ts
@@ -69,6 +69,7 @@ export async function POST(request: Request) {
         axis_scores: report.axisScores,
         axis_feedbacks: report.axisFeedbacks,
         summary: report.summary,
+        is_public: true,
       })
       .select("id")
       .single();

--- a/services/fint/src/app/api/og/report/route.tsx
+++ b/services/fint/src/app/api/og/report/route.tsx
@@ -1,0 +1,242 @@
+import { ImageResponse } from "@vercel/og";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export const runtime = "edge";
+
+const sessionIdSchema = z.string().uuid();
+
+const CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+};
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return "#0D9488";
+  if (score >= 60) return "#F59E0B";
+  return "#EF4444";
+}
+
+function FallbackCard() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#ffffff",
+        padding: "60px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 24,
+          fontWeight: 700,
+          color: "#0D9488",
+          marginBottom: 24,
+        }}
+      >
+        Fint
+      </div>
+      <div
+        style={{
+          fontSize: 36,
+          fontWeight: 700,
+          color: "#111827",
+          marginBottom: 12,
+        }}
+      >
+        내 면접 결과 보기
+      </div>
+      <div
+        style={{
+          fontSize: 20,
+          color: "#6B7280",
+        }}
+      >
+        Fint AI 모의면접
+      </div>
+    </div>
+  );
+}
+
+function OGCard({
+  totalScore,
+  jobCategory,
+  summary,
+}: {
+  totalScore: number;
+  jobCategory: string;
+  summary: string;
+}) {
+  const scoreColor = getScoreColor(totalScore);
+  const summaryPreview = summary.slice(0, 80);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#ffffff",
+        padding: "60px",
+        justifyContent: "space-between",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          fontSize: 24,
+          fontWeight: 700,
+          color: "#0D9488",
+        }}
+      >
+        Fint
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          flex: 1,
+          gap: 12,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 20,
+            color: "#374151",
+          }}
+        >
+          내 면접 점수는
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 96,
+              fontWeight: 900,
+              color: scoreColor,
+              lineHeight: 1,
+            }}
+          >
+            {totalScore}점
+          </span>
+          <span
+            style={{
+              fontSize: 32,
+              color: "#9CA3AF",
+            }}
+          >
+            / 100
+          </span>
+        </div>
+
+        <div
+          style={{
+            fontSize: 18,
+            color: "#6B7280",
+          }}
+        >
+          {jobCategory}
+        </div>
+
+        <div
+          style={{
+            fontSize: 16,
+            color: "#6B7280",
+            textAlign: "center",
+            maxWidth: 800,
+          }}
+        >
+          {summaryPreview}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          fontSize: 14,
+          color: "#0D9488",
+        }}
+      >
+        fint.app
+      </div>
+    </div>
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const sessionId = searchParams.get("sessionId");
+
+  const parsed = sessionIdSchema.safeParse(sessionId);
+  if (!parsed.success) {
+    return new ImageResponse(<FallbackCard />, {
+      width: 1200,
+      height: 630,
+      headers: CACHE_HEADERS,
+    });
+  }
+
+  try {
+    const supabase = createServiceClient();
+
+    const [reportResult, sessionResult] = await Promise.all([
+      supabase
+        .from("reports")
+        .select("total_score, summary")
+        .eq("session_id", parsed.data)
+        .eq("is_public", true)
+        .single(),
+      supabase
+        .from("interview_sessions")
+        .select("job_category")
+        .eq("id", parsed.data)
+        .single(),
+    ]);
+
+    if (reportResult.error || !reportResult.data) {
+      return new ImageResponse(<FallbackCard />, {
+        width: 1200,
+        height: 630,
+        headers: CACHE_HEADERS,
+      });
+    }
+
+    const { total_score, summary } = reportResult.data;
+    const jobCategory = sessionResult.data?.job_category ?? "";
+
+    return new ImageResponse(
+      <OGCard
+        totalScore={total_score}
+        jobCategory={jobCategory}
+        summary={summary ?? ""}
+      />,
+      {
+        width: 1200,
+        height: 630,
+        headers: CACHE_HEADERS,
+      }
+    );
+  } catch {
+    return new ImageResponse(<FallbackCard />, {
+      width: 1200,
+      height: 630,
+      headers: CACHE_HEADERS,
+    });
+  }
+}

--- a/services/fint/src/components/report/ReportContent.tsx
+++ b/services/fint/src/components/report/ReportContent.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { LoadingPhaseText } from "@/components/report/LoadingPhaseText";
+import { ScoreBar } from "@/components/report/ScoreBar";
+import { CategoryScoreGrid } from "@/components/report/CategoryScoreGrid";
+import { FeedbackSection } from "@/components/report/FeedbackSection";
+import { OrbPreviewCard } from "@/components/report/OrbPreviewCard";
+import { Button } from "@/components/ui/button";
+import { TopBar } from "@/components/layout/TopBar";
+import type { ReportResponse } from "@/lib/types";
+import { SaveAccountCTA } from "@/components/interview/SaveAccountCTA";
+import { ShareButtons } from "@/components/report/ShareButtons";
+
+interface ReportContentProps {
+  sessionId: string;
+  initialReport: ReportResponse | null;
+  isOwner: boolean;
+}
+
+export function ReportContent({ sessionId, initialReport, isOwner }: ReportContentProps) {
+  const router = useRouter();
+
+  const [report, setReport] = useState<ReportResponse | null>(initialReport);
+  const [loading, setLoading] = useState(initialReport === null);
+
+  useEffect(() => {
+    if (initialReport !== null) {
+      return;
+    }
+    const stored = sessionStorage.getItem(`report_${sessionId}`);
+    if (stored) {
+      try {
+        setReport(JSON.parse(stored));
+        setLoading(false);
+      } catch {
+        sessionStorage.removeItem(`report_${sessionId}`);
+        setLoading(false);
+      }
+    } else {
+      setLoading(false);
+    }
+  }, [sessionId, initialReport]);
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[100dvh] gap-6 px-6">
+        <div className="relative flex items-center justify-center">
+          <span className="absolute inline-flex h-16 w-16 animate-ping rounded-full bg-[#0D9488] opacity-20" />
+          <span className="absolute inline-flex h-12 w-12 animate-ping rounded-full bg-[#0D9488] opacity-30 animation-delay-150" />
+          <div className="relative z-10">
+            <LoadingPhaseText />
+          </div>
+        </div>
+        <p className="text-xs text-center text-[--color-muted-foreground]">
+          평균 12-18초 소요돼요. 잠깐만 기다려주세요!
+        </p>
+      </div>
+    );
+  }
+
+  if (!report) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[100dvh] gap-4 px-6 text-center">
+        <p className="text-base font-semibold">리포트를 불러올 수 없어요</p>
+        <Button onClick={() => router.push("/")}>다시 연습하기</Button>
+      </div>
+    );
+  }
+
+  const scoreColor =
+    report.totalScore >= 80 ? "text-[#0D9488]" :
+    report.totalScore >= 60 ? "text-yellow-600" :
+    "text-amber-500";
+
+  return (
+    <div className="flex flex-col min-h-[100dvh] bg-[--color-background]">
+      <TopBar title="면접 결과 리포트 📊" />
+
+      <main className="flex-1 px-5 py-6 space-y-6 pb-24">
+        <div className="bg-gradient-to-br from-white to-gray-50 rounded-2xl border border-[--color-border] p-5 flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-[--color-muted-foreground]">종합 점수</p>
+            <span className="text-xs text-[--color-muted-foreground] bg-gray-100 rounded-full px-2 py-0.5">
+              {new Date().toLocaleDateString("ko-KR", { month: "long", day: "numeric" })}
+            </span>
+          </div>
+          <div className="flex items-end gap-2">
+            <span className={`text-6xl font-black tabular-nums ${scoreColor}`}>{report.totalScore}</span>
+            <span className="text-lg text-[--color-muted-foreground] mb-1">/ 100</span>
+          </div>
+          <ScoreBar score={report.totalScore} size="lg" />
+          {report.totalScore < 60 && (
+            <p className="text-xs text-amber-600 bg-amber-50 rounded-xl px-3 py-2 text-center">
+              💪 처음엔 누구나 어려워요. 지금부터 함께 올라가봐요!
+            </p>
+          )}
+          {report.summary && (
+            <p className="text-sm text-[--color-muted-foreground] leading-relaxed border-t border-[--color-border] pt-3 border-l-4 border-l-[#0D9488] pl-3">
+              {report.summary}
+            </p>
+          )}
+        </div>
+
+        {report.axisFeedbacks && report.axisFeedbacks.length > 0 && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-bold text-gray-700 uppercase tracking-wider">카테고리별 점수</h2>
+            <CategoryScoreGrid axisFeedback={report.axisFeedbacks} />
+          </div>
+        )}
+
+        {report.axisFeedbacks && report.axisFeedbacks.length > 0 && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-bold text-gray-700 uppercase tracking-wider">상세 피드백</h2>
+            <FeedbackSection axisFeedback={report.axisFeedbacks} />
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <h2 className="text-sm font-bold text-gray-700 uppercase tracking-wider">합격 예언 오브</h2>
+          <OrbPreviewCard />
+        </div>
+
+        <ShareButtons sessionId={sessionId} totalScore={report.totalScore} summary={report.summary} />
+      </main>
+
+      <SaveAccountCTA sessionId={sessionId} />
+
+      <div
+        className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] bg-[--color-surface] border-t border-[--color-border] px-4 py-3 flex gap-2"
+        style={{ paddingBottom: `calc(0.75rem + env(safe-area-inset-bottom))` }}
+      >
+        {isOwner ? (
+          <>
+            <Button
+              className="flex-1 bg-[#0D9488] hover:bg-[#0b7a70] text-white font-semibold"
+              onClick={() => router.push("/interview")}
+            >
+              면접 기록 보기
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => router.push("/onboarding")}
+            >
+              다시 연습하기
+            </Button>
+          </>
+        ) : (
+          <Button
+            className="flex-1 bg-[#0D9488] hover:bg-[#0b7a70] text-white font-semibold"
+            onClick={() => router.push("/onboarding")}
+          >
+            나도 면접 연습하기
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/services/fint/src/components/report/ShareButtons.tsx
+++ b/services/fint/src/components/report/ShareButtons.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ShareButtonsProps {
+  sessionId: string;
+  totalScore: number;
+  summary?: string;
+}
+
+export function ShareButtons({ sessionId, totalScore, summary }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false);
+  const [isKakaoAvailable, setIsKakaoAvailable] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsKakaoAvailable(!!window.Kakao?.Share?.sendDefault);
+    check();
+    const timer = setTimeout(check, 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  function handleKakaoShare() {
+    const origin = window.location.origin;
+    const reportUrl = `${origin}/report/${sessionId}`;
+
+    window.Kakao?.Share?.sendDefault({
+      objectType: "feed",
+      content: {
+        title: `내 면접 점수는 ${totalScore}점!`,
+        description: summary ? `${summary.slice(0, 50)} | Fint` : "AI 모의면접 결과를 확인해보세요 | Fint",
+        imageUrl: `${origin}/api/og/report?sessionId=${sessionId}`,
+        link: {
+          mobileWebUrl: reportUrl,
+          webUrl: reportUrl,
+        },
+      },
+      buttons: [
+        {
+          title: "결과 보기",
+          link: {
+            mobileWebUrl: reportUrl,
+            webUrl: reportUrl,
+          },
+        },
+      ],
+    });
+  }
+
+  async function handleCopyLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  }
+
+  return (
+    <div className="flex gap-2">
+      <Button
+        onClick={handleKakaoShare}
+        disabled={!isKakaoAvailable}
+        className="bg-[#FEE500] text-[#3C1E1E] hover:bg-[#F5DC00] disabled:opacity-50"
+      >
+        카카오톡 공유
+      </Button>
+      <Button variant="outline" onClick={handleCopyLink}>
+        {copied ? "복사됨!" : "링크 복사"}
+      </Button>
+    </div>
+  );
+}

--- a/services/fint/src/components/report/__tests__/ReportContent.test.tsx
+++ b/services/fint/src/components/report/__tests__/ReportContent.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReportResponse } from "@/lib/types";
+
+// next/navigation mock
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// 하위 컴포넌트 mock — 렌더링 오류 방지
+vi.mock("@/components/report/LoadingPhaseText", () => ({
+  LoadingPhaseText: () => <span>Loading...</span>,
+}));
+vi.mock("@/components/report/ScoreBar", () => ({
+  ScoreBar: ({ score }: { score: number }) => <div data-testid="score-bar">{score}</div>,
+}));
+vi.mock("@/components/report/CategoryScoreGrid", () => ({
+  CategoryScoreGrid: () => <div />,
+}));
+vi.mock("@/components/report/FeedbackSection", () => ({
+  FeedbackSection: () => <div />,
+}));
+vi.mock("@/components/report/OrbPreviewCard", () => ({
+  OrbPreviewCard: () => <div />,
+}));
+vi.mock("@/components/layout/TopBar", () => ({
+  TopBar: ({ title }: { title: string }) => <header>{title}</header>,
+}));
+vi.mock("@/components/interview/SaveAccountCTA", () => ({
+  SaveAccountCTA: () => <div />,
+}));
+
+import { ReportContent } from "../ReportContent";
+
+const mockReport: ReportResponse = {
+  totalScore: 85,
+  summary: "테스트 요약",
+  axisFeedbacks: [],
+  growthCurve: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+});
+
+describe("ReportContent", () => {
+  it("renders report when initialReport prop provided", () => {
+    render(
+      <ReportContent sessionId="test-id" initialReport={mockReport} isOwner={true} />
+    );
+
+    expect(screen.getAllByText("85").length).toBeGreaterThan(0);
+  });
+
+  it("non-owner view hides exit dialog elements and shows single CTA", () => {
+    render(
+      <ReportContent sessionId="test-id" initialReport={mockReport} isOwner={false} />
+    );
+
+    expect(screen.getByText("나도 면접 연습하기")).toBeInTheDocument();
+    expect(screen.queryByText("면접 기록 보기")).not.toBeInTheDocument();
+  });
+
+  it("owner view shows full CTA buttons", () => {
+    render(
+      <ReportContent sessionId="test-id" initialReport={mockReport} isOwner={true} />
+    );
+
+    expect(screen.getByText("면접 기록 보기")).toBeInTheDocument();
+    expect(screen.getByText("다시 연습하기")).toBeInTheDocument();
+  });
+
+  it("falls back to sessionStorage when initialReport is null", async () => {
+    sessionStorage.setItem("report_test-id", JSON.stringify(mockReport));
+
+    render(
+      <ReportContent sessionId="test-id" initialReport={null} isOwner={true} />
+    );
+
+    // useEffect 실행 후 점수가 표시되는지 확인
+    expect((await screen.findAllByText("85")).length).toBeGreaterThan(0);
+  });
+});

--- a/services/fint/src/components/report/__tests__/ShareButtons.test.tsx
+++ b/services/fint/src/components/report/__tests__/ShareButtons.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShareButtons } from "../ShareButtons";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // clipboard mock
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("ShareButtons", () => {
+  it("renders kakao share button and copy button", () => {
+    render(<ShareButtons sessionId="test-id" totalScore={85} />);
+
+    expect(screen.getByText("카카오톡 공유")).toBeInTheDocument();
+    expect(screen.getByText("링크 복사")).toBeInTheDocument();
+  });
+
+  it("copy button writes to clipboard", async () => {
+    render(<ShareButtons sessionId="test-id" totalScore={85} />);
+
+    const copyButton = screen.getByText("링크 복사");
+    fireEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      window.location.href
+    );
+  });
+
+  it("kakao button is disabled when SDK not available", () => {
+    // window.Kakao가 없으면 disabled
+    (window as any).Kakao = undefined;
+
+    render(<ShareButtons sessionId="test-id" totalScore={85} />);
+
+    const kakaoButton = screen.getByText("카카오톡 공유");
+    expect(kakaoButton.closest("button")).toBeDisabled();
+  });
+});

--- a/services/fint/src/types/kakao.d.ts
+++ b/services/fint/src/types/kakao.d.ts
@@ -1,0 +1,9 @@
+interface Window {
+  Kakao?: {
+    init: (appKey: string) => void;
+    isInitialized: () => boolean;
+    Share?: {
+      sendDefault: (options: unknown) => void;
+    };
+  };
+}

--- a/services/fint/supabase/migrations/20260325000000_add_reports_is_public.sql
+++ b/services/fint/supabase/migrations/20260325000000_add_reports_is_public.sql
@@ -1,0 +1,19 @@
+-- Migration: Add is_public column to reports table for SNS sharing (Issue #184)
+-- Date: 2026-03-25
+
+-- RLS 활성화 (이미 활성화된 경우 no-op)
+ALTER TABLE reports ENABLE ROW LEVEL SECURITY;
+
+-- is_public 컬럼 추가 (DEFAULT false — 신규 리포트만 공유 허용, 기존 리포트 소급 공개 방지)
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
+
+-- RLS 정책: anon 사용자가 is_public=true 리포트를 읽을 수 있도록 허용
+CREATE POLICY "public reports are viewable by everyone"
+  ON reports
+  FOR SELECT
+  TO anon
+  USING (is_public = true);
+
+-- 주의: 이 마이그레이션 실행 전 Supabase 대시보드에서
+-- reports 테이블의 기존 RLS 정책을 확인하세요.
+-- 기존 인증된 사용자 SELECT 정책이 있는지 확인이 필요합니다.

--- a/services/fint/tests/api/og-report.test.ts
+++ b/services/fint/tests/api/og-report.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// @vercel/og mock — ImageResponse를 일반 Response처럼 동작하게 처리
+vi.mock("@vercel/og", () => ({
+  ImageResponse: class ImageResponse extends Response {
+    constructor(_element: unknown, options?: ResponseInit & { headers?: Record<string, string> }) {
+      const headers = new Headers({ "Content-Type": "image/png" });
+      if (options?.headers) {
+        Object.entries(options.headers).forEach(([k, v]) => headers.set(k, v));
+      }
+      super(new Uint8Array([0, 0]), { status: 200, headers });
+    }
+  },
+}));
+
+// supabase/server mock
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { createServiceClient } from "@/lib/supabase/server";
+import { GET } from "../../src/app/api/og/report/route";
+
+const mockCreateServiceClient = vi.mocked(createServiceClient);
+
+function buildRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/og/report");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new Request(url.toString()) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/og/report", () => {
+  it("valid sessionId with is_public=true report returns ImageResponse", async () => {
+    const validId = "550e8400-e29b-41d4-a716-446655440000";
+
+    mockCreateServiceClient.mockReturnValue({
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "reports") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: { total_score: 85, summary: "잘 했어요" },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        // interview_sessions
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { job_category: "IT/개발" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }),
+    } as any);
+
+    const response = await GET(buildRequest({ sessionId: validId }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("image/png");
+  });
+
+  it("invalid UUID returns fallback ImageResponse (200)", async () => {
+    const response = await GET(buildRequest({ sessionId: "not-a-uuid" }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("image/png");
+  });
+
+  it("missing sessionId returns fallback ImageResponse (200)", async () => {
+    const response = await GET(buildRequest());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("image/png");
+  });
+});


### PR DESCRIPTION
## 이슈 배경

면접 결과를 카카오톡으로 공유할 때 점수·직군이 담긴 OG 카드 이미지가 미리보기에 표시되도록 구현합니다. 기존에는 기본 OG 태그만 뜨고 점수 정보가 없어 공유 유인이 없었으며, 프로포절 AARRR Referral 핵심인 "결과 리포트 카드 SNS 공유 → 바이럴 루프"를 완성하기 위한 Phase 1 작업입니다.

## 완료 기준 (AC)

- [x] 리포트 URL 공유 시 카카오톡·SNS 미리보기에 점수·직군이 포함된 OG 카드 이미지 표시
- [x] 리포트 화면에 카카오톡 공유 버튼 + 링크 복사 버튼 추가
- [x] 공유 링크로 비로그인 유저도 리포트 조회 가능 (읽기 전용, RLS 설정)
- [x] OG 카드에 Fint 브랜딩 (Teal #0D9488) 적용

## 작업 내역

### 신규 파일
- `src/app/api/og/report/route.tsx` — `@vercel/og` Edge Runtime으로 1200×630 OG 카드 동적 생성. UUID 검증 실패 또는 is_public=false 시 fallback 이미지 반환. Cache-Control: s-maxage=86400
- `src/components/report/ReportContent.tsx` — 기존 page.tsx의 UI 로직을 Client Component로 분리. `initialReport` prop 우선, 없으면 sessionStorage fallback. `isOwner` prop으로 소유자/뷰어 CTA 분기
- `src/components/report/ShareButtons.tsx` — 카카오톡 공유(`Kakao.Share.sendDefault`) + 클립보드 링크 복사. SDK async 로드를 useEffect로 감지
- `src/types/kakao.d.ts` — Kakao SDK Window 타입 선언
- `supabase/migrations/20260325000000_add_reports_is_public.sql` — `reports.is_public BOOLEAN DEFAULT false` 컬럼 + anon SELECT RLS 정책
- 테스트 3종: OG 라우트, ShareButtons, ReportContent

### 수정 파일
- `page.tsx` → Server Component 전환, `generateMetadata`로 og:image/og:title 추가, `createClient()` anon으로 서버 fetch, `isOwner` 판별
- `end/route.ts` — insert 시 `is_public: true` 추가 (신규 리포트 공개)
- `layout.tsx` — Kakao JS SDK v2.7.2 lazyOnload로 `(interview)` 그룹에 스코프 로드
- `package.json` — `@vercel/og` 의존성 추가

### 기술적 결정
- 별도 `/share/[sessionId]` 페이지 대신 동일 URL 유지 → 바이럴 링크 일관성
- `createServiceClient()` (service role) 사용 → Edge Runtime에서 cookies() 의존 회피
- `is_public DEFAULT false` → 기존 리포트 소급 공개 없음, 신규만 공유 허용

## 참고

- `NEXT_PUBLIC_KAKAO_JS_KEY` 환경 변수 Vercel에 추가 필요 (Kakao 개발자 콘솔 JavaScript 키)
- Supabase 대시보드에서 마이그레이션 SQL 직접 실행 필요 (`supabase/migrations/` 참고)

Closes #184