### PR TITLE
feat: [fint] Phase 1 크레딧 시스템 기초 — 코인 지급·잔액 UI (#181)

### DIFF
--- a/docs/work/done/000181-lww-phase-1/00_issue.md
+++ b/docs/work/done/000181-lww-phase-1/00_issue.md
@@ -1,0 +1,92 @@
+# feat: [lww] Phase 1 — 크레딧 시스템 기초 (획득 전용)
+
+## 사용자 관점 목표
+
+취준생이 면접을 완료할 때마다 크레딧을 획득해 "쌓이는 보상"을 느끼고, 이후 Phase 1 후반 크레딧 소비처(합격 예언 오브 등)에 자연스럽게 연결된다.
+
+## 배경
+
+프로포절 Phase 1 핵심 기능 중 하나. 현재는 면접 완료 후 아무런 보상 피드백이 없어 재방문 동기가 부족하다. 크레딧 획득 전용 시스템을 먼저 구축하고, Phase 1 후반에 크레딧 소비처(결제 포함)를 붙인다.
+크레딧은 게임머니로 현금화 없음 — 1크레딧 ≈ 5,000원 내부 단가 [가설, 실측 후 재조정].
+
+## 완료 기준
+
+- [x] 면접 완료(리포트 생성) 시 크레딧 자동 지급 (세션당 1회, 중복 지급 방지)
+- [x] `credit_transactions` 테이블에 지급 내역 기록 (session_id unique 제약)
+- [x] `profiles.credit_balance` 필드에 잔액 갱신
+- [x] UI에서 현재 크레딧 잔액 표시 (TopBar 또는 인터뷰 탭 상단)
+- [x] 비로그인 유저는 크레딧 지급 없음 (로그인 상태에서만 적립)
+
+## 구현 플랜
+
+1. DB 마이그레이션 — `credit_transactions` 테이블 생성 + `profiles.credit_balance` 필드 추가, RLS 설정
+2. `/api/interview/end` 라우트 — 리포트 생성 성공 후 서버 사이드에서 크레딧 지급 트리거 (service_role client 사용)
+3. 중복 방지 — `credit_transactions.session_id` unique constraint, 이미 적립된 세션이면 skip
+4. 잔액 표시 UI 컴포넌트 — Supabase `profiles` 구독 또는 API 조회로 실시간 반영
+5. 획득량 상수 관리 — `CREDIT_REWARD_PER_SESSION=10` (환경변수 또는 상수, 추후 조정 가능)
+
+## 의존성
+
+- 소셜 로그인 #179 ✅ 완료 (merged)
+- Phase 1 후반 크레딧 소비처 (합격 예언 오브 등) 및 크레딧 구매(결제)는 별도 이슈
+
+## 개발 체크리스트
+
+- [x] 테스트 코드 포함
+- [x] `services/fint/.ai.md` 최신화 (서비스명 lww→fint 변경 반영)
+- [x] 불변식 위반 없음 (DB는 서비스가 소유)
+
+---
+
+## 작업 내역
+
+### 2026-03-25
+
+**현황**: 0/5 완료
+
+**완료된 항목**:
+- (없음)
+
+**미완료 항목**:
+- 면접 완료(리포트 생성) 시 크레딧 자동 지급 (세션당 1회, 중복 지급 방지)
+- `credit_transactions` 테이블에 지급 내역 기록 (session_id unique 제약)
+- `profiles.credit_balance` 필드에 잔액 갱신
+- UI에서 현재 크레딧 잔액 표시 (TopBar 또는 인터뷰 탭 상단)
+- 비로그인 유저는 크레딧 지급 없음 (로그인 상태에서만 적립)
+
+**변경 파일**: 0개 (계획 수립 완료, 구현 시작 전)
+
+### 2026-03-28
+
+**현황**: 5/5 완료
+
+**완료된 항목**:
+- 면접 완료(리포트 생성) 시 크레딧 자동 지급 (세션당 1회, 중복 지급 방지)
+- `credit_transactions` 테이블에 지급 내역 기록 (session_id unique 제약)
+- `profiles.credit_balance` 필드에 잔액 갱신
+- UI에서 현재 크레딧 잔액 표시 (인터뷰 탭 header)
+- 비로그인 유저는 크레딧 지급 없음 (로그인 상태에서만 적립)
+
+**미완료 항목**:
+- (없음)
+
+**변경 파일**: 8개 (migration, credit.ts, route.ts, coins/balance API, CreditBadge.tsx, interview/page.tsx, 테스트 파일 2개)
+
+### 2026-04-05
+
+**현황**: 5/5 완료, PR 준비
+
+**완료된 항목**:
+- 면접 완료(리포트 생성) 시 크레딧 자동 지급 (세션당 1회, 중복 방지)
+- `coin_transactions` 테이블에 지급 내역 기록 (`uq_coin_tx_event` unique index)
+- `profiles.coins` 잔액 갱신 (award_coin RPC 원자적 처리)
+- UI에서 현재 크레딧 잔액 표시 (인터뷰 탭 header, CreditBadge)
+- 비로그인 유저는 크레딧 지급 없음
+
+**구현 결정사항**:
+- `award_coin` RPC — SECURITY DEFINER, FOR UPDATE 잠금으로 TOCTOU 방지
+- `awardInterviewCoin` — fire-and-forget (응답 지연 없음), 실패 시 warn 로깅
+- `getUserCoins` 헬퍼 — `lib/credit.ts`에 코인 도메인 집중, `balance/route.ts` + `interview/page.tsx` 공유
+- InterviewPage 쿼리 병렬화 — `Promise.all([sessionsQuery, getUserCoins])`
+
+**변경 파일**: 9개 (migration SQL, credit.ts, end/route.ts, coins/balance/route.ts, CreditBadge.tsx, interview/page.tsx, 테스트 파일 2개, .ai.md)

--- a/docs/work/done/000181-lww-phase-1/01_plan.md
+++ b/docs/work/done/000181-lww-phase-1/01_plan.md
@@ -1,0 +1,386 @@
+# [#181] feat: [fint] Phase 1 — 크레딧 시스템 기초 (획득 전용) — 구현 계획
+
+> 작성: 2026-03-25
+> ralplan 컨센서스 (Planner → Architect → Critic ITERATE → 수정)
+
+---
+
+## 완료 기준 (이슈 AC → spec 명칭으로 정렬)
+
+- [ ] 면접 완료(리포트 생성) 시 코인 자동 지급 (세션당 1회, 중복 지급 방지)
+- [ ] `coin_transactions` 테이블에 지급 내역 기록 (`user_id + event_type + ref_id` 복합 unique)
+- [ ] `profiles.coins` 잔액 갱신 (원자적)
+- [ ] UI에서 현재 코인 잔액 표시 (인터뷰 탭 header)
+- [ ] 비로그인 유저는 코인 지급 없음
+- [ ] AI 페르소나 계정 코인 집계 제외 (`profiles.type = 'ai_persona'` 체크)
+- [ ] 일일 획득 상한 적용 (어뷰징 방지)
+
+---
+
+## ADR (결정 기록)
+
+**Decision:** Supabase RPC function (`award_coin`) 방식으로 코인 지급
+
+**Drivers:**
+1. 원자성 — AI 페르소나 체크 + 일일 캡 체크 + INSERT + coins UPDATE가 단일 트랜잭션
+2. 비즈니스 룰 강제 — 일일 상한, AI 페르소나 제외를 DB 레벨에서 보장
+3. 명확한 반환값 — `BOOLEAN` 반환으로 "지급됨 / 이미 지급 / 캡 초과 / 제외 대상" 구분
+
+**Rejected:**
+- DB trigger (INSERT → balance 자동 갱신): 비즈니스 룰(일일 캡)을 trigger에 넣기 어렵고, pre-condition 강제 불가
+- 2-step write (INSERT + UPDATE 별도): partial failure 시 잔액 불일치 위험
+
+**Naming:** dev_spec.md 기준 준수 — `coin_transactions`, `event_type`, `ref_id`, `profiles.coins`
+
+**Note (credit amount):** `.ai.md`의 `CREDIT_INTERVIEW_COMPLETE = 5` 사용. 일일 캡은 `DAILY_COIN_CAP = 50` (미확정 — 추후 조정)
+
+---
+
+## 구현 계획
+
+### Step 1: DB 마이그레이션 — `coin_transactions` 테이블 + RPC
+
+**파일 생성:**
+- `services/fint/supabase/migrations/20260325_001_coin_transactions.sql`
+
+> **주의:** `profiles` 테이블은 이슈 #179 마이그레이션에서 이미 생성됨 (`coins` 컬럼 포함). 이 마이그레이션은 `coin_transactions` 테이블만 추가.
+
+**SQL 내용:**
+
+```sql
+-- coin_transactions 테이블
+create table if not exists coin_transactions (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  amount     integer not null,
+  event_type text not null,  -- 'interview_complete' | 'profile_complete' | ...
+  ref_id     uuid,           -- session_id, persona_id 등
+  created_at timestamptz not null default now()
+);
+
+-- 중복 지급 방지: 동일 유저 + 이벤트 타입 + 참조 ID 조합 unique
+create unique index if not exists uq_coin_tx_event
+  on coin_transactions (user_id, event_type, ref_id)
+  where ref_id is not null;
+
+create index if not exists idx_coin_tx_user_date
+  on coin_transactions (user_id, created_at);
+
+-- RLS
+alter table coin_transactions enable row level security;
+
+create policy "read own transactions"
+  on coin_transactions for select to authenticated
+  using (user_id = auth.uid());
+
+-- RPC: 코인 지급 (원자적, 비즈니스 룰 포함)
+-- SECURITY DEFINER: service_role 권한으로 실행 (RLS 우회)
+create or replace function award_coin(
+  p_user_id   uuid,
+  p_event_type text,
+  p_ref_id    uuid,
+  p_amount    integer
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_type         text;
+  v_daily_earned integer;
+  v_daily_cap    integer := 50;  -- 미확정, 추후 조정
+  v_inserted     integer;
+begin
+  -- 0. 동일 유저의 동시 요청 직렬화 (daily cap TOCTOU 방지)
+  perform 1 from profiles where id = p_user_id for update;
+
+  -- 1. AI 페르소나 계정 제외
+  select type into v_type from profiles where id = p_user_id;
+  if v_type = 'ai_persona' then
+    return false;
+  end if;
+
+  -- 2. 일일 획득 상한 체크
+  select coalesce(sum(amount), 0) into v_daily_earned
+  from coin_transactions
+  where user_id = p_user_id
+    and created_at >= current_date
+    and amount > 0;
+
+  if v_daily_earned >= v_daily_cap then
+    return false;
+  end if;
+
+  -- 3. 중복 방지 INSERT (이미 지급된 경우 skip)
+  with ins as (
+    insert into coin_transactions (user_id, amount, event_type, ref_id)
+    values (p_user_id, p_amount, p_event_type, p_ref_id)
+    on conflict (user_id, event_type, ref_id) where ref_id is not null
+    do nothing
+    returning id
+  )
+  select count(*) into v_inserted from ins;
+
+  if v_inserted = 0 then
+    return false;  -- 이미 지급됨
+  end if;
+
+  -- 4. 잔액 갱신
+  update profiles
+  set coins = coins + p_amount,
+      updated_at = now()
+  where id = p_user_id;
+
+  return true;
+end;
+$$;
+
+-- RPC 직접 호출 방지 (anon role에서 호출 불가)
+revoke all on function award_coin(uuid, text, uuid, integer) from anon, authenticated;
+grant execute on function award_coin(uuid, text, uuid, integer) to service_role;
+```
+
+**검증:**
+- `coin_transactions` 테이블 생성 확인
+- `uq_coin_tx_event` unique index 확인
+- `award_coin` RPC 존재 확인
+- RLS 활성화 확인
+
+---
+
+### Step 2: 크레딧 상수 + 헬퍼 함수
+
+**파일 생성:**
+- `services/fint/src/lib/credit.ts`
+
+```typescript
+import { createServiceClient } from "@/lib/supabase/server";
+
+export const COIN_REWARDS = {
+  INTERVIEW_COMPLETE: 5,  // 미확정, .ai.md CONFIG 기준
+} as const;
+
+// DAILY_COIN_CAP은 DB RPC 내부 상수(50)와 동기화
+// 서버 코드에서는 별도 체크 불필요 (RPC가 보장)
+
+/**
+ * 면접 완료 코인 지급 (서버 사이드 전용)
+ * - non-fatal: 실패해도 throw 하지 않음
+ * - 반환: { awarded: true } | { awarded: false, reason: string }
+ */
+export async function awardInterviewCoin(
+  userId: string,
+  sessionId: string
+): Promise<{ awarded: boolean; reason?: string }> {
+  try {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("award_coin", {
+      p_user_id: userId,
+      p_event_type: "interview_complete",
+      p_ref_id: sessionId,
+      p_amount: COIN_REWARDS.INTERVIEW_COMPLETE,
+    });
+
+    if (error) {
+      console.error("[awardInterviewCoin] RPC 오류 (non-fatal):", error);
+      return { awarded: false, reason: "rpc_error" };
+    }
+
+    return { awarded: data === true };
+  } catch (err) {
+    console.error("[awardInterviewCoin] 예외 (non-fatal):", err);
+    return { awarded: false, reason: "exception" };
+  }
+}
+```
+
+**검증:**
+- `awardInterviewCoin` export 확인
+- 중복 세션 → `awarded: false` 반환 (throw 없음)
+- DB 에러 → `awarded: false` 반환 (throw 없음)
+
+---
+
+### Step 3: `/api/interview/end` 수정
+
+**파일 수정:**
+- `services/fint/src/app/api/interview/end/route.ts`
+
+**변경 내용:**
+
+`awardInterviewCoin` import 추가:
+```typescript
+import { awardInterviewCoin } from "@/lib/credit";
+```
+
+report INSERT 성공 블록(`reportRow` 존재) + `userId` 존재 조건에서 크레딧 지급:
+```typescript
+// 기존 session UPDATE 직후, return Response.json({ report }) 직전에 삽입
+if (reportRow && userId) {
+  await awardInterviewCoin(userId, sessionId);
+  // 결과는 non-fatal — 실패해도 report 응답에 영향 없음
+}
+```
+
+응답에 `coinAwarded` 포함 (UI 피드백용, optional):
+```typescript
+return Response.json({ report });
+// → report 응답 변경 없음 (코인 지급 결과는 노출 안 함, UI는 profiles 조회)
+```
+
+**검증:**
+- 로그인 유저 면접 완료 → `coin_transactions` 행 생성 확인
+- 동일 세션 재요청 → 중복 행 없음 확인
+- 비로그인 유저 → `userId`가 null이므로 `awardInterviewCoin` 미호출 확인
+- 크레딧 지급 실패 → report 응답 정상 반환 확인
+
+---
+
+### Step 4: 잔액 조회 API
+
+**파일 생성:**
+- `services/fint/src/app/api/coins/balance/route.ts`
+
+```typescript
+import { createClient } from "@/lib/supabase/server";
+import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
+
+export async function GET() {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    return Response.json({ coins: null });
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("coins")
+    .eq("id", userId)
+    .single();
+
+  if (error || !data) {
+    return Response.json({ coins: 0 });
+  }
+
+  return Response.json({ coins: data.coins });
+}
+```
+
+**경로:** `/api/coins/balance` (dev_spec.md:200 기준)
+
+**검증:**
+- 로그인 → `{ coins: number }` 반환
+- 비로그인 → `{ coins: null }` 반환
+- profiles 없음 → `{ coins: 0 }` 반환
+
+---
+
+### Step 5: CreditBadge UI + InterviewPage 통합
+
+**파일 생성:**
+- `services/fint/src/components/credit/CreditBadge.tsx`
+
+```tsx
+// Server Component — InterviewPage에서 서버 사이드로 coins 조회
+import { Coins } from "lucide-react";
+
+interface CreditBadgeProps {
+  coins: number;
+}
+
+export function CreditBadge({ coins }: CreditBadgeProps) {
+  return (
+    <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-amber-50 border border-amber-200">
+      <Coins className="w-4 h-4 text-amber-600" aria-hidden="true" />
+      <span className="text-sm font-bold text-amber-900">{coins}</span>
+    </div>
+  );
+}
+```
+
+**접근성 주의:** Coin Amber(`#F59E0B`)는 아이콘/배경에만 사용. 텍스트는 `text-amber-900` (WCAG AA 충족).
+
+**파일 수정:**
+- `services/fint/src/app/(main)/interview/page.tsx`
+
+InterviewPage는 이미 서버 컴포넌트이고 `user` 정보를 갖고 있음 → 추가 API 호출 없이 profiles 조회:
+
+```tsx
+// 기존 user 체크 직후 coins 조회 추가
+let coins: number | null = null;
+if (user) {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("coins")
+    .eq("id", user.id)
+    .single();
+  coins = profile?.coins ?? 0;
+}
+```
+
+header 수정 — "+ 새 면접" 링크 왼쪽에 CreditBadge 삽입:
+```tsx
+<div className="flex items-center gap-3 pr-5">
+  {coins !== null && <CreditBadge coins={coins} />}
+  <Link href="/onboarding" className="text-sm font-bold text-[#0D9488] whitespace-nowrap">
+    + 새 면접
+  </Link>
+</div>
+```
+
+**검증:**
+- 로그인 유저: 코인 배지 표시
+- 비로그인 유저: 배지 미표시
+- 잔액 0: "0" 표시 (빈 화면 아님)
+
+---
+
+### Step 6: 테스트
+
+**파일 생성:**
+- `services/fint/src/app/api/interview/end/__tests__/credit.test.ts`
+- `services/fint/src/lib/__tests__/credit.test.ts`
+
+**테스트 케이스:**
+
+`awardInterviewCoin`:
+1. 정상 지급 → `{ awarded: true }` 반환 (RPC mock)
+2. 중복 session_id → `{ awarded: false }` 반환 (RPC returns false)
+3. AI 페르소나 → `{ awarded: false }` 반환 (RPC returns false)
+4. 일일 캡 초과 → `{ awarded: false }` 반환
+5. DB 오류 → throw 없이 `{ awarded: false }` 반환
+
+`/api/interview/end`:
+6. 로그인 유저 + report 성공 → `awardInterviewCoin` 호출됨
+7. 비로그인 유저 → `awardInterviewCoin` 미호출 (userId null)
+8. 크레딧 지급 실패해도 → report 200 정상 반환
+
+`/api/coins/balance`:
+9. 로그인 유저 → `{ coins: number }` 반환
+10. 비로그인 유저 → `{ coins: null }` 반환
+
+---
+
+## 파일 변경 요약
+
+| 구분 | 파일 | 작업 |
+|------|------|------|
+| 생성 | `services/fint/supabase/migrations/20260325_001_coin_transactions.sql` | coin_transactions 테이블 + RPC |
+| 생성 | `services/fint/src/lib/credit.ts` | 코인 상수 + 지급 헬퍼 |
+| 수정 | `services/fint/src/app/api/interview/end/route.ts` | 크레딧 지급 호출 추가 |
+| 생성 | `services/fint/src/app/api/coins/balance/route.ts` | 잔액 조회 API |
+| 생성 | `services/fint/src/components/credit/CreditBadge.tsx` | 코인 배지 UI |
+| 수정 | `services/fint/src/app/(main)/interview/page.tsx` | header에 CreditBadge 삽입 |
+| 생성 | `services/fint/src/lib/__tests__/credit.test.ts` | 헬퍼 단위 테스트 |
+| 생성 | `services/fint/src/app/api/interview/end/__tests__/credit.test.ts` | route 통합 테스트 |
+| 수정 | `services/fint/.ai.md` | 크레딧 시스템 구현 현황 추가 |
+
+---
+
+## 엣지 케이스 및 주의사항
+
+- **`profiles` 없는 유저**: #179 마이그레이션의 `handle_new_user` trigger가 auth.users INSERT 시 자동 생성. 단, 기존 유저 중 profiles 없는 경우 백필 필요 (이미 #179 마이그레이션에 `INSERT INTO profiles SELECT id FROM auth.users ON CONFLICT DO NOTHING` 포함됨).
+- **일일 캡 값**: 현재 DB RPC 내부 상수 `50`. 추후 환경변수 또는 어드민 설정으로 이전 가능.
+- **코인 획득량**: `COIN_REWARDS.INTERVIEW_COMPLETE = 5` (미확정). `.ai.md` CONFIG 업데이트 시 동기화 필요.
+- **Phase 2 확장**: 코인 차감 시 `profiles.coins >= 0` CHECK 없음 (spec 미명시) — 차감 로직은 별도 RPC로 추가.
+- **`services/lww/.ai.md` 참조**: 이슈 checklist의 `services/lww/.ai.md`는 `services/fint/.ai.md`로 수정 필요 (#194에서 서비스명 변경됨).

--- a/services/fint/.ai.md
+++ b/services/fint/.ai.md
@@ -75,6 +75,16 @@ CREATE POLICY "Users can manage own resumes" ON resumes FOR ALL
 **익명→인증 마이그레이션**: 로그인 콜백에서 `migrate_anon_to_user` RPC 호출 (원자적 트랜잭션)
 **중요**: Tailwind v4에서 `bg-[--color-primary]` 임의값 문법이 포화 색상 변수에 적용 안 됨 → 하드코딩 `bg-[#0D9488]` 사용. `--color-background`, `--color-muted` 등 무채색 변수는 정상 동작.
 
+### Phase 1 — 코인 시스템 기초 (이슈 #181, 2026-03-25)
+**DB**: `coin_transactions` 테이블 + `award_coin` RPC (SECURITY DEFINER, FOR UPDATE 잠금)
+**헬퍼**: `src/lib/credit.ts` — `awardInterviewCoin(userId, sessionId)` (non-fatal, Supabase RPC 래퍼)
+**지급 흐름**: `/api/interview/end` → report INSERT 성공 + 로그인 유저 → `award_coin` RPC 호출 → `profiles.coins` 원자적 갱신
+**UI**: `src/components/credit/CreditBadge.tsx` — InterviewPage header에 조건부 표시 (로그인 유저만)
+**API**: `GET /api/coins/balance` — `{ coins: number | null }` 반환 (비로그인 시 null)
+**보안**: `award_coin` RPC는 `service_role`만 호출 가능 (anon/authenticated 직접 호출 금지)
+**코인량**: `COIN_REWARDS.INTERVIEW_COMPLETE = 5` (미확정, 추후 조정)
+**일일 캡**: RPC 내부 50 (미확정)
+
 ### UI/UX 전면 개선 (이슈 #187, 2026-03-23)
 **스토리보드**: `docs/specs/fint/storyboard.md` — 화면 1-11 (기존) + 화면 12-31 (신규, 총 31화면)
 **디자인 시안**: `docs/specs/fint/designs/` (24개 — Phase 1: v2_01~v2_13, Phase 2: 2026-03-23-p2-*)
@@ -127,6 +137,7 @@ CREDIT_PERSONA_CREATOR_SHARE = 3   // 현직자 배분 (CREDIT_PERSONA_INTERVIEW
 /api/resume/questions  POST: PDF → 예상 질문 (미로그인 사용자용, 저장 없음)
 /api/resume/upload     POST: 로그인 유저 PDF 저장 (parse-first, Storage+DB upsert)
 /api/resume            GET:  현재 저장된 자소서 메타데이터
+/api/coins/balance     GET:  코인 잔액 조회 (로그인 유저: { coins: number }, 비로그인: { coins: null })
 ```
 
 ### Phase 1 — SNS 공유 (이슈 #184, 2026-03-25)
@@ -184,6 +195,7 @@ fint/
 │   │   ├── onboarding/             OnboardingSlider, JobCategorySelector
 │   │   ├── report/                 LoadingPhaseText, ScoreBar, CategoryScoreGrid, FeedbackSection, OrbPreviewCard
 │   │   ├── interview/              InterviewHistoryCard
+│   │   ├── credit/                 CreditBadge (코인 잔액 배지)
 │   │   └── common/                 EmptyState, NetworkError
 │   ├── hooks/
 │   │   └── useInterview.ts         면접 상태 훅 (sessionStorage 백업)
@@ -229,9 +241,9 @@ fint/
 ### DB
 
 - **DB**: Supabase PostgreSQL (스키마: `docs/specs/fint/dev_spec.md` §DB 스키마)
-  - 테이블: `interview_sessions`, `reports`, `profiles`
+  - 테이블: `interview_sessions`, `reports`, `profiles`, `coin_transactions`
   - RLS 정책: 비로그인은 `anonymous_id` 검증, 로그인은 `auth.uid()` 검증
-  - Supabase RPC: `migrate_anon_to_user(p_anon_id text, p_user_id uuid)` — 원자적 마이그레이션
+  - Supabase RPC: `migrate_anon_to_user(p_anon_id text, p_user_id uuid)` — 원자적 마이그레이션, `award_coin(p_user_id uuid, p_event_type text, p_ref_id uuid, p_amount integer)` — 코인 지급 (SECURITY DEFINER)
 - **스토리지**: Supabase Storage — 버킷명 `SUPABASE_STORAGE_BUCKET` 환경변수 (하드코딩 금지)
 - **보안**: `SUPABASE_SERVICE_ROLE_KEY`는 서버 전용 — `NEXT_PUBLIC_` 절대 금지
 

--- a/services/fint/src/app/(main)/interview/page.tsx
+++ b/services/fint/src/app/(main)/interview/page.tsx
@@ -1,8 +1,10 @@
 import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { getUserCoins } from "@/lib/credit";
 import { cookies } from "next/headers";
 import { Mic } from "lucide-react";
 import { EmptyState } from "@/components/common/EmptyState";
 import { InterviewHistoryCard } from "@/components/interview/InterviewHistoryCard";
+import { CreditBadge } from "@/components/credit/CreditBadge";
 import Link from "next/link";
 
 interface InterviewRecord {
@@ -28,17 +30,22 @@ export default async function InterviewPage() {
   const { data: { user } } = await supabase.auth.getUser();
 
   let history: InterviewRecord[] = [];
+  let coins: number | null = null;
 
   if (user) {
-    // 로그인: user_id 기준 쿼리
-    const { data } = await supabase
-      .from("interview_sessions")
-      .select("id, created_at, job_category, reports(total_score)")
-      .eq("user_id", user.id)
-      .eq("status", "completed")
-      .order("created_at", { ascending: false });
+    // 로그인: user_id 기준 쿼리 (두 쿼리 병렬 실행)
+    const [{ data }, userCoins] = await Promise.all([
+      supabase
+        .from("interview_sessions")
+        .select("id, created_at, job_category, reports(total_score)")
+        .eq("user_id", user.id)
+        .eq("status", "completed")
+        .order("created_at", { ascending: false }),
+      getUserCoins(user.id),
+    ]);
 
     history = toHistory(data as SessionRow[]);
+    coins = userCoins;
   } else {
     // 비로그인: anon_id 기준 (service client, RLS 우회)
     const cookieStore = await cookies();
@@ -63,9 +70,12 @@ export default async function InterviewPage() {
       <header className="h-14 pl-5 flex items-center justify-between bg-[--color-surface] border-b border-[--color-border] sticky top-0 z-40">
         <div className="w-9" />
         <span className="text-base font-semibold text-[--color-foreground]">내 면접 기록</span>
-        <Link href="/onboarding" className="text-sm font-bold text-[#0D9488] whitespace-nowrap pr-5">
-          + 새 면접
-        </Link>
+        <div className="flex items-center gap-3 pr-5">
+          {coins !== null && <CreditBadge coins={coins} />}
+          <Link href="/onboarding" className="text-sm font-bold text-[#0D9488] whitespace-nowrap">
+            + 새 면접
+          </Link>
+        </div>
       </header>
       <main className="flex-1 px-5 py-5 pb-24">
         <div className="flex items-center justify-between mb-5">

--- a/services/fint/src/app/api/coins/balance/route.ts
+++ b/services/fint/src/app/api/coins/balance/route.ts
@@ -1,0 +1,11 @@
+import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
+import { getUserCoins } from "@/lib/credit";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const userId = await getCurrentUserId();
+  if (!userId) return Response.json({ coins: null });
+  const coins = await getUserCoins(userId);
+  return Response.json({ coins });
+}

--- a/services/fint/src/app/api/interview/end/__tests__/credit.test.ts
+++ b/services/fint/src/app/api/interview/end/__tests__/credit.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks
+vi.mock("@/lib/engine-client", () => ({
+  engineFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/anon-cookie", () => ({
+  getAnonId: vi.fn().mockResolvedValue("test-anon-id"),
+}));
+
+vi.mock("@/lib/supabase/get-current-user-id", () => ({
+  getCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("@/lib/credit", () => ({
+  awardInterviewCoin: vi.fn().mockResolvedValue({ awarded: true }),
+}));
+
+import { engineFetch } from "@/lib/engine-client";
+import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
+import { createServiceClient } from "@/lib/supabase/server";
+import { awardInterviewCoin } from "@/lib/credit";
+import { POST } from "../route";
+
+const mockEngFetch = vi.mocked(engineFetch);
+const mockGetCurrentUserId = vi.mocked(getCurrentUserId);
+const mockCreateServiceClient = vi.mocked(createServiceClient);
+const mockAwardInterviewCoin = vi.mocked(awardInterviewCoin);
+
+const validBody = {
+  sessionId: "550e8400-e29b-41d4-a716-446655440000",
+  resumeText: "저는 열정적인 개발자입니다.",
+  history: Array.from({ length: 5 }, (_, i) => ({
+    question: `질문 ${i + 1}`,
+    answer: `답변 ${i + 1}`,
+    persona: "hr",
+    personaLabel: "HR 담당자",
+  })),
+};
+
+const mockReport = {
+  totalScore: 80,
+  axisScores: {},
+  axisFeedbacks: {},
+  summary: "좋은 면접이었습니다.",
+};
+
+function makeSupabaseMock() {
+  return {
+    from: vi.fn().mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: "report-uuid" },
+            error: null,
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe("POST /api/interview/end — 코인 지급", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEngFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockReport,
+    } as Response);
+    mockCreateServiceClient.mockReturnValue(
+      makeSupabaseMock() as unknown as ReturnType<typeof createServiceClient>
+    );
+  });
+
+  it("로그인 유저 + report 성공 시 awardInterviewCoin을 호출한다", async () => {
+    mockGetCurrentUserId.mockResolvedValue("user-uuid");
+
+    const request = new Request("http://localhost/api/interview/end", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(mockAwardInterviewCoin).toHaveBeenCalledWith(
+      "user-uuid",
+      validBody.sessionId
+    );
+  });
+
+  it("비로그인 유저 (userId null) 시 awardInterviewCoin을 호출하지 않는다", async () => {
+    mockGetCurrentUserId.mockResolvedValue(null);
+
+    const request = new Request("http://localhost/api/interview/end", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(mockAwardInterviewCoin).not.toHaveBeenCalled();
+  });
+
+  it("awardInterviewCoin 실패해도 report 200을 반환한다 (non-fatal)", async () => {
+    mockGetCurrentUserId.mockResolvedValue("user-uuid");
+    mockAwardInterviewCoin.mockResolvedValue({ awarded: false, reason: "rpc_error" });
+
+    const request = new Request("http://localhost/api/interview/end", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.report).toBeDefined();
+  });
+});

--- a/services/fint/src/app/api/interview/end/route.ts
+++ b/services/fint/src/app/api/interview/end/route.ts
@@ -3,6 +3,7 @@ import { engineFetch } from "@/lib/engine-client";
 import { getAnonId } from "@/lib/anon-cookie";
 import { createServiceClient } from "@/lib/supabase/server";
 import { getCurrentUserId } from "@/lib/supabase/get-current-user-id";
+import { awardInterviewCoin } from "@/lib/credit";
 
 export const runtime = "nodejs";
 export const maxDuration = 110;
@@ -86,6 +87,12 @@ export async function POST(request: Request) {
         .eq("id", sessionId)
         .eq("anonymous_id", anonymousId);
       if (sessionUpdateErr) console.error("[end] interview_sessions UPDATE 실패 (non-fatal):", sessionUpdateErr);
+      // 코인 지급 — non-fatal, fire-and-forget (응답 지연 없음)
+      if (userId) {
+        awardInterviewCoin(userId, sessionId).then(({ awarded, reason }) => {
+          if (!awarded) console.warn("[end] coin award skipped:", reason);
+        });
+      }
     }
 
     return Response.json({ report });

--- a/services/fint/src/components/credit/CreditBadge.tsx
+++ b/services/fint/src/components/credit/CreditBadge.tsx
@@ -1,0 +1,12 @@
+interface CreditBadgeProps {
+  coins: number;
+}
+
+export function CreditBadge({ coins }: CreditBadgeProps) {
+  return (
+    <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-amber-50 border border-amber-200">
+      <span className="text-sm" aria-hidden="true">🪙</span>
+      <span className="text-sm font-bold text-amber-900">{coins}</span>
+    </div>
+  );
+}

--- a/services/fint/src/lib/__tests__/credit.test.ts
+++ b/services/fint/src/lib/__tests__/credit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Supabase server mock
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { createServiceClient } from "@/lib/supabase/server";
+import { awardInterviewCoin, COIN_REWARDS } from "../credit";
+
+const mockCreateServiceClient = vi.mocked(createServiceClient);
+
+describe("awardInterviewCoin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("RPC가 true를 반환하면 awarded: true를 반환한다", async () => {
+    mockCreateServiceClient.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
+    } as unknown as ReturnType<typeof createServiceClient>);
+
+    const result = await awardInterviewCoin("user-uuid", "session-uuid");
+
+    expect(result).toEqual({ awarded: true });
+  });
+
+  it("RPC가 false를 반환하면 awarded: false를 반환한다 (중복 또는 캡 초과)", async () => {
+    mockCreateServiceClient.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({ data: false, error: null }),
+    } as unknown as ReturnType<typeof createServiceClient>);
+
+    const result = await awardInterviewCoin("user-uuid", "session-uuid");
+
+    expect(result).toEqual({ awarded: false });
+  });
+
+  it("RPC 오류 시 throw 없이 awarded: false를 반환한다", async () => {
+    mockCreateServiceClient.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: "DB error", code: "PGRST116" },
+      }),
+    } as unknown as ReturnType<typeof createServiceClient>);
+
+    const result = await awardInterviewCoin("user-uuid", "session-uuid");
+
+    expect(result.awarded).toBe(false);
+    expect(result.reason).toBe("rpc_error");
+  });
+
+  it("예외 발생 시 throw 없이 awarded: false를 반환한다", async () => {
+    mockCreateServiceClient.mockReturnValue({
+      rpc: vi.fn().mockRejectedValue(new Error("Network error")),
+    } as unknown as ReturnType<typeof createServiceClient>);
+
+    const result = await awardInterviewCoin("user-uuid", "session-uuid");
+
+    expect(result.awarded).toBe(false);
+    expect(result.reason).toBe("exception");
+  });
+
+  it("COIN_REWARDS.INTERVIEW_COMPLETE는 5이다", () => {
+    expect(COIN_REWARDS.INTERVIEW_COMPLETE).toBe(5);
+  });
+
+  it("RPC 호출 시 올바른 파라미터를 전달한다", async () => {
+    const mockRpc = vi.fn().mockResolvedValue({ data: true, error: null });
+    mockCreateServiceClient.mockReturnValue({
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof createServiceClient>);
+
+    await awardInterviewCoin("user-123", "session-456");
+
+    expect(mockRpc).toHaveBeenCalledWith("award_coin", {
+      p_user_id: "user-123",
+      p_event_type: "interview_complete",
+      p_ref_id: "session-456",
+      p_amount: COIN_REWARDS.INTERVIEW_COMPLETE,
+    });
+  });
+});

--- a/services/fint/src/lib/credit.ts
+++ b/services/fint/src/lib/credit.ts
@@ -1,0 +1,58 @@
+import { createServiceClient, createClient } from "@/lib/supabase/server";
+
+export const COIN_REWARDS = {
+  INTERVIEW_COMPLETE: 5, // .ai.md CONFIG 기준 (미확정, 추후 조정)
+} as const;
+
+export const DEFAULT_COINS = 0;
+
+/**
+ * 유저의 현재 코인 잔액 조회 (서버 사이드 전용)
+ * - 오류 시 DEFAULT_COINS 반환 (non-fatal)
+ */
+export async function getUserCoins(userId: string): Promise<number> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("coins")
+      .eq("id", userId)
+      .single();
+    if (error || !data) return DEFAULT_COINS;
+    return data.coins ?? DEFAULT_COINS;
+  } catch {
+    return DEFAULT_COINS;
+  }
+}
+
+/**
+ * 면접 완료 코인 지급 (서버 사이드 전용)
+ *
+ * - non-fatal: 실패 시 throw 하지 않음
+ * - 중복 지급 방지는 DB RPC award_coin이 보장 (unique index + FOR UPDATE)
+ * - 반환: { awarded: true } | { awarded: false, reason: string }
+ */
+export async function awardInterviewCoin(
+  userId: string,
+  sessionId: string
+): Promise<{ awarded: boolean; reason?: string }> {
+  try {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("award_coin", {
+      p_user_id: userId,
+      p_event_type: "interview_complete",
+      p_ref_id: sessionId,
+      p_amount: COIN_REWARDS.INTERVIEW_COMPLETE,
+    });
+
+    if (error) {
+      console.error("[awardInterviewCoin] RPC 오류 (non-fatal):", error);
+      return { awarded: false, reason: "rpc_error" };
+    }
+
+    return { awarded: data === true };
+  } catch (err) {
+    console.error("[awardInterviewCoin] 예외 (non-fatal):", err);
+    return { awarded: false, reason: "exception" };
+  }
+}

--- a/services/fint/supabase/migrations/20260325_001_coin_transactions.sql
+++ b/services/fint/supabase/migrations/20260325_001_coin_transactions.sql
@@ -1,0 +1,94 @@
+-- [#181] Phase 1 — 코인 시스템 기초: coin_transactions 테이블 + award_coin RPC
+-- 주의: profiles 테이블은 이슈 #179에서 이미 생성됨 (coins 컬럼 포함)
+
+-- 1. coin_transactions 테이블
+create table if not exists coin_transactions (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  amount     integer not null,
+  event_type text not null,  -- 'interview_complete' | 'profile_complete' | ...
+  ref_id     uuid,           -- session_id, persona_id 등 관련 엔티티 id
+  created_at timestamptz not null default now()
+);
+
+-- 2. 중복 지급 방지 index: 동일 유저 + 이벤트 타입 + ref_id 조합 unique
+create unique index if not exists uq_coin_tx_event
+  on coin_transactions (user_id, event_type, ref_id)
+  where ref_id is not null;
+
+-- 3. 조회 성능 index
+create index if not exists idx_coin_tx_user_date
+  on coin_transactions (user_id, created_at);
+
+-- 4. RLS
+alter table coin_transactions enable row level security;
+
+create policy "read own transactions"
+  on coin_transactions for select to authenticated
+  using (user_id = auth.uid());
+
+-- 5. award_coin RPC: 코인 지급 (원자적, 비즈니스 룰 포함)
+-- SECURITY DEFINER: service_role 권한으로 실행 (RLS 우회)
+create or replace function award_coin(
+  p_user_id    uuid,
+  p_event_type text,
+  p_ref_id     uuid,
+  p_amount     integer
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_type         text;
+  v_daily_earned integer;
+  v_daily_cap    integer := 50;  -- 미확정, 추후 조정 가능
+  v_inserted     integer;
+begin
+  -- 0. 동일 유저의 동시 요청 직렬화 (daily cap TOCTOU race condition 방지)
+  perform 1 from profiles where id = p_user_id for update;
+
+  -- 1. AI 페르소나 계정 제외 (크레딧 집계 오염 방지)
+  select type into v_type from profiles where id = p_user_id;
+  if v_type = 'ai_persona' then
+    return false;
+  end if;
+
+  -- 2. 일일 획득 상한 체크 (어뷰징 방지)
+  select coalesce(sum(amount), 0) into v_daily_earned
+  from coin_transactions
+  where user_id = p_user_id
+    and created_at >= current_date
+    and amount > 0;
+
+  if v_daily_earned >= v_daily_cap then
+    return false;
+  end if;
+
+  -- 3. 중복 방지 INSERT (이미 지급된 세션이면 skip)
+  with ins as (
+    insert into coin_transactions (user_id, amount, event_type, ref_id)
+    values (p_user_id, p_amount, p_event_type, p_ref_id)
+    on conflict (user_id, event_type, ref_id) where ref_id is not null
+    do nothing
+    returning id
+  )
+  select count(*) into v_inserted from ins;
+
+  if v_inserted = 0 then
+    return false;  -- 이미 지급된 세션
+  end if;
+
+  -- 4. profiles.coins 잔액 원자적 갱신
+  update profiles
+  set coins      = coins + p_amount,
+      updated_at = now()
+  where id = p_user_id;
+
+  return true;
+end;
+$$;
+
+-- 6. 보안: anon/authenticated에서 award_coin 직접 호출 금지 (서버 사이드 전용)
+revoke all on function award_coin(uuid, text, uuid, integer) from anon, authenticated;
+grant execute on function award_coin(uuid, text, uuid, integer) to service_role;


### PR DESCRIPTION
## 이슈 배경

취준생이 면접을 완료할 때마다 코인을 획득해 "쌓이는 보상"을 느낄 수 있도록 크레딧 시스템 기초를 구현합니다. 현재는 면접 완료 후 아무런 보상 피드백이 없어 재방문 동기가 부족한 상태였으며, Phase 1 후반의 크레딧 소비처(합격 예언 오브 등)로 자연스럽게 연결하기 위한 기반입니다.

## 완료 기준 (AC)

- [x] 면접 완료(리포트 생성) 시 코인 자동 지급 (세션당 1회, 중복 지급 방지)
- [x] `coin_transactions` 테이블에 지급 내역 기록 (`uq_coin_tx_event` unique index)
- [x] `profiles.coins` 잔액 갱신 (`award_coin` RPC 원자적 처리)
- [x] UI에서 현재 코인 잔액 표시 (인터뷰 탭 header, CreditBadge)
- [x] 비로그인 유저는 코인 지급 없음

## 작업 내역

### 핵심 구현

- **DB**: `coin_transactions` 테이블 + `award_coin` RPC (SECURITY DEFINER, FOR UPDATE 잠금으로 TOCTOU 방지)
- **`src/lib/credit.ts`**: `awardInterviewCoin` (fire-and-forget, non-fatal) + `getUserCoins` 헬퍼 (도메인 집중)
- **`/api/interview/end`**: 리포트 저장 성공 + 로그인 유저 조건에서 코인 지급 트리거
- **`/api/coins/balance`**: `GET { coins: number | null }` 잔액 조회 API
- **`CreditBadge`**: 인터뷰 탭 header에 조건부 표시 (로그인 유저만)
- **InterviewPage**: `Promise.all`로 세션 목록 + 코인 쿼리 병렬화

### 기술 결정

- `award_coin` RPC는 `service_role`만 호출 가능 (anon/authenticated 직접 호출 금지)
- `awardInterviewCoin` fire-and-forget — 응답 지연 없이 처리, 실패 시 `console.warn`
- `getUserCoins` 헬퍼로 `balance/route.ts`와 `interview/page.tsx` 중복 제거

Closes #181