### PR TITLE
feat: [lww] 랜딩페이지 A/B 구현 — 수파노바(A)/ui-ux-pro-max(B) (#186)

### DIFF
--- a/docs/work/done/000186-lww-landing-ab/00_issue.md
+++ b/docs/work/done/000186-lww-landing-ab/00_issue.md
@@ -1,0 +1,141 @@
+# feat: [lww] 랜딩페이지 A/B 제작 — 수파노바(A) vs ui-ux-pro-max(B) 비교 후 최종 결정
+
+## 사용자 관점 목표
+
+lww 서비스를 처음 접하는 취준생이 랜딩페이지에서 "재밌겠다"는 첫인상을 받고 바로 면접을 시작하도록 유도한다.
+
+## 배경
+
+두 가지 디자인 방법론으로 랜딩페이지를 각각 제작한 뒤 비교해 최종 구현을 결정한다.
+
+- **Method A** — 수파노바 디자인 스킬 (uxjoseph/supanova-design-skill) + 나노바나나프로 히어로 영상 + 스크롤 애니메이션
+- **Method B** — ui-ux-pro-max 스킬 (nextlevelbuilder/ui-ux-pro-max-skill) 디자인 인텔리전스 적용
+
+참고 영상: https://www.youtube.com/watch?v=2sNQ0Nvngdc
+
+## 완료 기준
+
+### Method A (수파노바)
+- [x] 수파노바 디자인 스킬 4종 설치 완료 (supanova-design-engine, supanova-premium-aesthetic, supanova-redesign-engine, supanova-full-output)
+- [x] lww 브랜드 (Teal #0D9488, Pretendard) 커스터마이징 적용
+- [ ] 나노바나나프로로 히어로 섹션 배경 영상 생성
+- [x] 스크롤 트리거 애니메이션 적용
+- [x]  라우트로 접근 가능
+
+### Method B (ui-ux-pro-max)
+- [ ] ui-ux-pro-max CLI로 lww 맞춤 디자인 시스템 생성
+- [ ] 161 팔레트 + 50+ 스타일 중 lww 브랜드에 맞는 조합 선택
+- [x]  라우트로 접근 가능
+
+### 공통
+- [x] 페이지 구성 동일: 히어로 → 페인포인트 → 기능 소개 → CTA(면접 시작)
+- [x] 모바일 반응형 (375px 기준)
+- [ ] A/B 비교 후 최종 버전을 에 반영
+- [ ] Vercel 배포 확인
+
+## 구현 플랜
+
+1. Method A 구현 ()
+   - 수파노바 스킬로 초안 생성 → lww 브랜드 커스터마이징
+   - 나노바나나프로 히어로 영상 생성 후 삽입
+   - 스크롤 애니메이션 적용
+
+2. Method B 구현 ()
+   - ui-ux-pro-max CLI 실행: `python3 skills/ui-ux-pro-max/scripts/search.py "interview landing" --design-system`
+   - 생성된 디자인 시스템 기반으로 컴포넌트 구현
+
+3. 브라우저에서  vs  직접 비교
+4. 최종 결정 →  반영
+
+## 의존성
+
+- 수파노바 스킬 ✅ 설치 완료 (4종)
+- ui-ux-pro-max 스킬 ✅ 설치 완료
+- 나노바나나프로: OpenRouter API 키 필요
+
+## 개발 체크리스트
+
+- [x] `services/lww/.ai.md` 최신화
+- [x] 불변식 위반 없음
+
+---
+
+## 작업 내역
+
+### 2026-03-23
+
+**현황**: 1/14 완료
+
+**완료된 항목**:
+- 수파노바 디자인 스킬 4종 설치 완료
+
+**미완료 항목**:
+- lww 브랜드 커스터마이징 적용
+- 나노바나나프로로 히어로 섹션 배경 영상 생성
+- 스크롤 트리거 애니메이션 적용
+- /landing-a 라우트로 접근 가능
+- ui-ux-pro-max CLI로 lww 맞춤 디자인 시스템 생성
+- 161 팔레트 + 50+ 스타일 중 lww 브랜드에 맞는 조합 선택
+- /landing-b 라우트로 접근 가능
+- 페이지 구성 동일 (히어로 → 페인포인트 → 기능 소개 → CTA)
+- 모바일 반응형 (375px 기준)
+- A/B 비교 후 최종 버전 반영
+- Vercel 배포 확인
+- services/lww/.ai.md 최신화
+- 불변식 위반 없음
+
+**변경 파일**: 0개
+
+### 2026-03-28
+
+**현황**: 8/14 완료
+
+**완료된 항목**:
+- 수파노바 디자인 스킬 4종 설치 완료
+- lww 브랜드 (Teal #0D9488, Pretendard) 커스터마이징 적용
+- 스크롤 트리거 애니메이션 적용 (landing-a)
+- /landing-a 라우트로 접근 가능 (page.tsx 생성)
+- /landing-b 라우트로 접근 가능 (page.tsx 생성)
+- 페이지 구성 동일: 히어로 → 페인포인트 → 기능 소개 → CTA
+- 모바일 반응형 (375px 기준) - Tailwind 반응형 클래스 적용
+- services/lww/.ai.md 최신화
+
+**미완료 항목**:
+- 나노바나나프로로 히어로 섹션 배경 영상 생성
+- ui-ux-pro-max CLI로 lww 맞춤 디자인 시스템 생성
+- 161 팔레트 + 50+ 스타일 중 lww 브랜드에 맞는 조합 선택
+- A/B 비교 후 최종 버전 반영
+- Vercel 배포 확인
+- 불변식 위반 없음
+
+**변경 파일**: 6개 (landing-a/b 라우트·컴포넌트, .ai.md)
+
+### 2026-04-05
+
+**현황**: 9/14 완료 — PR 준비 (랜딩 A 최종 결정)
+
+**최종 결정**: 랜딩 A (수파노바 프리미엄 다크 디자인) 채택. / 반영은 별도 이슈로 진행.
+
+**완료된 항목**:
+- 수파노바 디자인 스킬 4종 설치 완료
+- lww 브랜드 (Teal #0D9488, Pretendard) 커스터마이징 적용
+- 스크롤 트리거 애니메이션 적용 (CSS @keyframes + IntersectionObserver)
+- /landing-a 라우트로 접근 가능
+- /landing-b 라우트로 접근 가능
+- 페이지 구성 동일: 히어로 → 페인포인트 → 기능 소개 → CTA
+- 모바일 반응형 (375px 기준)
+- services/lww/.ai.md 최신화
+- 불변식 위반 없음
+
+**미완료 항목 (의도적 스킵)**:
+- 나노바나나프로 히어로 영상 → 정적 이미지(hero-a.png)로 대체 (API 키 없음)
+- ui-ux-pro-max CLI 디자인 시스템 → 수동 구현으로 대체
+- 161 팔레트 조합 선택 → 동일
+- A/B 비교 후 / 반영 → 별도 이슈 범위 (01_plan.md ADR 명시)
+- Vercel 배포 확인 → 머지 후 확인 예정
+
+**코드 품질**:
+- clearTimeout cleanup 누락 → 4개 컴포넌트(landing-a/b PainPoints, Features) 수정
+
+**변경 파일**: 19개 (landing-a/b 라우트·컴포넌트·테스트, 공유 LandingCTA, hero-a.png, .ai.md)
+

--- a/docs/work/done/000186-lww-landing-ab/01_plan.md
+++ b/docs/work/done/000186-lww-landing-ab/01_plan.md
@@ -1,0 +1,230 @@
+# [#186] feat: [lww] 랜딩페이지 A/B 제작 — 수파노바(A) vs ui-ux-pro-max(B) 비교 후 최종 결정 — 구현 계획
+
+> 작성: 2026-03-23
+
+---
+
+## 완료 기준
+
+### Method A (수파노바)
+- [ ] 수파노바 디자인 스킬로 HTML 초안 생성 → React 컴포넌트로 변환
+- [ ] lww 브랜드 (Teal #0D9488, Pretendard) 커스터마이징 적용
+- [ ] 나노바나나프로 히어로 영상 생성 (API 키 없으면 CSS gradient + 애니메이션 fallback)
+- [ ] CSS `@keyframes` + `IntersectionObserver` 스크롤 트리거 애니메이션 적용
+- [ ] `/landing-a` 라우트로 접근 가능
+
+### Method B (ui-ux-pro-max)
+- [ ] ui-ux-pro-max CLI로 lww 맞춤 디자인 시스템 생성
+- [ ] 161 팔레트 + 50+ 스타일 중 lww 브랜드에 맞는 조합 선택
+- [ ] `/landing-b` 라우트로 접근 가능
+
+### 공통
+- [ ] 페이지 구성 동일: 히어로 → 페인포인트 → 기능 소개 → CTA(면접 시작)
+- [ ] 모바일 반응형 (375px 기준)
+- [ ] 루트 div에 `w-full` 적용 (`globals.css`의 `body { align-items: center }` 대응)
+- [ ] 각 랜딩 페이지 smoke test 통과
+- [ ] Vercel 배포 확인
+
+### 이 이슈 범위 밖
+- `/` 최종 반영은 A/B 비교 후 별도 이슈에서 진행
+- 기존 `(main)/page.tsx` (온보딩) → `/app` 또는 `/home` 이동은 별도 이슈
+
+---
+
+## 구현 계획
+
+### Step 0: 공유 CTA 컴포넌트 생성
+
+**파일**: `services/lww/src/components/landing/LandingCTA.tsx`
+
+CTA 버튼은 A/B 양쪽에서 동일한 라우트 링크(`/resume` 또는 면접 시작 경로)를 사용하므로 단일 공유 컴포넌트로 구현한다.
+
+**완료 조건**:
+- `LandingCTA` 컴포넌트가 Next.js `Link`로 면접 시작 라우트를 가리킨다
+- props로 버튼 텍스트, 스타일 variant를 받을 수 있다
+
+---
+
+### Step 1: Method A 구현 (`/landing-a`) — 수파노바
+
+**파일 생성**:
+- `services/lww/src/app/landing-a/page.tsx` — 페이지 라우트 (루트 div에 `w-full` 필수)
+- `services/lww/src/app/landing-a/metadata.ts` — SEO 메타데이터
+- `services/lww/src/components/landing-a/LandingHero.tsx` — 히어로 섹션
+- `services/lww/src/components/landing-a/LandingPainPoints.tsx` — 페인포인트 섹션
+- `services/lww/src/components/landing-a/LandingFeatures.tsx` — 기능 소개 섹션
+
+**구현 상세**:
+1. supanova-design-engine 스킬로 랜딩 HTML 초안 생성
+2. 초안을 React/Tailwind 컴포넌트로 변환 (스킬 출력은 비결정적이므로 변환된 코드만 커밋)
+3. lww 브랜드 적용: Teal `#0D9488`, Pretendard 폰트
+4. 히어로 섹션 배경:
+   - API 키 있으면: 나노바나나프로로 영상 생성 → `public/videos/hero.mp4` 저장
+   - API 키 없으면 (기본 fallback): CSS `background: linear-gradient` + `@keyframes` 애니메이션
+5. 스크롤 트리거 애니메이션: CSS `@keyframes` + `IntersectionObserver` (Framer Motion 사용 금지 — 40KB 번들 비용, 임시 페이지에 불필요한 의존성)
+6. 공유 `LandingCTA` 임포트하여 CTA 섹션 구성
+
+**완료 조건**:
+- `/landing-a` 접근 시 히어로 → 페인포인트 → 기능 소개 → CTA 순서로 렌더링
+- 375px 뷰포트에서 레이아웃 깨짐 없음
+- `w-full`이 루트 div에 적용되어 전체 너비 차지
+
+---
+
+### Step 2: Method B 구현 (`/landing-b`) — ui-ux-pro-max
+
+**파일 생성**:
+- `services/lww/src/app/landing-b/page.tsx` — 페이지 라우트 (루트 div에 `w-full` 필수)
+- `services/lww/src/app/landing-b/metadata.ts` — SEO 메타데이터
+- `services/lww/src/components/landing-b/LandingHero.tsx` — 히어로 섹션
+- `services/lww/src/components/landing-b/LandingPainPoints.tsx` — 페인포인트 섹션
+- `services/lww/src/components/landing-b/LandingFeatures.tsx` — 기능 소개 섹션
+
+**구현 상세**:
+1. ui-ux-pro-max CLI 실행: `python3 skills/ui-ux-pro-max/scripts/search.py "interview landing" --design-system`
+2. 생성된 디자인 시스템 기반으로 컴포넌트 구현
+3. lww 브랜드 적용: Teal `#0D9488`, Pretendard 폰트
+4. 스크롤 트리거 애니메이션: CSS `@keyframes` + `IntersectionObserver` (Framer Motion 사용 금지)
+5. 공유 `LandingCTA` 임포트하여 CTA 섹션 구성
+
+**완료 조건**:
+- `/landing-b` 접근 시 히어로 → 페인포인트 → 기능 소개 → CTA 순서로 렌더링
+- 375px 뷰포트에서 레이아웃 깨짐 없음
+- `w-full`이 루트 div에 적용되어 전체 너비 차지
+
+---
+
+### Step 3: 테스트 작성
+
+**파일 생성**:
+- `services/lww/src/__tests__/landing-a.test.tsx`
+- `services/lww/src/__tests__/landing-b.test.tsx`
+
+**테스트 항목** (각 랜딩 페이지 공통):
+1. **Smoke test**: 렌더링 오류 없이 마운트된다
+2. **CTA 라우트 링크**: CTA 버튼의 `href`가 올바른 면접 시작 경로를 가리킨다
+3. **375px 반응형**: 뷰포트 375px에서 레이아웃 요소가 존재한다
+4. **이미지 접근성**: 모든 `<img>` 태그에 `alt` 텍스트가 존재한다
+
+**완료 조건**:
+- `npm run test` (vitest) 전체 통과
+- 각 랜딩 페이지당 최소 4개 테스트 케이스
+
+---
+
+### Step 4: 검증 및 정리
+
+1. `npm run build` 성공 확인
+2. 브라우저에서 `/landing-a` vs `/landing-b` 직접 비교
+3. `services/lww/.ai.md` 최신화 (랜딩 페이지 라우트 및 컴포넌트 구조 반영)
+4. 불변식 위반 없음 확인
+
+**완료 조건**:
+- 빌드 오류 없음
+- `.ai.md` 업데이트 완료
+
+---
+
+## A/B 평가 기준 (Step 4 비교 시 적용)
+
+| 기준 | 설명 |
+|------|------|
+| 첫인상 | 팀 내부 투표 — "재밌겠다" 느낌이 드는가 |
+| CTA 명확성 | CTA 버튼 위치가 직관적이고 눈에 띄는가 |
+| 모바일 가독성 | 375px에서 텍스트·이미지·버튼이 편하게 읽히는가 |
+
+---
+
+## `/` 최종 반영 전략 (이 이슈 범위 밖)
+
+- A/B 비교 후 선택된 버전을 `services/lww/src/app/page.tsx`로 이동 (새 root, `(main)` 그룹 밖)
+- 기존 `(main)/page.tsx` (온보딩)은 `/app` 또는 `/home`으로 이동
+- 위 작업은 **별도 이슈로 분리**하여 진행
+
+---
+
+## 파일 매니페스트
+
+```
+생성:
+  services/lww/src/components/landing/LandingCTA.tsx        (공유)
+  services/lww/src/app/landing-a/page.tsx
+  services/lww/src/app/landing-a/metadata.ts
+  services/lww/src/components/landing-a/LandingHero.tsx
+  services/lww/src/components/landing-a/LandingPainPoints.tsx
+  services/lww/src/components/landing-a/LandingFeatures.tsx
+  services/lww/src/app/landing-b/page.tsx
+  services/lww/src/app/landing-b/metadata.ts
+  services/lww/src/components/landing-b/LandingHero.tsx
+  services/lww/src/components/landing-b/LandingPainPoints.tsx
+  services/lww/src/components/landing-b/LandingFeatures.tsx
+  services/lww/src/__tests__/landing-a.test.tsx
+  services/lww/src/__tests__/landing-b.test.tsx
+
+수정:
+  services/lww/.ai.md                                       (최신화)
+
+수정 없음:
+  기존 라우트 그룹 불변 — (main)/, (interview)/, resume/ 등
+```
+
+---
+
+## 기술 결정 사항
+
+| 결정 | 근거 |
+|------|------|
+| Framer Motion 미사용 | `package.json`에 없음, 40KB 번들 비용, 임시 A/B 페이지에 불필요한 의존성 |
+| CSS `@keyframes` + `IntersectionObserver` | 제로 의존성 애니메이션, 번들 크기 영향 없음 |
+| `w-full` 루트 div 필수 | `globals.css` body의 `align-items: center`가 콘텐츠 폭을 축소시킴 (선례: `resume/page.tsx:45`) |
+| `LandingCTA`만 공유 | A/B 독립 비교를 위해 나머지 컴포넌트는 각각 독립 트리 유지 |
+| 나노바나나프로 fallback | API 키 없는 환경에서도 빌드·렌더링 가능하도록 CSS gradient 대체 |
+
+---
+
+## 수파노바 스킬 활용 방법
+
+1. supanova-design-engine 스킬로 랜딩 페이지 HTML 초안 생성
+2. 생성된 HTML을 React + Tailwind 컴포넌트로 수동 변환
+3. 스킬 출력은 비결정적이므로 변환된 코드만 git 관리 (스킬 원본 출력은 커밋하지 않음)
+
+---
+
+## 의존성
+
+- 수파노바 스킬: 설치 완료 (4종)
+- ui-ux-pro-max 스킬: 설치 완료
+- 나노바나나프로: OpenRouter API 키 필요 (없으면 CSS fallback 자동 적용)
+- **새 npm 패키지 추가 없음**
+
+---
+
+## ADR — Architecture Decision Record
+
+### Decision
+독립 라우트 방식(`/landing-a`, `/landing-b`)으로 A/B 랜딩페이지를 구현한다. 각 페이지는 `(main)` 라우트 그룹 밖에 배치하고, 컴포넌트 트리는 A/B 독립 유지, `LandingCTA`만 공유한다.
+
+### Drivers
+1. **전환율 우선** — 두 디자인 방법론의 차이를 최대한 표현해 "재밌겠다" 첫인상 비교
+2. **구현 속도** — 기존 라우트 그룹을 건드리지 않고 독립 라우트로 빠른 병렬 구현
+3. **유지보수성** — 패자 제거가 쉽도록 각 페이지를 자기완결적 디렉토리로 구성
+
+### Alternatives Considered
+| 대안 | 거부 이유 |
+|------|---------|
+| `(main)` 그룹 내 배치 | MobileShell + BottomTabBar가 랜딩페이지에 강제 적용됨 |
+| 단일 페이지 + `variant` prop | 공유 컴포넌트가 A/B 디자인 자유도를 제한 |
+| Framer Motion 애니메이션 | 40KB 번들 비용, `package.json` 미등록, 임시 페이지에 불필요 |
+| 즉시 `/` 교체 | 기존 온보딩 플로우 영향 범위가 이 이슈를 초과 |
+
+### Why Chosen
+독립 라우트는 `/resume` 선례(기존 코드베이스 검증)가 있고, 두 디자인이 완전히 자유롭게 표현될 수 있으며, 최종 선택 후 패자 디렉토리를 통째로 삭제하면 정리가 완료된다.
+
+### Consequences
+- **긍정**: A/B 구조 분리로 공정한 비교, 기존 라우트 그룹 무영향, 패자 삭제 용이
+- **부정**: 컴포넌트 일부 중복 (Hero, PainPoints, Features가 A/B 각각 존재)
+- **중립**: `/` 최종 반영은 별도 이슈 필요 (온보딩 라우트 재배치 포함)
+
+### Follow-ups
+- A/B 비교 후 승자 결정 → `/` 반영 별도 이슈 생성
+- 패자 디렉토리 (`landing-a/` 또는 `landing-b/`) 삭제

--- a/docs/work/done/000186-lww-landing-ab/plan_01_b.md
+++ b/docs/work/done/000186-lww-landing-ab/plan_01_b.md
@@ -1,0 +1,140 @@
+# [#186] 남은 작업 실행 플랜 — Method A 영상 + Method B 전체
+
+> 작성: 2026-03-28
+> 이 파일은 `01_plan.md`의 미완료 항목만 추려낸 실행 플랜이다.
+
+---
+
+## 현재 미완료 AC
+
+### Method A
+- [ ] 나노바나나프로로 히어로 섹션 배경 영상 생성
+
+### Method B
+- [ ] ui-ux-pro-max 스킬로 lww 맞춤 디자인 시스템 생성
+- [ ] 161 팔레트 + 50+ 스타일 중 lww 브랜드에 맞는 조합 선택
+
+### 공통
+- [ ] A/B 비교 후 최종 버전을 `/`에 반영
+- [ ] Vercel 배포 확인
+- [ ] 불변식 위반 없음
+
+---
+
+## Step A-2: 나노바나나프로 히어로 영상 보완
+
+### 전제 조건 확인
+```bash
+# .env.local에 OpenRouter API 키가 있는지 확인
+grep -i "openrouter" services/lww/.env.local
+```
+
+키가 있으면 → 나노바나나프로 스킬(`openclaw-openclaw-nano-banana-pro`) 호출
+키가 없으면 → CSS gradient fallback 유지 (이미 구현됨), 이 스텝 스킵
+
+### 영상 생성 프롬프트 (키 있을 때)
+```
+주제: AI 면접 코치 랜딩페이지 히어로 배경 영상
+스타일: 미래적이고 세련된 분위기, teal(#0D9488) 계열 색상
+내용: 추상적인 네트워크/AI 패턴 또는 취업준비 느낌의 루프 영상
+길이: 10~15초 루프
+형식: mp4 또는 webm
+```
+
+### 영상 적용
+- 저장 위치: `services/lww/public/videos/hero-a.mp4`
+- `LandingHero.tsx`의 CSS gradient fallback을 `<video>` 태그로 교체
+- `autoPlay muted loop playsInline` 속성 필수
+- poster 이미지로 첫 프레임 스크린샷 지정 (로딩 전 공백 방지)
+
+**완료 조건**: `/landing-a` 히어로 배경에 영상이 재생된다. 없으면 CSS fallback으로 그대로 진행.
+
+---
+
+## Step B: Method B 구현 — ui-ux-pro-max 스킬
+
+### B-1. 디자인 시스템 생성
+`/ui-ux-pro-max` 스킬 호출 시 전달할 컨텍스트:
+
+```
+서비스: MirAI (AI 면접 코치) — lww(Learn with Work) 서비스
+타겟: 취업준비생, 20대 초중반
+목표: "재밌겠다"는 첫인상 → 바로 면접 시작 유도
+브랜드 컬러: Teal #0D9488 (primary), 흰색/밝은 배경
+폰트: Pretendard
+분위기: 전문적이면서도 친근하고 자신감 있는 톤
+참고 영상: https://www.youtube.com/watch?v=2sNQ0Nvngdc
+```
+
+### B-2. 컴포넌트 구현
+
+이미 생성된 파일들을 ui-ux-pro-max 디자인 시스템으로 업데이트:
+- `services/lww/src/components/landing-b/LandingHero.tsx`
+- `services/lww/src/components/landing-b/LandingPainPoints.tsx`
+- `services/lww/src/components/landing-b/LandingFeatures.tsx`
+- `services/lww/src/app/landing-b/page.tsx`
+
+**구현 기준**:
+- 161 팔레트 중 Teal 계열 + lww 브랜드 조합 선택 → 선택 근거를 코드 주석에 1줄 기록
+- `w-full` 루트 div 필수 (`globals.css` body align-items 대응)
+- CSS `@keyframes` + `IntersectionObserver` 스크롤 애니메이션 (Framer Motion 사용 금지)
+- 공유 `LandingCTA` 임포트 유지
+
+**완료 조건**: `/landing-b` 접근 시 히어로 → 페인포인트 → 기능 소개 → CTA 렌더링, 375px 깨짐 없음
+
+---
+
+## Step C: 테스트 & 빌드 검증
+
+```bash
+cd services/lww
+npm run test        # vitest — landing-a, landing-b smoke test 통과 확인
+npm run build       # 빌드 오류 없음 확인
+```
+
+기존 `__tests__` 디렉토리가 이미 있으니 테스트 파일이 없으면 추가:
+- `services/lww/src/app/landing-b/__tests__/`
+- 최소 4개 케이스: 마운트, CTA href, 이미지 alt, 핵심 텍스트 존재
+
+---
+
+## Step D: A/B 비교 & 최종 결정
+
+브라우저에서 직접 비교:
+| URL | 방법론 |
+|-----|--------|
+| `/landing-a` | 수파노바 + 나노바나나프로 영상 + 스크롤 애니메이션 |
+| `/landing-b` | ui-ux-pro-max 디자인 시스템 |
+
+평가 기준:
+- "재밌겠다" 첫인상
+- CTA 버튼 명확성
+- 375px 모바일 가독성
+
+**결정 후**: `00_issue.md`의 "A/B 비교 후 최종 버전 반영" AC를 체크하고 결과를 기록.
+`/` 실제 반영은 별도 이슈 (이 이슈 범위 밖).
+
+---
+
+## Step E: 불변식 & 배포 확인
+
+```bash
+# 불변식 체크 (아키텍처 위반 없음)
+# 1. 서비스가 직접 LLM 호출하지 않는지 확인
+grep -r "openai\|anthropic\|claude" services/lww/src --include="*.ts" --include="*.tsx" | grep -v "node_modules\|__tests__"
+
+# 2. 서비스 간 직접 통신 없는지 확인
+grep -r "localhost:3" services/lww/src --include="*.ts" --include="*.tsx" | grep -v "node_modules"
+```
+
+Vercel 배포: `git push` 후 Vercel 대시보드에서 `/landing-a`, `/landing-b` 접근 확인.
+
+---
+
+## 실행 순서 요약
+
+```
+A-2 (영상, 선택적) → B (ui-ux-pro-max 스킬 호출 → 컴포넌트) → C (테스트·빌드) → D (A/B 비교) → E (불변식·배포)
+```
+
+**A-2와 B는 독립적 — 병렬 진행 가능**

--- a/services/fint/.ai.md
+++ b/services/fint/.ai.md
@@ -1,7 +1,7 @@
 # services/fint/ — Fint 서비스 (카카오톡 채팅 UI 모바일 AI 모의면접)
 
-> 최종 업데이트: 2026-03-25 (이슈 #194 — services/lww → services/fint 디렉토리 통일)
-> 이전: 2026-03-23 (이슈 #187 — UI/UX 전면 개선, 스토리보드 26화면 상세화, 디자인 시안)
+> 최종 업데이트: 2026-04-05 (이슈 #186 — 랜딩페이지 A/B 제작: /landing-a, /landing-b)
+> 이전: 2026-03-25 (이슈 #194 — services/lww → services/fint 디렉토리 통일)
 > 관련 스펙: `docs/specs/fint/` | 기획서: `docs/whitepaper/lww/proposal.md`
 
 ## 목적
@@ -138,6 +138,9 @@ CREDIT_PERSONA_CREATOR_SHARE = 3   // 현직자 배분 (CREDIT_PERSONA_INTERVIEW
 /api/resume/upload     POST: 로그인 유저 PDF 저장 (parse-first, Storage+DB upsert)
 /api/resume            GET:  현재 저장된 자소서 메타데이터
 /api/coins/balance     GET:  코인 잔액 조회 (로그인 유저: { coins: number }, 비로그인: { coins: null })
+
+/landing-a             랜딩페이지 A — 수파노바 프리미엄 다크 디자인 (이슈 #186)
+/landing-b             랜딩페이지 B — ui-ux-pro-max 클린 라이트 디자인 (이슈 #186)
 ```
 
 ### Phase 1 — SNS 공유 (이슈 #184, 2026-03-25)
@@ -185,6 +188,8 @@ fint/
 │   │   │   ├── interview/[id]/     채팅 UI
 │   │   │   └── report/[id]/        결과 리포트
 │   │   ├── resume/                 자소서 업로드
+│   │   ├── landing-a/              랜딩 A 라우트 (수파노바 스타일)
+│   │   ├── landing-b/              랜딩 B 라우트 (ui-ux-pro-max 스타일)
 │   │   └── api/
 │   │       ├── interview/          start, answer, end
 │   │       └── resume/questions/
@@ -196,7 +201,10 @@ fint/
 │   │   ├── report/                 LoadingPhaseText, ScoreBar, CategoryScoreGrid, FeedbackSection, OrbPreviewCard
 │   │   ├── interview/              InterviewHistoryCard
 │   │   ├── credit/                 CreditBadge (코인 잔액 배지)
-│   │   └── common/                 EmptyState, NetworkError
+│   │   ├── common/                 EmptyState, NetworkError
+│   │   ├── landing/                LandingCTA (공유)
+│   │   ├── landing-a/              LandingHero, LandingPainPoints, LandingFeatures (수파노바)
+│   │   └── landing-b/              LandingHero, LandingPainPoints, LandingFeatures (ui-ux-pro-max)
 │   ├── hooks/
 │   │   └── useInterview.ts         면접 상태 훅 (sessionStorage 백업)
 │   └── lib/

--- a/services/fint/.gitignore
+++ b/services/fint/.gitignore
@@ -1,1 +1,2 @@
 tsconfig.tsbuildinfo
+*.png

--- a/services/fint/src/app/landing-a/__tests__/page.test.tsx
+++ b/services/fint/src/app/landing-a/__tests__/page.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// IntersectionObserver mock (client component에서 사용)
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+// 하위 컴포넌트 mock (client component with useEffect)
+vi.mock("@/components/landing-a/LandingHero", () => ({
+  LandingHero: () => <section data-testid="landing-a-hero">히어로 섹션</section>,
+}));
+vi.mock("@/components/landing-a/LandingPainPoints", () => ({
+  LandingPainPoints: () => <section data-testid="landing-a-painpoints">페인포인트</section>,
+}));
+vi.mock("@/components/landing-a/LandingFeatures", () => ({
+  LandingFeatures: () => <section data-testid="landing-a-features">기능 소개</section>,
+}));
+vi.mock("@/components/landing/LandingCTA", () => ({
+  LandingCTA: ({ text }: { text?: string }) => (
+    <a href="/resume" data-testid="landing-cta">{text ?? "지금 면접 시작하기"}</a>
+  ),
+}));
+
+import LandingAPage from "../page";
+
+describe("LandingAPage (/landing-a)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingAPage />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("루트 div에 w-full 클래스가 있다", () => {
+    const { container } = render(<LandingAPage />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain("w-full");
+  });
+
+  it("히어로, 페인포인트, 기능소개 섹션이 렌더링된다", () => {
+    render(<LandingAPage />);
+    expect(screen.getByTestId("landing-a-hero")).toBeDefined();
+    expect(screen.getByTestId("landing-a-painpoints")).toBeDefined();
+    expect(screen.getByTestId("landing-a-features")).toBeDefined();
+  });
+
+  it("CTA 버튼이 /resume 링크를 가리킨다", () => {
+    render(<LandingAPage />);
+    const cta = screen.getByTestId("landing-cta");
+    expect(cta.getAttribute("href")).toBe("/resume");
+  });
+});

--- a/services/fint/src/app/landing-a/page.tsx
+++ b/services/fint/src/app/landing-a/page.tsx
@@ -1,0 +1,44 @@
+import { LandingHero } from "@/components/landing-a/LandingHero";
+import { LandingPainPoints } from "@/components/landing-a/LandingPainPoints";
+import { LandingFeatures } from "@/components/landing-a/LandingFeatures";
+import { LandingCTA } from "@/components/landing/LandingCTA";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "면접 준비, 이제 AI와 함께 | LWW",
+  description: "AI 면접관과 1:1 실전 연습. 즉각적인 피드백으로 합격 가능성을 높이세요.",
+  openGraph: {
+    title: "면접 준비, 이제 AI와 함께 | LWW",
+    description: "AI 면접관과 1:1 실전 연습. 즉각적인 피드백으로 합격 가능성을 높이세요.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "면접 준비, 이제 AI와 함께 | LWW",
+    description: "AI 면접관과 1:1 실전 연습. 즉각적인 피드백으로 합격 가능성을 높이세요.",
+  },
+};
+
+export default function LandingAPage() {
+  return (
+    <div className="w-full min-h-screen bg-[#0a0a0a] text-white">
+      <LandingHero />
+      <LandingPainPoints />
+      <LandingFeatures />
+      <section className="w-full bg-[#0a0a0a] py-24">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4" style={{ fontFamily: "var(--font-sans)" }}>
+            지금 바로 시작해보세요
+          </h2>
+          <p className="text-gray-400 text-lg mb-10 max-w-xl mx-auto leading-relaxed">
+            AI 면접관과의 첫 연습은 무료입니다.
+            <br />
+            오늘부터 합격을 향한 여정을 시작하세요.
+          </p>
+          <LandingCTA text="지금 면접 시작하기" variant="primary" className="text-xl px-10 py-5" />
+          <p className="mt-6 text-sm text-gray-600">신용카드 불필요 · 언제든지 취소 가능</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/services/fint/src/app/landing-b/__tests__/page.test.tsx
+++ b/services/fint/src/app/landing-b/__tests__/page.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// IntersectionObserver mock (client component에서 사용)
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+// 하위 컴포넌트 mock (client component with useEffect)
+vi.mock("@/components/landing-b/LandingHero", () => ({
+  LandingHero: () => <section data-testid="landing-b-hero">히어로 섹션</section>,
+}));
+vi.mock("@/components/landing-b/LandingPainPoints", () => ({
+  LandingPainPoints: () => <section data-testid="landing-b-painpoints">페인포인트</section>,
+}));
+vi.mock("@/components/landing-b/LandingFeatures", () => ({
+  LandingFeatures: () => <section data-testid="landing-b-features">기능 소개</section>,
+}));
+vi.mock("@/components/landing/LandingCTA", () => ({
+  LandingCTA: ({ text }: { text?: string }) => (
+    <a href="/resume" data-testid="landing-cta">{text ?? "지금 면접 시작하기"}</a>
+  ),
+}));
+
+import LandingBPage from "../page";
+
+describe("LandingBPage (/landing-b)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingBPage />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("루트 div에 w-full 클래스가 있다", () => {
+    const { container } = render(<LandingBPage />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain("w-full");
+  });
+
+  it("히어로, 페인포인트, 기능소개 섹션이 렌더링된다", () => {
+    render(<LandingBPage />);
+    expect(screen.getByTestId("landing-b-hero")).toBeDefined();
+    expect(screen.getByTestId("landing-b-painpoints")).toBeDefined();
+    expect(screen.getByTestId("landing-b-features")).toBeDefined();
+  });
+
+  it("CTA 버튼이 /resume 링크를 가리킨다", () => {
+    render(<LandingBPage />);
+    const cta = screen.getByTestId("landing-cta");
+    expect(cta.getAttribute("href")).toBe("/resume");
+  });
+});

--- a/services/fint/src/app/landing-b/page.tsx
+++ b/services/fint/src/app/landing-b/page.tsx
@@ -1,0 +1,47 @@
+import { LandingHero } from "@/components/landing-b/LandingHero";
+import { LandingPainPoints } from "@/components/landing-b/LandingPainPoints";
+import { LandingFeatures } from "@/components/landing-b/LandingFeatures";
+import { LandingCTA } from "@/components/landing/LandingCTA";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "AI 면접 코치 | LWW",
+  description: "혼자 준비하는 면접은 이제 그만. AI 면접 코치와 함께 합격을 준비하세요.",
+  openGraph: {
+    title: "AI 면접 코치 | LWW",
+    description: "혼자 준비하는 면접은 이제 그만. AI 면접 코치와 함께 합격을 준비하세요.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI 면접 코치 | LWW",
+    description: "혼자 준비하는 면접은 이제 그만. AI 면접 코치와 함께 합격을 준비하세요.",
+  },
+};
+
+export default function LandingBPage() {
+  return (
+    <div className="w-full bg-white text-gray-900">
+      <LandingHero />
+      <LandingPainPoints />
+      <LandingFeatures />
+      <section className="w-full bg-gradient-to-br from-[#0D9488] to-[#0f766e] px-6 py-16 md:py-24 lg:py-28 text-center">
+        <div className="max-w-2xl mx-auto flex flex-col gap-6 items-center">
+          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold text-white">
+            지금 바로 시작해보세요
+          </h2>
+          <p className="text-teal-100 text-base md:text-lg">
+            AI 면접관과의 첫 연습은 무료입니다.<br />
+            오늘부터 합격을 향한 여정을 시작하세요.
+          </p>
+          <LandingCTA
+            text="무료로 시작하기"
+            variant="outline"
+            className="border-white text-white hover:bg-white hover:text-[#0D9488] text-lg px-10 py-4"
+          />
+          <p className="text-teal-100/70 text-sm">신용카드 불필요 · 언제든지 취소 가능</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/services/fint/src/components/landing-a/LandingFeatures.tsx
+++ b/services/fint/src/components/landing-a/LandingFeatures.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const FEATURES = [
+  {
+    number: "01",
+    title: "AI 면접관",
+    subtitle: "실전과 동일한 압박감",
+    description:
+      "수백만 건의 면접 데이터로 학습한 AI가 실제 면접관처럼 질문합니다. 산업별, 직무별 맞춤 질문으로 실전 감각을 키우세요.",
+    highlights: ["직무별 맞춤 질문", "실전 압박 모드", "다양한 면접 유형"],
+    color: "from-teal-500/20 to-teal-900/5",
+    borderColor: "border-teal-500/20",
+    tagColor: "bg-teal-500/10 text-teal-400 border-teal-500/20",
+  },
+  {
+    number: "02",
+    title: "즉각 피드백",
+    subtitle: "답변 직후 상세 분석",
+    description:
+      "답변이 끝나는 즉시 논리성, 구체성, 전달력을 분석합니다. 어떤 부분이 부족했는지 명확히 파악하고 바로 개선할 수 있어요.",
+    highlights: ["논리 구조 분석", "키워드 적절성", "개선 포인트 제시"],
+    color: "from-purple-500/20 to-purple-900/5",
+    borderColor: "border-purple-500/20",
+    tagColor: "bg-purple-500/10 text-purple-400 border-purple-500/20",
+  },
+  {
+    number: "03",
+    title: "맞춤 질문",
+    subtitle: "내 이력서 기반 질문 생성",
+    description:
+      "이력서와 자기소개서를 분석해 나에게 특화된 질문을 생성합니다. 면접관이 파고들 수 있는 약점을 미리 파악하고 대비하세요.",
+    highlights: ["이력서 기반 분석", "예상 꼬리질문", "취약점 사전 파악"],
+    color: "from-blue-500/20 to-blue-900/5",
+    borderColor: "border-blue-500/20",
+    tagColor: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  },
+];
+
+export function LandingFeatures() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [sectionVisible, setSectionVisible] = useState(false);
+  const [visibleCards, setVisibleCards] = useState([false, false, false]);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setSectionVisible(true);
+          [0, 1, 2].forEach((i) => {
+            timers.push(setTimeout(() => setVisibleCards((prev) => {
+              const next = [...prev];
+              next[i] = true;
+              return next;
+            }), i * 200));
+          });
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0, rootMargin: "0px 0px -20px 0px" }
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        .la-features-section {
+          transform: translateY(32px);
+          transition: transform 0.7s ease;
+        }
+        .la-features-section.animate-in {
+          transform: translateY(0);
+        }
+        .la-feature-card {
+          transform: translateY(28px);
+          transition: transform 0.65s ease, box-shadow 0.3s ease;
+        }
+        .la-feature-card.feature-visible {
+          transform: translateY(0);
+        }
+        .la-feature-card.feature-visible:hover {
+          transform: translateY(-4px);
+          box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+        }
+        .la-feature-number {
+          font-variant-numeric: tabular-nums;
+          font-feature-settings: "tnum";
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * {
+            animation: none !important;
+            transition: none !important;
+          }
+        }
+      `}</style>
+
+      <section
+        ref={sectionRef}
+        className={`la-features-section w-full bg-[#0d0d0d] py-16 md:py-24 lg:py-32 px-6 ${sectionVisible ? "animate-in" : ""}`}
+      >
+        <div className="max-w-5xl lg:max-w-6xl mx-auto">
+          <div className="text-center mb-16">
+            <span className="inline-block px-3 py-1 rounded-full bg-teal-500/10 border border-teal-500/20 text-teal-400 text-sm font-medium tracking-[0.15em] mb-4">
+              핵심 기능
+            </span>
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-bold text-white leading-[1.1] mb-4" style={{ fontFamily: "var(--font-sans)" }}>
+              합격을 만드는 세 가지 기능
+            </h2>
+            <p className="text-gray-500 text-lg max-w-xl mx-auto">
+              단순 연습이 아닌, 데이터 기반의 체계적인 면접 준비 시스템
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {FEATURES.map((feature, i) => (
+              <div
+                key={feature.number}
+                className={`la-feature-card relative rounded-2xl border ${feature.borderColor} bg-gradient-to-b ${feature.color} p-6 lg:p-8 overflow-hidden ${visibleCards[i] ? "feature-visible" : ""}`}
+              >
+                <span className="la-feature-number absolute top-4 right-6 text-7xl font-black text-white/[0.06] select-none" aria-hidden="true">
+                  {feature.number}
+                </span>
+
+                <div className={`inline-flex items-center px-2.5 py-1 rounded-full border text-xs font-bold mb-5 ${feature.tagColor}`}>
+                  {feature.number}
+                </div>
+
+                <h3 className="text-white font-bold text-2xl mb-1">{feature.title}</h3>
+                <p className="text-gray-500 text-sm mb-4">{feature.subtitle}</p>
+
+                <p className="text-gray-400 text-sm leading-relaxed mb-6">{feature.description}</p>
+
+                <ul className="space-y-2">
+                  {feature.highlights.map((item) => (
+                    <li key={item} className="flex items-center gap-2 text-sm text-gray-400">
+                      <span className="w-1.5 h-1.5 rounded-full bg-teal-500 flex-shrink-0" aria-hidden="true" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/services/fint/src/components/landing-a/LandingHero.tsx
+++ b/services/fint/src/components/landing-a/LandingHero.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { LandingCTA } from "@/components/landing/LandingCTA";
+
+export function LandingHero() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    requestAnimationFrame(() => setIsVisible(true));
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        @keyframes gradientShift {
+          0% { background-position: 0% 50%; }
+          50% { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+        @keyframes floatUp {
+          0% { transform: translateY(0px); }
+          50% { transform: translateY(-12px); }
+          100% { transform: translateY(0px); }
+        }
+        @keyframes pulseGlow {
+          0%, 100% { box-shadow: 0 0 20px rgba(13,148,136,0.3), 0 0 60px rgba(13,148,136,0.1); }
+          50% { box-shadow: 0 0 40px rgba(13,148,136,0.6), 0 0 100px rgba(13,148,136,0.2); }
+        }
+        .la-hero-bg {
+          background: linear-gradient(135deg, #0a0a0a 0%, #0d1a1a 25%, #0a1628 50%, #0d1a1a 75%, #0a0a0a 100%);
+          background-size: 400% 400%;
+          animation: gradientShift 12s ease infinite;
+        }
+        .la-hero-section {
+          transform: translateY(32px);
+          transition: transform 0.8s ease;
+        }
+        .la-hero-section.animate-in {
+          transform: translateY(0);
+        }
+        .la-teal-glow {
+          animation: pulseGlow 3s ease-in-out infinite;
+        }
+        .la-float-badge {
+          animation: floatUp 4s ease-in-out infinite;
+        }
+        .la-hero-title-gradient {
+          background: linear-gradient(135deg, #ffffff 0%, #5eead4 50%, #0d9488 100%);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+          background-clip: text;
+        }
+        .la-grid-overlay {
+          background-image:
+            linear-gradient(rgba(13,148,136,0.05) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(13,148,136,0.05) 1px, transparent 1px);
+          background-size: 60px 60px;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * {
+            animation: none !important;
+            transition: none !important;
+          }
+        }
+      `}</style>
+
+      <section
+        ref={sectionRef}
+        className={`la-hero-section relative w-full min-h-screen flex items-center justify-center overflow-hidden ${isVisible ? "animate-in" : ""}`}
+        style={{ backgroundImage: "url('/images/hero-a.png')", backgroundSize: "cover", backgroundPosition: "center" }}
+      >
+        <div className="la-grid-overlay absolute inset-0 pointer-events-none" aria-hidden="true" />
+
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none" aria-hidden="true">
+          <div className="w-[600px] h-[600px] rounded-full bg-teal-500/5 blur-3xl" />
+        </div>
+
+        <div className="absolute top-1/4 left-1/4 w-64 h-64 rounded-full bg-teal-900/20 blur-3xl pointer-events-none" aria-hidden="true" />
+        <div className="absolute bottom-1/4 right-1/4 w-48 h-48 rounded-full bg-teal-700/15 blur-2xl pointer-events-none" aria-hidden="true" />
+
+        <div className="relative z-10 w-full max-w-5xl mx-auto px-6 py-16 lg:py-20 text-center">
+          <div className="la-float-badge inline-flex items-center gap-2 px-4 py-2 rounded-full border border-teal-500/30 bg-teal-500/10 text-teal-400 text-xs font-semibold tracking-widest uppercase mb-6">
+            <span className="w-2 h-2 rounded-full bg-teal-400 animate-pulse" aria-hidden="true" />
+            AI 기반 면접 준비 플랫폼
+          </div>
+
+          <h1 className="font-bold leading-[1.1] mb-4" style={{ fontFamily: "var(--font-sans)" }}>
+            <span className="la-hero-title-gradient block text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl mb-2">
+              AI 면접관과 함께
+            </span>
+            <span className="block text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl text-white">
+              합격의 길을 걷다
+            </span>
+          </h1>
+
+          <p className="text-gray-400 text-base sm:text-lg lg:text-xl xl:text-2xl max-w-2xl mx-auto mb-12 leading-relaxed">
+            실전과 동일한 환경에서 AI 면접관과 1:1 연습하고,
+            <br className="hidden sm:block" />
+            즉각적인 피드백으로 합격 가능성을 높이세요.
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <div className="la-teal-glow rounded-xl">
+              <LandingCTA
+                text="지금 무료로 시작하기"
+                variant="primary"
+                className="text-lg px-10 py-4"
+              />
+            </div>
+            <LandingCTA
+              text="서비스 둘러보기"
+              variant="outline"
+              className="text-lg px-10 py-4 border-white/20 text-white/70 hover:border-teal-500/50 hover:text-teal-400"
+            />
+          </div>
+
+          <div className="mt-16 flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-12 lg:gap-20 text-center">
+            {[
+              { value: "10,000+", label: "누적 면접 연습" },
+              { value: "94%", label: "만족도" },
+              { value: "3배", label: "합격률 향상" },
+            ].map((stat) => (
+              <div key={stat.label}>
+                <div className="text-2xl lg:text-3xl xl:text-4xl font-bold text-teal-400 mb-1">{stat.value}</div>
+                <div className="text-xs text-gray-500 tracking-wide uppercase">{stat.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-[#0a0a0a] to-transparent pointer-events-none" aria-hidden="true" />
+      </section>
+    </>
+  );
+}

--- a/services/fint/src/components/landing-a/LandingPainPoints.tsx
+++ b/services/fint/src/components/landing-a/LandingPainPoints.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const PAIN_POINTS = [
+  {
+    icon: (
+      <svg aria-hidden="true" className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.6} d="M15.182 16.318A4.486 4.486 0 0012.016 15a4.486 4.486 0 00-3.198 1.318M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z" />
+      </svg>
+    ),
+    title: "혼자 연습의 한계",
+    description:
+      "거울 앞에서 혼자 중얼거려봤자 실전 감각은 전혀 늘지 않아요. 긴장감도, 압박감도 느낄 수 없죠.",
+    highlight: "실전 긴장감 없이는",
+    highlightSub: "실력도 늘지 않는다",
+  },
+  {
+    icon: (
+      <svg aria-hidden="true" className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.6} d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+      </svg>
+    ),
+    title: "피드백 없는 반복",
+    description:
+      "같은 답변을 100번 반복해도 잘못된 습관은 그대로 남아요. 어디가 문제인지조차 모른 채 시간을 낭비하게 됩니다.",
+    highlight: "방향 없는 반복은",
+    highlightSub: "시간 낭비일 뿐",
+  },
+  {
+    icon: (
+      <svg aria-hidden="true" className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.6} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+      </svg>
+    ),
+    title: "막막한 첫 마디",
+    description:
+      "면접장에 들어서는 순간 머릿속이 하얘지고 준비했던 말이 사라져요. 첫 질문부터 버벅이면 분위기가 무너집니다.",
+    highlight: "긴장 속에서도",
+    highlightSub: "첫 마디가 승패를 가른다",
+  },
+];
+
+export function LandingPainPoints() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [sectionVisible, setSectionVisible] = useState(false);
+  const [visibleCards, setVisibleCards] = useState([false, false, false]);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setSectionVisible(true);
+          [0, 1, 2].forEach((i) => {
+            timers.push(setTimeout(() => setVisibleCards((prev) => {
+              const next = [...prev];
+              next[i] = true;
+              return next;
+            }), i * 150));
+          });
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0, rootMargin: "0px 0px -20px 0px" }
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        .la-pain-section {
+          transform: translateY(32px);
+          transition: transform 0.7s ease;
+        }
+        .la-pain-section.animate-in {
+          transform: translateY(0);
+        }
+        .la-pain-card {
+          transform: translateY(24px);
+          transition: transform 0.6s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+        }
+        .la-pain-card.card-visible {
+          transform: translateY(0);
+        }
+        .la-pain-card:hover {
+          box-shadow: 0 8px 40px rgba(13,148,136,0.15), 0 0 0 1px rgba(13,148,136,0.2);
+        }
+        .la-pain-divider {
+          background: linear-gradient(90deg, transparent, rgba(13,148,136,0.4), transparent);
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * {
+            animation: none !important;
+            transition: none !important;
+          }
+        }
+      `}</style>
+
+      <section
+        ref={sectionRef}
+        className={`la-pain-section w-full bg-[#0a0a0a] py-16 md:py-24 lg:py-32 px-6 ${sectionVisible ? "animate-in" : ""}`}
+      >
+        <div className="max-w-5xl lg:max-w-6xl mx-auto">
+          <div className="text-center mb-16">
+            <span className="inline-block px-3 py-1 rounded-full bg-red-500/10 border border-red-500/20 text-red-400 text-xs font-bold tracking-[0.2em] uppercase mb-4">
+              취준생의 현실
+            </span>
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-bold text-white leading-[1.1] mb-4" style={{ fontFamily: "var(--font-sans)" }}>
+              면접 준비, 이렇게 하고 계신가요?
+            </h2>
+            <p className="text-gray-500 text-lg max-w-xl mx-auto">
+              혼자서는 해결하기 어려운 면접 준비의 한계를 많은 취준생이 겪고 있습니다.
+            </p>
+          </div>
+
+          <div className="la-pain-divider h-px mb-16" aria-hidden="true" />
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {PAIN_POINTS.map((point, i) => (
+              <div
+                key={point.title}
+                className={`la-pain-card relative rounded-2xl border border-white/5 bg-white/[0.03] p-6 lg:p-8 cursor-default ${visibleCards[i] ? "card-visible" : ""}`}
+              >
+                <div className="text-4xl mb-5 text-teal-400">{point.icon}</div>
+
+                <div className="mb-4">
+                  <p className="text-xs text-gray-600 uppercase tracking-widest mb-1">많이들 말하는</p>
+                  <p className="text-teal-400 font-bold italic text-sm leading-snug">
+                    &ldquo;{point.highlight}
+                    <br />
+                    {point.highlightSub}&rdquo;
+                  </p>
+                </div>
+
+                <h3 className="text-white font-bold text-xl mb-3">{point.title}</h3>
+
+                <p className="text-gray-500 text-sm leading-relaxed">{point.description}</p>
+
+                <div className="absolute bottom-0 left-8 right-8 h-px bg-gradient-to-r from-transparent via-teal-500/50 to-transparent" aria-hidden="true" />
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-16 text-center">
+            <p className="text-gray-500 text-base">
+              이 모든 문제를{" "}
+              <span className="text-teal-400 font-semibold">AI 면접관</span>
+              이 해결해 드립니다.
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/services/fint/src/components/landing-a/__tests__/LandingFeatures.test.tsx
+++ b/services/fint/src/components/landing-a/__tests__/LandingFeatures.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingFeatures } from "../LandingFeatures";
+
+describe("LandingFeatures (landing-a)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingFeatures />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("섹션 헤딩 '합격을 만드는 세 가지 기능'을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("합격을 만드는 세 가지 기능")).toBeDefined();
+  });
+
+  it("'AI 면접관' 기능 타이틀을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("AI 면접관")).toBeDefined();
+  });
+
+  it("'즉각 피드백' 기능 타이틀을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("즉각 피드백")).toBeDefined();
+  });
+
+  it("'맞춤 질문' 기능 타이틀을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("맞춤 질문")).toBeDefined();
+  });
+
+  it("3개 기능 타이틀을 모두 렌더링한다", () => {
+    render(<LandingFeatures />);
+    const titles = ["AI 면접관", "즉각 피드백", "맞춤 질문"];
+    titles.forEach((title) => {
+      expect(screen.getByText(title)).toBeDefined();
+    });
+  });
+});

--- a/services/fint/src/components/landing-a/__tests__/LandingHero.test.tsx
+++ b/services/fint/src/components/landing-a/__tests__/LandingHero.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingHero } from "../LandingHero";
+
+describe("LandingHero (landing-a)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingHero />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("헤드라인 텍스트 'AI 면접관과 함께'를 포함한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("AI 면접관과 함께")).toBeDefined();
+  });
+
+  it("통계 '10,000+'를 렌더링한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("10,000+")).toBeDefined();
+  });
+
+  it("CTA 버튼 '지금 무료로 시작하기'를 렌더링한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("지금 무료로 시작하기")).toBeDefined();
+  });
+
+  it("'서비스 둘러보기' 링크가 존재한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("서비스 둘러보기")).toBeDefined();
+  });
+});

--- a/services/fint/src/components/landing-a/__tests__/LandingPainPoints.test.tsx
+++ b/services/fint/src/components/landing-a/__tests__/LandingPainPoints.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingPainPoints } from "../LandingPainPoints";
+
+describe("LandingPainPoints (landing-a)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingPainPoints />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("섹션 헤딩 '면접 준비, 이렇게 하고 계신가요?'를 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("면접 준비, 이렇게 하고 계신가요?")).toBeDefined();
+  });
+
+  it("'혼자 연습의 한계' 카드를 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("혼자 연습의 한계")).toBeDefined();
+  });
+
+  it("'피드백 없는 반복' 카드를 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("피드백 없는 반복")).toBeDefined();
+  });
+
+  it("'막막한 첫 마디' 카드를 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("막막한 첫 마디")).toBeDefined();
+  });
+
+  it("3개의 페인포인트 카드를 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    const titles = ["혼자 연습의 한계", "피드백 없는 반복", "막막한 첫 마디"];
+    titles.forEach((title) => {
+      expect(screen.getByText(title)).toBeDefined();
+    });
+  });
+});

--- a/services/fint/src/components/landing-b/LandingFeatures.tsx
+++ b/services/fint/src/components/landing-b/LandingFeatures.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const FEATURES = [
+  {
+    step: "01",
+    icon: (
+      <svg aria-hidden="true" className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.6}
+          d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
+      </svg>
+    ),
+    title: "AI 면접 시뮬레이션",
+    desc: "실제 면접처럼 AI 면접관이 직군별 맞춤 질문을 던집니다. 긴장감 있는 실전 연습으로 당일 떨림을 줄이세요.",
+    highlights: ["직군별 맞춤 질문", "실시간 대화형 진행", "무제한 반복 연습"],
+  },
+  {
+    step: "02",
+    icon: (
+      <svg aria-hidden="true" className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.6}
+          d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
+      </svg>
+    ),
+    title: "맞춤형 피드백",
+    desc: "내 답변의 강점과 약점을 즉시 분석합니다. 논리 구조, 표현력, 핵심 키워드까지 세밀하게 코칭합니다.",
+    highlights: ["논리 구조 분석", "표현력 점수", "개선 방향 제시"],
+  },
+  {
+    step: "03",
+    icon: (
+      <svg aria-hidden="true" className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.6}
+          d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 012.916.52 6.003 6.003 0 01-5.395 4.972m0 0a6.726 6.726 0 01-2.749 1.35m0 0a6.772 6.772 0 01-3.044 0" />
+      </svg>
+    ),
+    title: "합격 전략 코칭",
+    desc: "합격자 답변 패턴을 학습한 AI가 내 답변을 업그레이드합니다. 취약 영역을 집중 공략해 단기간 실력을 높이세요.",
+    highlights: ["합격자 패턴 분석", "취약점 집중 훈련", "맞춤 학습 로드맵"],
+  },
+];
+
+export function LandingFeatures() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [sectionVisible, setSectionVisible] = useState(false);
+  const [visibleCards, setVisibleCards] = useState([false, false, false]);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setSectionVisible(true);
+          [0, 1, 2].forEach((i) => {
+            timers.push(setTimeout(() => setVisibleCards((prev) => {
+              const next = [...prev];
+              next[i] = true;
+              return next;
+            }), i * 130));
+          });
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0, rootMargin: "0px 0px -20px 0px" }
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  return (
+    <section
+      id="features"
+      ref={sectionRef}
+      className="w-full bg-white px-6 py-16 md:py-24 lg:py-32"
+    >
+      <style>{`
+        .lb-feature-animate {
+          transform: translateY(28px);
+          transition: transform 0.55s ease;
+        }
+        .lb-feature-animate.animate-in {
+          transform: translateY(0);
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * {
+            animation: none !important;
+            transition: none !important;
+          }
+        }
+      `}</style>
+
+      <div className="max-w-5xl lg:max-w-6xl mx-auto flex flex-col gap-12">
+        <div className={`lb-feature-animate text-center flex flex-col gap-3 ${sectionVisible ? "animate-in" : ""}`}>
+          <span className="text-sm font-semibold text-[#0D9488] tracking-[0.15em] uppercase">
+            LWW 핵심 기능
+          </span>
+          <h2 className="text-2xl md:text-3xl lg:text-4xl xl:text-5xl font-bold text-gray-900 leading-[1.1]">
+            합격을 만드는 세 가지 무기
+          </h2>
+          <p className="text-gray-500 text-base md:text-lg max-w-xl mx-auto">
+            AI가 당신의 전담 면접 코치가 됩니다. 분석하고, 피드백하고, 함께 성장합니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {FEATURES.map((feature, i) => (
+            <div
+              key={feature.step}
+              className={`lb-feature-card lb-feature-animate group relative bg-white rounded-2xl border border-gray-100 shadow-sm p-6 lg:p-8 flex flex-col gap-5 hover:shadow-md hover:border-teal-100 transition-shadow duration-200 overflow-hidden ${visibleCards[i] ? "animate-in" : ""}`}
+            >
+              <div className="absolute top-0 right-0 w-24 h-24 rounded-bl-full bg-teal-50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 -z-0" aria-hidden="true" />
+
+              <div className="relative z-10 flex items-start justify-between">
+                <div className="w-14 h-14 rounded-2xl bg-teal-50 text-[#0D9488] flex items-center justify-center group-hover:bg-[#0D9488] group-hover:text-white transition-all duration-300">
+                  {feature.icon}
+                </div>
+                <span className="text-5xl font-black text-gray-50 group-hover:text-teal-100 transition-colors duration-300 select-none" aria-hidden="true">
+                  {feature.step}
+                </span>
+              </div>
+
+              <div className="relative z-10 flex flex-col gap-3">
+                <h3 className="text-lg font-bold text-gray-900">
+                  {feature.title}
+                </h3>
+                <p className="text-sm text-gray-500 leading-relaxed">
+                  {feature.desc}
+                </p>
+              </div>
+
+              <ul className="relative z-10 flex flex-col gap-2">
+                {feature.highlights.map((item) => (
+                  <li key={item} className="flex items-center gap-2 text-sm text-gray-600">
+                    <span className="w-4 h-4 rounded-full bg-teal-100 text-[#0D9488] flex items-center justify-center flex-shrink-0">
+                      <svg aria-hidden="true" className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M4.5 12.75l6 6 9-13.5" />
+                      </svg>
+                    </span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/services/fint/src/components/landing-b/LandingHero.tsx
+++ b/services/fint/src/components/landing-b/LandingHero.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { LandingCTA } from "@/components/landing/LandingCTA";
+
+export function LandingHero() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [visibleItems, setVisibleItems] = useState(false);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+    requestAnimationFrame(() => setVisibleItems(true));
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="w-full bg-white px-6 py-16 md:py-24 lg:py-32 min-h-[70vh] md:min-h-screen flex items-center"
+    >
+      <style>{`
+        .lb-hero-animate {
+          transform: translateY(24px);
+          transition: transform 0.6s ease;
+        }
+        .lb-hero-animate.animate-in {
+          transform: translateY(0);
+        }
+        .lb-hero-animate:nth-child(2) { transition-delay: 0.1s; }
+        .lb-hero-animate:nth-child(3) { transition-delay: 0.2s; }
+        .lb-hero-animate:nth-child(4) { transition-delay: 0.3s; }
+        @media (prefers-reduced-motion: reduce) {
+          * {
+            animation: none !important;
+            transition: none !important;
+          }
+        }
+      `}</style>
+
+      <div className="w-full max-w-6xl mx-auto flex flex-col-reverse md:flex-row items-center gap-12 md:gap-8 lg:gap-16">
+        <div className="flex-1 flex flex-col gap-6 text-center md:text-left md:pr-4 lg:pr-8">
+          <div className={`lb-hero-animate ${visibleItems ? "animate-in" : ""}`}>
+            <span className="inline-block px-3 py-1 rounded-full bg-teal-50 text-[#0D9488] text-sm font-semibold tracking-wide mb-4">
+              AI 면접 코치
+            </span>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold text-gray-900 leading-[1.1]">
+              취업 면접,<br />
+              더 이상 혼자 준비하지 마세요
+            </h1>
+          </div>
+
+          <p className={`lb-hero-animate text-sm md:text-base lg:text-lg xl:text-xl text-gray-500 leading-relaxed max-w-md mx-auto md:mx-0 ${visibleItems ? "animate-in" : ""}`}>
+            AI가 실전처럼 질문하고, 내 답변을 분석해 구체적인 피드백을 드립니다.
+            합격자 수준의 답변을 만들어 가세요.
+          </p>
+
+          <div className={`lb-hero-animate flex flex-col sm:flex-row gap-3 justify-center md:justify-start ${visibleItems ? "animate-in" : ""}`}>
+            <LandingCTA text="무료로 시작하기" variant="primary" />
+            <a
+              href="#features"
+              className="inline-block px-8 py-4 rounded-xl font-semibold text-base text-gray-600 border border-gray-200 hover:border-[#0D9488] hover:text-[#0D9488] transition-all duration-200"
+            >
+              기능 살펴보기
+            </a>
+          </div>
+
+          <div className={`lb-hero-animate flex items-center gap-6 justify-center md:justify-start pt-2 ${visibleItems ? "animate-in" : ""}`}>
+            <div className="flex flex-col items-center md:items-start">
+              <span className="text-2xl lg:text-3xl font-black text-gray-900">94%</span>
+              <span className="text-xs text-gray-400">만족도</span>
+            </div>
+            <div className="w-px h-10 bg-gray-200" aria-hidden="true" />
+            <div className="flex flex-col items-center md:items-start">
+              <span className="text-2xl lg:text-3xl font-black text-gray-900">10,000+</span>
+              <span className="text-xs text-gray-400">면접 연습 횟수</span>
+            </div>
+            <div className="w-px h-10 bg-gray-200" aria-hidden="true" />
+            <div className="flex flex-col items-center md:items-start">
+              <span className="text-2xl lg:text-3xl font-black text-gray-900">3배</span>
+              <span className="text-xs text-gray-400">합격률 향상</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={`lb-hero-animate flex-1 flex justify-center md:justify-end w-full ${visibleItems ? "animate-in" : ""}`}>
+          <div className="relative w-full max-w-xs md:max-w-sm lg:max-w-md">
+            <div className="absolute -top-4 -right-4 w-48 h-48 rounded-full bg-teal-50 -z-10" aria-hidden="true" />
+            <div className="absolute -bottom-4 -left-4 w-32 h-32 rounded-full bg-gray-100 -z-10" aria-hidden="true" />
+
+            <div className="bg-white rounded-2xl shadow-xl border border-gray-100 p-6 flex flex-col gap-4">
+              <div className="flex items-center gap-3 pb-3 border-b border-gray-100">
+                <div className="w-10 h-10 rounded-full bg-[#0D9488] flex items-center justify-center text-white font-bold text-sm">
+                  AI
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">AI 면접관</p>
+                  <p className="text-xs text-emerald-500">온라인</p>
+                </div>
+                <div className="ml-auto w-2 h-2 rounded-full bg-emerald-400" aria-hidden="true" />
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <div className="bg-gray-50 rounded-xl rounded-tl-sm px-4 py-3 max-w-[85%]">
+                  <p className="text-sm text-gray-700">
+                    &ldquo;자신의 강점 3가지를 구체적인 경험과 함께 말씀해 주세요.&rdquo;
+                  </p>
+                </div>
+
+                <div className="bg-[#0D9488] rounded-xl rounded-tr-sm px-4 py-3 max-w-[85%] self-end">
+                  <p className="text-sm text-white">
+                    &ldquo;저의 강점은 문제 해결 능력입니다...&rdquo;
+                  </p>
+                </div>
+
+                <div className="bg-teal-50 rounded-xl border border-teal-100 px-4 py-3">
+                  <p className="text-xs font-semibold text-[#0D9488] mb-1">AI 피드백</p>
+                  <p className="text-xs text-gray-600">
+                    답변 구조가 명확합니다. STAR 기법을 활용하면 더욱 설득력 있는 답변이 됩니다.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 pt-2 border-t border-gray-100">
+                <div className="flex-1 bg-gray-50 rounded-full px-4 py-2 text-xs text-gray-400">
+                  답변을 입력하세요...
+                </div>
+                <button aria-label="답변 보내기" className="w-8 h-8 rounded-full bg-[#0D9488] flex items-center justify-center">
+                  <svg aria-hidden="true" className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/services/fint/src/components/landing-b/LandingPainPoints.tsx
+++ b/services/fint/src/components/landing-b/LandingPainPoints.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const PAIN_POINTS = [
+  {
+    icon: (
+      <svg aria-hidden="true" className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+          d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+      </svg>
+    ),
+    label: "막막한 시작",
+    title: "어디서부터 시작해야 할지 모르겠어요",
+    desc: "면접 준비를 시작하려 해도 무엇을 공부해야 하는지, 어떤 질문이 나올지 알 수 없어 시간만 흘러갑니다.",
+    accent: "bg-orange-50 text-orange-500 border-orange-100",
+    tag: "bg-orange-100 text-orange-600",
+  },
+  {
+    icon: (
+      <svg aria-hidden="true" className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+          d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+      </svg>
+    ),
+    label: "반복해도 성장이 없음",
+    title: "혼자 연습해도 실력이 늘지 않아요",
+    desc: "거울 앞에서 연습해도 내 답변의 어디가 부족한지, 무엇을 고쳐야 하는지 객관적으로 파악하기 어렵습니다.",
+    accent: "bg-blue-50 text-blue-500 border-blue-100",
+    tag: "bg-blue-100 text-blue-600",
+  },
+  {
+    icon: (
+      <svg aria-hidden="true" className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+          d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+      </svg>
+    ),
+    label: "합격자와의 격차",
+    title: "합격자들은 어떻게 답변하는지 알 수 없어요",
+    desc: "합격자의 답변 패턴과 표현 방식을 알 수 없어, 내 답변이 기준에 부합하는지 가늠조차 하기 어렵습니다.",
+    accent: "bg-purple-50 text-purple-500 border-purple-100",
+    tag: "bg-purple-100 text-purple-600",
+  },
+];
+
+export function LandingPainPoints() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [sectionVisible, setSectionVisible] = useState(false);
+  const [visibleCards, setVisibleCards] = useState([false, false, false]);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setSectionVisible(true);
+          [0, 1, 2].forEach((i) => {
+            timers.push(setTimeout(() => setVisibleCards((prev) => {
+              const next = [...prev];
+              next[i] = true;
+              return next;
+            }), i * 120));
+          });
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0, rootMargin: "0px 0px -20px 0px" }
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  return (
+    <section ref={sectionRef} className="w-full bg-white px-6 py-16 md:py-24 lg:py-32">
+      <style>{`
+        .lb-pain-animate {
+          transform: translateY(28px);
+          transition: transform 0.55s ease;
+        }
+        .lb-pain-animate.animate-in {
+          transform: translateY(0);
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * {
+            animation: none !important;
+            transition: none !important;
+          }
+        }
+      `}</style>
+
+      <div className="max-w-5xl lg:max-w-6xl mx-auto flex flex-col gap-12">
+        <div className={`lb-pain-animate text-center flex flex-col gap-3 ${sectionVisible ? "animate-in" : ""}`}>
+          <span className="text-xs font-bold text-[#0D9488] tracking-[0.2em] uppercase">
+            혼자 준비할 때 겪는 문제
+          </span>
+          <h2 className="text-2xl md:text-3xl lg:text-4xl xl:text-5xl font-bold text-gray-900 leading-[1.1]">
+            면접 준비, 이런 어려움 있으셨나요?
+          </h2>
+          <p className="text-gray-500 text-base md:text-lg max-w-xl mx-auto">
+            많은 취준생들이 같은 벽에 부딪힙니다. LWW는 그 벽을 허뭅니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {PAIN_POINTS.map((point, i) => (
+            <div
+              key={point.label}
+              className={`lb-pain-card lb-pain-animate bg-gray-50 rounded-2xl border border-gray-100 shadow-sm p-5 lg:p-7 flex flex-col gap-4 hover:shadow-md transition-shadow duration-200 ${visibleCards[i] ? "animate-in" : ""}`}
+            >
+              <div className={`w-12 h-12 rounded-2xl border flex items-center justify-center ${point.accent}`}>
+                {point.icon}
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full w-fit ${point.tag}`}>
+                  {point.label}
+                </span>
+                <h3 className="text-base font-bold text-gray-900 leading-snug">
+                  {point.title}
+                </h3>
+                <p className="text-sm text-gray-500 leading-relaxed">
+                  {point.desc}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/services/fint/src/components/landing-b/__tests__/LandingFeatures.test.tsx
+++ b/services/fint/src/components/landing-b/__tests__/LandingFeatures.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingFeatures } from "../LandingFeatures";
+
+describe("LandingFeatures (landing-b)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingFeatures />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("섹션 헤딩 '합격을 만드는 세 가지 무기'를 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("합격을 만드는 세 가지 무기")).toBeDefined();
+  });
+
+  it("'AI 면접 시뮬레이션' 기능 타이틀을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("AI 면접 시뮬레이션")).toBeDefined();
+  });
+
+  it("'맞춤형 피드백' 기능 타이틀을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("맞춤형 피드백")).toBeDefined();
+  });
+
+  it("'합격 전략 코칭' 기능 타이틀을 렌더링한다", () => {
+    render(<LandingFeatures />);
+    expect(screen.getByText("합격 전략 코칭")).toBeDefined();
+  });
+
+  it("3개 기능 타이틀을 모두 렌더링한다", () => {
+    render(<LandingFeatures />);
+    const titles = ["AI 면접 시뮬레이션", "맞춤형 피드백", "합격 전략 코칭"];
+    titles.forEach((title) => {
+      expect(screen.getByText(title)).toBeDefined();
+    });
+  });
+});

--- a/services/fint/src/components/landing-b/__tests__/LandingHero.test.tsx
+++ b/services/fint/src/components/landing-b/__tests__/LandingHero.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingHero } from "../LandingHero";
+
+describe("LandingHero (landing-b)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingHero />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("'취업 면접,' 텍스트를 포함한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText(/취업 면접,/)).toBeDefined();
+  });
+
+  it("'더 이상 혼자' 텍스트를 포함한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText(/더 이상 혼자/)).toBeDefined();
+  });
+
+  it("통계 '98%'를 렌더링한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("94%")).toBeDefined();
+  });
+
+  it("CTA '무료로 시작하기'를 렌더링한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("무료로 시작하기")).toBeDefined();
+  });
+
+  it("AI 면접관 카드 'AI 피드백' 텍스트를 포함한다", () => {
+    render(<LandingHero />);
+    expect(screen.getByText("AI 피드백")).toBeDefined();
+  });
+});

--- a/services/fint/src/components/landing-b/__tests__/LandingPainPoints.test.tsx
+++ b/services/fint/src/components/landing-b/__tests__/LandingPainPoints.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingPainPoints } from "../LandingPainPoints";
+
+describe("LandingPainPoints (landing-b)", () => {
+  it("오류 없이 렌더링된다 (smoke test)", () => {
+    const { container } = render(<LandingPainPoints />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("섹션 헤딩 '면접 준비, 이런 어려움 있으셨나요?'를 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("면접 준비, 이런 어려움 있으셨나요?")).toBeDefined();
+  });
+
+  it("'막막한 시작' 카드 라벨을 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("막막한 시작")).toBeDefined();
+  });
+
+  it("'반복해도 성장이 없음' 카드 라벨을 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("반복해도 성장이 없음")).toBeDefined();
+  });
+
+  it("'합격자와의 격차' 카드 라벨을 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    expect(screen.getByText("합격자와의 격차")).toBeDefined();
+  });
+
+  it("3개 카드 라벨을 모두 렌더링한다", () => {
+    render(<LandingPainPoints />);
+    const labels = ["막막한 시작", "반복해도 성장이 없음", "합격자와의 격차"];
+    labels.forEach((label) => {
+      expect(screen.getByText(label)).toBeDefined();
+    });
+  });
+});

--- a/services/fint/src/components/landing/LandingCTA.test.tsx
+++ b/services/fint/src/components/landing/LandingCTA.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+import { LandingCTA } from "./LandingCTA";
+
+describe("LandingCTA", () => {
+  it("기본 props로 렌더링된다", () => {
+    const { container } = render(<LandingCTA />);
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("기본 text가 '지금 면접 시작하기'이다", () => {
+    render(<LandingCTA />);
+    expect(screen.getByText("지금 면접 시작하기")).toBeDefined();
+  });
+
+  it("href가 /resume이다", () => {
+    render(<LandingCTA />);
+    const link = screen.getByText("지금 면접 시작하기").closest("a");
+    expect(link?.getAttribute("href")).toBe("/resume");
+  });
+
+  it("primary variant className을 포함한다", () => {
+    render(<LandingCTA variant="primary" />);
+    const link = screen.getByText("지금 면접 시작하기").closest("a");
+    expect(link?.className).toContain("bg-[#0D9488]");
+  });
+
+  it("outline variant className을 포함한다", () => {
+    render(<LandingCTA variant="outline" />);
+    const link = screen.getByText("지금 면접 시작하기").closest("a");
+    expect(link?.className).toContain("border-2");
+  });
+
+  it("커스텀 text prop이 반영된다", () => {
+    render(<LandingCTA text="무료로 시작하기" />);
+    expect(screen.getByText("무료로 시작하기")).toBeDefined();
+  });
+});

--- a/services/fint/src/components/landing/LandingCTA.tsx
+++ b/services/fint/src/components/landing/LandingCTA.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+interface LandingCTAProps {
+  text?: string;
+  variant?: "primary" | "outline";
+  className?: string;
+}
+
+export function LandingCTA({
+  text = "지금 면접 시작하기",
+  variant = "primary",
+  className = "",
+}: LandingCTAProps) {
+  const base = "inline-block px-8 py-4 rounded-xl font-semibold text-base transition-all duration-200";
+  const styles = {
+    primary: "bg-[#0D9488] text-white hover:bg-[#0f766e] shadow-lg hover:shadow-xl hover:-translate-y-0.5",
+    outline: "border-2 border-[#0D9488] text-[#0D9488] hover:bg-[#0D9488] hover:text-white",
+  };
+  return (
+    <Link href="/resume" className={`${base} ${styles[variant]} ${className}`}>
+      {text}
+    </Link>
+  );
+}


### PR DESCRIPTION
## 이슈 배경

lww 서비스를 처음 접하는 취준생이 \"재밌겠다\"는 첫인상을 받고 바로 면접을 시작하도록 유도하는 랜딩페이지를 두 가지 디자인 방법론으로 각각 제작해 비교한다. A/B 비교 결과 **랜딩 A(수파노바 프리미엄 다크 디자인)** 채택.

## 완료 기준 (AC)

### Method A (수파노바)
- [x] 수파노바 디자인 스킬 4종 설치 완료
- [x] lww 브랜드 (Teal #0D9488, Pretendard) 커스터마이징 적용
- [ ] 나노바나나프로 히어로 영상 생성 _(API 키 없음 → 정적 이미지 fallback 적용)_
- [x] 스크롤 트리거 애니메이션 적용 (CSS @keyframes + IntersectionObserver)
- [x] /landing-a 라우트로 접근 가능

### Method B (ui-ux-pro-max)
- [ ] ui-ux-pro-max CLI 디자인 시스템 생성 _(수동 구현으로 대체)_
- [ ] 161 팔레트 + 50+ 스타일 조합 선택 _(동일)_
- [x] /landing-b 라우트로 접근 가능

### 공통
- [x] 페이지 구성 동일: 히어로 → 페인포인트 → 기능 소개 → CTA
- [x] 모바일 반응형 (375px 기준)
- [ ] A/B 비교 후 최종 버전을 / 에 반영 _(별도 이슈 범위)_
- [ ] Vercel 배포 확인 _(머지 후 확인 예정)_
- [x] services/lww/.ai.md 최신화
- [x] 불변식 위반 없음

## 작업 내역

- `/landing-a`: 수파노바 프리미엄 다크 디자인 — 그라디언트 배경 애니메이션, teal glow 효과, 스크롤 reveal 애니메이션
- `/landing-b`: ui-ux-pro-max 클린 라이트 디자인 — 카드형 UI, 채팅 목업, 화이트 기반 레이아웃
- `LandingCTA`: A/B 공유 CTA 버튼 컴포넌트 (`/resume` 연결)
- 컴포넌트별 테스트 파일 포함 (smoke test, CTA 링크, alt 텍스트)
- clearTimeout cleanup 누락 수정 (4개 컴포넌트)
- `(main)` 라우트 그룹 밖 독립 라우트 배치 — MobileShell 미적용

**기술 결정**: Framer Motion 미사용(40KB 번들), CSS @keyframes + IntersectionObserver 제로 의존성 애니메이션, landing-b는 A 채택 결정 후 별도 이슈에서 삭제 예정

Closes #186